### PR TITLE
Add GitHub Pages support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,44 @@
 name: Deploy to GitHub Pages
+
 on:
-    push:
-        branches: ['main']
+  push:
+    branches: ['main']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-    build-and-deploy:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - uses: actions/setup-node@v3
-            - run: npm ci
-            - run: npm run build
-            - uses: JamesIves/github-pages-deploy-action@v4
-              with:
-                  folder: dist
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "^2.0.0",
+        "@sveltejs/adapter-static": "^3.0.8",
         "@sveltejs/kit": "^1.20.4",
         "@types/gapi.client.drive-v3": "^0.0.4",
         "@typescript-eslint/eslint-plugin": "^5.45.0",
@@ -688,6 +689,16 @@
       },
       "peerDependencies": {
         "@sveltejs/kit": "^1.0.0"
+      }
+    },
+    "node_modules/@sveltejs/adapter-static": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.8.tgz",
+      "integrity": "sha512-YaDrquRpZwfcXbnlDsSrBQNCChVOT9MGuSg+dMAyfsAa1SmiAhrA5jUYUiIMC59G92kIbY/AaQOWcBdq+lh+zg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@sveltejs/kit": "^2.0.0"
       }
     },
     "node_modules/@sveltejs/kit": {
@@ -4750,6 +4761,12 @@
         "import-meta-resolve": "^3.0.0"
       }
     },
+    "@sveltejs/adapter-static": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.8.tgz",
+      "integrity": "sha512-YaDrquRpZwfcXbnlDsSrBQNCChVOT9MGuSg+dMAyfsAa1SmiAhrA5jUYUiIMC59G92kIbY/AaQOWcBdq+lh+zg==",
+      "dev": true
+    },
     "@sveltejs/kit": {
       "version": "1.30.4",
       "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.30.4.tgz",
@@ -4992,8 +5009,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -5506,8 +5522,7 @@
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.9.0.tgz",
       "integrity": "sha512-+sbni7NfVXnOpnRadUA8S28AUlsZt9GjgFvABIRL9Hkn8KqNzOp+7Lw4QWtrwn20KzU3wqu1QoOj2m+7rKRqkA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-svelte": {
       "version": "2.32.4",
@@ -5783,8 +5798,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/flowbite-svelte-icons/-/flowbite-svelte-icons-0.4.2.tgz",
       "integrity": "sha512-fwobCTdaJF/ptI8eWqIfkh/CMo3Q/qZgYRxZYDrR22HfAROYe/ZdBfg6zXcDsxeXCpSr4IrmN2bDsnB4q9ZLcg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "fraction.js": {
       "version": "4.3.6",
@@ -6540,15 +6554,13 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
       "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-scss": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.6.tgz",
       "integrity": "sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-selector-parser": {
       "version": "6.0.13",
@@ -6582,8 +6594,7 @@
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.10.1.tgz",
       "integrity": "sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "punycode": {
       "version": "2.3.0",
@@ -6942,8 +6953,7 @@
       "version": "0.15.3",
       "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz",
       "integrity": "sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "svelte-preprocess": {
       "version": "5.0.4",
@@ -7249,8 +7259,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
       "integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "wheel": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@sveltejs/adapter-auto": "^2.0.0",
+    "@sveltejs/adapter-static": "^3.0.8",
     "@sveltejs/kit": "^1.20.4",
     "@types/gapi.client.drive-v3": "^0.0.4",
     "@typescript-eslint/eslint-plugin": "^5.45.0",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/kit/vite';
 
 /** @type {import('@sveltejs/kit').Config} */
@@ -11,7 +11,13 @@ const config = {
     // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
     // If your environment is not supported or you settled on a specific environment, switch out the adapter.
     // See https://kit.svelte.dev/docs/adapters for more information about adapters.
-    adapter: adapter()
+    adapter: adapter({
+      pages: 'build',
+      assets: 'build',
+      fallback: 'index.html',
+      precompress: false,
+      strict: true
+    })
   },
 
   vitePlugin: {


### PR DESCRIPTION
This PR adds GitHub Pages support by:

- Updating the GitHub Actions workflow to use the latest actions and correct build path
- Configuring SvelteKit to use the static adapter
- Setting up proper build and deployment configuration

After merging this PR, you will need to:
1. Go to repository Settings > Pages
2. Under "Build and deployment", select "GitHub Actions" as the source
3. The site will be automatically deployed on every push to the main branch