### PR TITLE
Fix volume navigation issues

### DIFF
--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -19,7 +19,7 @@
   $: volumeData = $currentVolumeData;
   $: pages = volumeData?.pages || [];
 
-  $: page = $progress?.[volume?.volume_uuid || 0] || 1;
+  $: page = volume?.volume_uuid ? ($progress?.[volume.volume_uuid] ?? 1) : 1;
   $: index = page - 1;
   $: navAmount =
     volumeSettings.singlePageView ||

--- a/src/lib/settings/volume-data.ts
+++ b/src/lib/settings/volume-data.ts
@@ -51,13 +51,14 @@ export function initializeVolume(volume: string) {
 
   const { hasCover, rightToLeft, singlePageView } = volumeDefaults
   volumes.update((prev) => {
+    const existingVolume = prev[volume];
     return {
       ...prev,
       [volume]: {
-        chars: 0,
-        completed: false,
-        progress: 0,
-        timeReadInMinutes: 0,
+        chars: existingVolume?.chars ?? 0,
+        completed: existingVolume?.completed ?? false,
+        progress: existingVolume?.progress ?? 1,
+        timeReadInMinutes: existingVolume?.timeReadInMinutes ?? 0,
         settings: {
           hasCover,
           rightToLeft,


### PR DESCRIPTION
Fixes #29

This PR addresses the issue where pages are not being displayed when resuming a reading session across multiple volumes.

Changes:
- Use nullish coalescing operator to handle undefined progress
- Preserve existing volume data when initializing volume
- Fix page calculation in Reader component

The previous approach had issues with volume initialization and progress handling. This new approach:
1. Preserves existing volume data when reinitializing a volume
2. Uses the nullish coalescing operator to handle undefined progress values
3. Fixes the page calculation in the Reader component to handle edge cases better

Steps to test:
1. Start with a fresh catalog
2. Upload a manga series with multiple volumes
3. Navigate to the end of volume 1
4. Flip to volume 2
5. Return to the manga series page
6. Select volume 2 again

The page should now display correctly instead of showing a blank screen.