### PR TITLE
Fix DOM refresh when changing pages

### DIFF
--- a/src/lib/components/Reader/MangaPage.svelte
+++ b/src/lib/components/Reader/MangaPage.svelte
@@ -14,12 +14,13 @@
   onMount(() => {
     legacy = document.getElementById('popupAbout');
     zoomDefault();
+  });
 
-    return () => {
-      setTimeout(() => {
-        zoomDefault();
-      }, 10);
-    };
+  onDestroy(() => {
+    if (legacy) {
+      legacy.style.backgroundImage = '';
+    }
+    URL.revokeObjectURL(url);
   });
 
   $: {

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -345,10 +345,12 @@
         role="none"
         id="manga-panel"
       >
-        {#if showSecondPage()}
-          <MangaPage page={pages[index + 1]} src={Object.values(volume?.files)[index + 1]} />
-        {/if}
-        <MangaPage page={pages[index]} src={Object.values(volume?.files)[index]} />
+        {#key page}
+          {#if showSecondPage()}
+            <MangaPage page={pages[index + 1]} src={Object.values(volume?.files)[index + 1]} />
+          {/if}
+          <MangaPage page={pages[index]} src={Object.values(volume?.files)[index]} />
+        {/key}
       </div>
     </Panzoom>
   </div>


### PR DESCRIPTION
This PR fixes issues with language learning extensions not detecting page changes properly by ensuring proper DOM refresh between page transitions.

### Changes
- Add `{#key page}` directive to force DOM refresh when changing pages
- Improve cleanup in MangaPage component by properly handling onDestroy
- Fix memory leaks by revoking object URLs
- Remove unnecessary delayed zoom reset

### Impact
- Language learning extensions will now properly detect page changes
- Better memory management
- Cleaner DOM transitions between pages