### PR TITLE
Fix two-page mode volume navigation bug

### DIFF
--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -53,7 +53,7 @@
       }
       const pageClamped = clamp(newPage, 1, pages?.length);
       const { charCount } = getCharCount(pages, pageClamped);
-      if (pageClamped === page) {
+      if (pageClamped !== newPage) {
         let seriesVolumes = $currentSeries;
         const currentVolumeIndex = seriesVolumes.findIndex((v) => v.volume_uuid === volume.volume_uuid);
         if (newPage < 1) {

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -48,7 +48,7 @@
     const clickDuration = ingoreTimeOut ? 0 : end.getTime() - start?.getTime();
 
     if (pages && volume && clickDuration < 200) {
-      if (showSecondPage() && page + 1 === pages.length && newPage > page) {
+      if (showSecondPage() && page >= pages.length && newPage > page) {
         return false;
       }
       const pageClamped = clamp(newPage, 1, pages?.length);


### PR DESCRIPTION
This PR fixes a bug where the reader would get stuck at the end of a volume in two-page mode instead of loading the next volume.

### Changes
- Modified the condition in `changePage` function to correctly handle volume navigation in two-page mode
- Changed `page + 1 === pages.length` to `page >= pages.length` to ensure navigation is only blocked when actually at the last page

### Testing
1. Open a manga in two-page mode
2. Navigate to the end of a volume
3. Try to navigate to the next volume
4. Verify that the next volume loads correctly