### PR TITLE
Add pagination to catalog view

### DIFF
--- a/src/lib/components/Catalog.svelte
+++ b/src/lib/components/Catalog.svelte
@@ -7,6 +7,11 @@
   import { miscSettings, updateMiscSetting } from '$lib/settings';
   import CatalogListItem from './CatalogListItem.svelte';
 
+  const PAGE_SIZE = 20;
+  let currentPage = 0;
+
+  $: totalPages = $catalog ? Math.ceil($catalog.length / PAGE_SIZE) : 0;
+
   $: sortedCatalog = $catalog
     ?.sort((a, b) => {
       if ($miscSettings.gallerySorting === 'ASC') {
@@ -18,6 +23,24 @@
     .filter((item) => {
       return item.manga[0].mokuroData.title.toLowerCase().indexOf(search.toLowerCase()) !== -1;
     });
+
+  $: paginatedCatalog = sortedCatalog
+    ? sortedCatalog.slice(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE)
+    : [];
+
+  function nextPage() {
+    if (currentPage < totalPages - 1) {
+      currentPage++;
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }
+
+  function prevPage() {
+    if (currentPage > 0) {
+      currentPage--;
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  }
 
   let search = '';
 
@@ -61,15 +84,26 @@
       {:else}
         <div class="flex sm:flex-row flex-col gap-5 flex-wrap justify-center sm:justify-start">
           {#if $miscSettings.galleryLayout === 'grid'}
-            {#each sortedCatalog as { id } (id)}
+            {#each paginatedCatalog as { id } (id)}
               <CatalogItem {id} />
             {/each}
           {:else}
             <Listgroup active class="w-full">
-              {#each sortedCatalog as { id } (id)}
+              {#each paginatedCatalog as { id } (id)}
                 <CatalogListItem {id} />
               {/each}
             </Listgroup>
+          {/if}
+          {#if totalPages > 1}
+            <div class="flex justify-center gap-2 mt-4 w-full">
+              <Button size="sm" disabled={currentPage === 0} on:click={prevPage}>
+                Previous
+              </Button>
+              <span class="py-2">Page {currentPage + 1} of {totalPages}</span>
+              <Button size="sm" disabled={currentPage >= totalPages - 1} on:click={nextPage}>
+                Next
+              </Button>
+            </div>
           {/if}
         </div>
       {/if}


### PR DESCRIPTION
This PR adds client-side pagination to the catalog view to improve initial load time and performance when dealing with many volumes.

### Changes

- Add pagination with 20 items per page
- Add Previous/Next buttons with page counter
- Smooth scroll to top when changing pages
- Keep existing search and sorting functionality intact

### Benefits

- Reduces the number of items rendered at once
- Improves scrolling performance
- Better user experience with large catalogs

### Testing

Please test:
1. Loading a catalog with >20 volumes
2. Navigation between pages
3. Search functionality still works
4. Sorting still works
5. Both grid and list views work with pagination