### PR TITLE
Add option to disable page turn on blank space

### DIFF
--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -318,28 +318,30 @@
   </button>
   <div class="flex" style:background-color={$settings.backgroundColor}>
     <Panzoom>
-      <button
-        class="h-full fixed -left-full z-10 w-full hover:bg-slate-400 opacity-[0.01]"
-        style:margin-left={`${$settings.edgeButtonWidth}px`}
-        on:mousedown={mouseDown}
-        on:mouseup={left}
-      />
-      <button
-        class="h-full fixed -right-full z-10 w-full hover:bg-slate-400 opacity-[0.01]"
-        style:margin-right={`${$settings.edgeButtonWidth}px`}
-        on:mousedown={mouseDown}
-        on:mouseup={right}
-      />
-      <button
-        class="h-screen fixed top-full -left-full z-10 w-[150%] hover:bg-slate-400 opacity-[0.01]"
-        on:mousedown={mouseDown}
-        on:mouseup={left}
-      />
-      <button
-        class="h-screen fixed top-full -right-full z-10 w-[150%] hover:bg-slate-400 opacity-[0.01]"
-        on:mousedown={mouseDown}
-        on:mouseup={right}
-      />
+      {#if !$settings.disableBlankSpacePageTurn}
+        <button
+          class="h-full fixed -left-full z-10 w-full hover:bg-slate-400 opacity-[0.01]"
+          style:margin-left={`${$settings.edgeButtonWidth}px`}
+          on:mousedown={mouseDown}
+          on:mouseup={left}
+        />
+        <button
+          class="h-full fixed -right-full z-10 w-full hover:bg-slate-400 opacity-[0.01]"
+          style:margin-right={`${$settings.edgeButtonWidth}px`}
+          on:mousedown={mouseDown}
+          on:mouseup={right}
+        />
+        <button
+          class="h-screen fixed top-full -left-full z-10 w-[150%] hover:bg-slate-400 opacity-[0.01]"
+          on:mousedown={mouseDown}
+          on:mouseup={left}
+        />
+        <button
+          class="h-screen fixed top-full -right-full z-10 w-[150%] hover:bg-slate-400 opacity-[0.01]"
+          on:mousedown={mouseDown}
+          on:mouseup={right}
+        />
+      {/if}
       <div
         class="flex flex-row"
         class:flex-row-reverse={!volumeSettings.rightToLeft}
@@ -357,7 +359,7 @@
       </div>
     </Panzoom>
   </div>
-  {#if !$settings.mobile}
+  {#if !$settings.mobile && !$settings.disableBlankSpacePageTurn}
     <button
       on:mousedown={mouseDown}
       on:mouseup={left}

--- a/src/lib/components/Settings/Reader/ReaderToggles.svelte
+++ b/src/lib/components/Settings/Reader/ReaderToggles.svelte
@@ -14,7 +14,8 @@
     { key: 'mobile', text: 'Mobile', value: $settings.mobile },
     { key: 'showTimer', text: 'Show timer', value: $settings.showTimer },
     { key: 'quickActions', text: 'Show quick actions', value: $settings.quickActions },
-    { key: 'invertColors', text: 'Invert colors of the images', value: $settings.invertColors }
+    { key: 'invertColors', text: 'Invert colors of the images', value: $settings.invertColors },
+    { key: 'disableBlankSpacePageTurn', text: 'Disable page turn on blank space', value: $settings.disableBlankSpacePageTurn }
   ] as { key: SettingsKey; text: string; value: any }[];
 </script>
 

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -58,6 +58,7 @@ export type Settings = {
   fontSize: FontSize;
   zoomDefault: ZoomModes;
   invertColors: boolean;
+  disableBlankSpacePageTurn: boolean;
   volumeDefaults: VolumeDefaults;
   ankiConnectSettings: AnkiConnectSettings;
 };
@@ -86,6 +87,7 @@ const defaultSettings: Settings = {
   fontSize: 'auto',
   zoomDefault: 'zoomFitToScreen',
   invertColors: false,
+  disableBlankSpacePageTurn: false,
   volumeDefaults: {
     singlePageView: false,
     rightToLeft: true,


### PR DESCRIPTION
This PR adds a new setting that allows users to disable the ability to turn pages by clicking/tapping the blank space outside of the pages.

Changes:
- Added `disableBlankSpacePageTurn` setting to the Settings type and defaultSettings
- Added a new toggle in ReaderToggles.svelte to control this setting
- Modified Reader.svelte to conditionally render the click areas based on the new setting

The setting is off by default to maintain the original behavior.