### PR TITLE
Improve scroll behavior in Reader component

### DIFF
--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -216,18 +216,8 @@
 
     const { scale } = $panzoomStore.getTransform();
 
-    // Handle zooming when Ctrl is pressed
-    if (event.ctrlKey) {
-      event.preventDefault();
-      const delta = event.deltaY;
-      const zoomFactor = delta > 0 ? 0.9 : 1.1;
-      $panzoomStore.zoomToPoint(event.clientX, event.clientY, zoomFactor * scale);
-      return;
-    }
-
-    // Handle page navigation when not zoomed in
-    if (scale <= 1) {
-      event.preventDefault();
+    // Only handle page navigation when not zoomed in
+    if (scale <= 1 && !event.ctrlKey) {
       if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
         if (event.deltaY > 0) {
           changePage(page + navAmount, true);
@@ -235,6 +225,7 @@
           changePage(page - navAmount, true);
         }
       }
+    }
     }
   }
 

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -113,22 +113,26 @@
   function handleWheel(event: WheelEvent) {
     if ($panzoomStore) {
       const { scale } = $panzoomStore.getTransform();
+      console.log('Current scale:', scale);
       
       // Handle zooming when Ctrl is pressed
       if (event.ctrlKey) {
         event.preventDefault();
         const delta = event.deltaY;
-        const zoomFactor = delta > 0 ? 0.9 : 1.1;  // Zoom out if delta positive, in if negative
+        console.log('Zoom delta:', delta);
+        const zoomFactor = delta > 0 ? 0.9 : 1.1;
+        console.log('Zoom factor:', zoomFactor);
         $panzoomStore.zoomToPoint(event.clientX, event.clientY, zoomFactor * scale);
         return;
       }
 
-      // If zoomed in (scale > 1), use traditional scrolling
-      if (scale > 1) {
+      // If zoomed in (scale < 1), use traditional scrolling
+      if (scale < 1) {
         event.preventDefault();
         event.stopPropagation();
         const deltaX = event.deltaX;
         const deltaY = event.deltaY;
+        console.log('Pan deltas:', deltaX, deltaY);
         $panzoomStore.pan(deltaX * -1, deltaY * -1, { relative: true });
         return;
       }

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -248,6 +248,35 @@
     }
   }
 
+  function handleWheel(event: WheelEvent) {
+    if (!$panzoomStore || !event.target.closest('#manga-panel')) {
+      return;
+    }
+
+    const { scale } = $panzoomStore.getTransform();
+
+    // Handle zooming when Ctrl is pressed
+    if (event.ctrlKey) {
+      event.preventDefault();
+      const delta = event.deltaY;
+      const zoomFactor = delta > 0 ? 0.9 : 1.1;
+      $panzoomStore.zoomToPoint(event.clientX, event.clientY, zoomFactor * scale);
+      return;
+    }
+
+    // Handle page navigation when not zoomed in
+    if (scale <= 1) {
+      event.preventDefault();
+      if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
+        if (event.deltaY > 0) {
+          changePage(page + navAmount, true);
+        } else {
+          changePage(page - navAmount, true);
+        }
+      }
+    }
+  }
+
   $: {
     if (volume) {
       const { charCount, lineCount } = getCharCount(pages, page);
@@ -298,6 +327,7 @@
   on:keyup={handleShortcuts}
   on:touchstart={handleTouchStart}
   on:touchend={handlePointerUp}
+  on:wheel={handleWheel}
 />
 <svelte:head>
   <title>{volume?.volume_title || 'Volume'}</title>

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -110,46 +110,7 @@
     changePage(manualPage, true);
   }
 
-  function handleWheel(event: WheelEvent) {
-    // Only handle events from the manga panel
-    const mangaPanel = document.getElementById('manga-panel');
-    if (!mangaPanel?.contains(event.target as Node)) {
-      return;
-    }
 
-    if ($panzoomStore) {
-      const { scale } = $panzoomStore.getTransform();
-
-      // Handle zooming only when Ctrl is pressed
-      if (event.ctrlKey) {
-        event.preventDefault();
-        event.stopPropagation();
-        const delta = event.deltaY;
-        const zoomFactor = delta > 0 ? 0.9 : 1.1;
-        $panzoomStore.zoomToPoint(event.clientX, event.clientY, zoomFactor * scale);
-        return;
-      }
-
-      // If zoomed in (scale > 1), use traditional scrolling
-      if (scale > 1) {
-        event.preventDefault();
-        const deltaX = event.deltaX;
-        const deltaY = event.deltaY;
-        $panzoomStore.moveBy(deltaX * -1, deltaY * -1);
-        return;
-      }
-
-      // If not zoomed in (scale <= 1), use page navigation
-      if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
-        event.preventDefault();
-        if (event.deltaY > 0) {
-          changePage(page + navAmount, true);
-        } else {
-          changePage(page - navAmount, true);
-        }
-      }
-    }
-  }
 
   function handleShortcuts(event: KeyboardEvent & { currentTarget: EventTarget & Window }) {
     const action = event.code || event.key;

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -298,7 +298,6 @@
   on:keyup={handleShortcuts}
   on:touchstart={handleTouchStart}
   on:touchend={handlePointerUp}
-  on:wheel|capture={handleWheel}
 />
 <svelte:head>
   <title>{volume?.volume_title || 'Volume'}</title>
@@ -387,6 +386,7 @@
         class:flex-row-reverse={!volumeSettings.rightToLeft}
         style:filter={`invert(${$settings.invertColors ? 1 : 0})`}
         on:dblclick={onDoubleTap}
+        on:wheel={handleWheel}
         role="none"
         id="manga-panel"
       >

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -110,6 +110,39 @@
     changePage(manualPage, true);
   }
 
+  function handleWheel(event: WheelEvent) {
+    if ($panzoomStore) {
+      // Handle zooming when Ctrl is pressed
+      if (event.ctrlKey) {
+        event.preventDefault();
+        const delta = event.deltaY;
+        const zoomFactor = delta > 0 ? 0.9 : 1.1;  // Zoom out if delta positive, in if negative
+        $panzoomStore.zoomToPoint(event.clientX, event.clientY, zoomFactor * $panzoomStore.getTransform().scale);
+        return;
+      }
+
+      const { scale } = $panzoomStore.getTransform();
+      
+      // If zoomed in (scale > 1), use traditional scrolling
+      if (scale > 1) {
+        event.stopPropagation();
+        const deltaX = event.deltaX;
+        const deltaY = event.deltaY;
+        $panzoomStore.pan(deltaX * -1, deltaY * -1, { relative: true });
+      } else {
+        // If not zoomed in, use page navigation
+        event.preventDefault();
+        if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
+          if (event.deltaY > 0) {
+            changePage(page + navAmount, true);
+          } else {
+            changePage(page - navAmount, true);
+          }
+        }
+      }
+    }
+  }
+
   function handleShortcuts(event: KeyboardEvent & { currentTarget: EventTarget & Window }) {
     const action = event.code || event.key;
 
@@ -257,6 +290,7 @@
   on:keyup={handleShortcuts}
   on:touchstart={handleTouchStart}
   on:touchend={handlePointerUp}
+  on:wheel={handleWheel}
 />
 <svelte:head>
   <title>{volume?.volume_title || 'Volume'}</title>

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -386,7 +386,6 @@
         class:flex-row-reverse={!volumeSettings.rightToLeft}
         style:filter={`invert(${$settings.invertColors ? 1 : 0})`}
         on:dblclick={onDoubleTap}
-        on:wheel={handleWheel}
         role="none"
         id="manga-panel"
       >

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -298,7 +298,7 @@
   on:keyup={handleShortcuts}
   on:touchstart={handleTouchStart}
   on:touchend={handlePointerUp}
-  on:wheel={handleWheel}
+  on:wheel|capture={handleWheel}
 />
 <svelte:head>
   <title>{volume?.volume_title || 'Volume'}</title>

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -113,31 +113,27 @@
   function handleWheel(event: WheelEvent) {
     if ($panzoomStore) {
       const { scale } = $panzoomStore.getTransform();
-      console.log('Current scale:', scale);
       
       // Handle zooming when Ctrl is pressed
       if (event.ctrlKey) {
         event.preventDefault();
         const delta = event.deltaY;
-        console.log('Zoom delta:', delta);
         const zoomFactor = delta > 0 ? 0.9 : 1.1;
-        console.log('Zoom factor:', zoomFactor);
         $panzoomStore.zoomToPoint(event.clientX, event.clientY, zoomFactor * scale);
         return;
       }
 
-      // If zoomed in (scale < 1), use traditional scrolling
-      if (scale < 1) {
+      // If zoomed in (scale > 1), use traditional scrolling
+      if (scale > 1) {
         event.preventDefault();
         event.stopPropagation();
         const deltaX = event.deltaX;
         const deltaY = event.deltaY;
-        console.log('Pan deltas:', deltaX, deltaY);
         $panzoomStore.pan(deltaX * -1, deltaY * -1, { relative: true });
         return;
       }
 
-      // If not zoomed in, use page navigation
+      // If not zoomed in (scale <= 1), use page navigation
       event.preventDefault();
       if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
         if (event.deltaY > 0) {

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -111,12 +111,19 @@
   }
 
   function handleWheel(event: WheelEvent) {
+    // Only handle events from the manga panel
+    const mangaPanel = document.getElementById('manga-panel');
+    if (!mangaPanel?.contains(event.target as Node)) {
+      return;
+    }
+
     if ($panzoomStore) {
       const { scale } = $panzoomStore.getTransform();
-      event.preventDefault();
 
       // Handle zooming only when Ctrl is pressed
       if (event.ctrlKey) {
+        event.preventDefault();
+        event.stopPropagation();
         const delta = event.deltaY;
         const zoomFactor = delta > 0 ? 0.9 : 1.1;
         $panzoomStore.zoomToPoint(event.clientX, event.clientY, zoomFactor * scale);
@@ -125,6 +132,7 @@
 
       // If zoomed in (scale > 1), use traditional scrolling
       if (scale > 1) {
+        event.preventDefault();
         const deltaX = event.deltaX;
         const deltaY = event.deltaY;
         $panzoomStore.moveBy(deltaX * -1, deltaY * -1);
@@ -133,6 +141,7 @@
 
       // If not zoomed in (scale <= 1), use page navigation
       if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
+        event.preventDefault();
         if (event.deltaY > 0) {
           changePage(page + navAmount, true);
         } else {

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -112,32 +112,34 @@
 
   function handleWheel(event: WheelEvent) {
     if ($panzoomStore) {
+      const { scale } = $panzoomStore.getTransform();
+      
       // Handle zooming when Ctrl is pressed
       if (event.ctrlKey) {
         event.preventDefault();
         const delta = event.deltaY;
         const zoomFactor = delta > 0 ? 0.9 : 1.1;  // Zoom out if delta positive, in if negative
-        $panzoomStore.zoomToPoint(event.clientX, event.clientY, zoomFactor * $panzoomStore.getTransform().scale);
+        $panzoomStore.zoomToPoint(event.clientX, event.clientY, zoomFactor * scale);
         return;
       }
 
-      const { scale } = $panzoomStore.getTransform();
-      
       // If zoomed in (scale > 1), use traditional scrolling
       if (scale > 1) {
+        event.preventDefault();
         event.stopPropagation();
         const deltaX = event.deltaX;
         const deltaY = event.deltaY;
         $panzoomStore.pan(deltaX * -1, deltaY * -1, { relative: true });
-      } else {
-        // If not zoomed in, use page navigation
-        event.preventDefault();
-        if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
-          if (event.deltaY > 0) {
-            changePage(page + navAmount, true);
-          } else {
-            changePage(page - navAmount, true);
-          }
+        return;
+      }
+
+      // If not zoomed in, use page navigation
+      event.preventDefault();
+      if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
+        if (event.deltaY > 0) {
+          changePage(page + navAmount, true);
+        } else {
+          changePage(page - navAmount, true);
         }
       }
     }

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -127,7 +127,7 @@
       if (scale > 1) {
         const deltaX = event.deltaX;
         const deltaY = event.deltaY;
-        $panzoomStore.pan(deltaX * -1, deltaY * -1, { relative: true });
+        $panzoomStore.moveBy(deltaX * -1, deltaY * -1);
         return;
       }
 

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -113,10 +113,10 @@
   function handleWheel(event: WheelEvent) {
     if ($panzoomStore) {
       const { scale } = $panzoomStore.getTransform();
-      
-      // Handle zooming when Ctrl is pressed
+      event.preventDefault();
+
+      // Handle zooming only when Ctrl is pressed
       if (event.ctrlKey) {
-        event.preventDefault();
         const delta = event.deltaY;
         const zoomFactor = delta > 0 ? 0.9 : 1.1;
         $panzoomStore.zoomToPoint(event.clientX, event.clientY, zoomFactor * scale);
@@ -125,8 +125,6 @@
 
       // If zoomed in (scale > 1), use traditional scrolling
       if (scale > 1) {
-        event.preventDefault();
-        event.stopPropagation();
         const deltaX = event.deltaX;
         const deltaY = event.deltaY;
         $panzoomStore.pan(deltaX * -1, deltaY * -1, { relative: true });
@@ -134,7 +132,6 @@
       }
 
       // If not zoomed in (scale <= 1), use page navigation
-      event.preventDefault();
       if (Math.abs(event.deltaY) > Math.abs(event.deltaX)) {
         if (event.deltaY > 0) {
           changePage(page + navAmount, true);

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -29,7 +29,7 @@ export function initPanzoom(node: HTMLElement) {
       const nodeName = (e.target as HTMLElement).nodeName;
       return nodeName === 'P';
     },
-    beforeWheel: (e) => !e.ctrlKey && e.target.closest('#manga-panel') && pz?.getTransform().scale > 1,
+    beforeWheel: (e) => !e.ctrlKey,
     onTouch: (e) => e.touches.length > 1,
     // Panzoom typing is wrong here
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -32,7 +32,20 @@ export function initPanzoom(node: HTMLElement) {
     beforeWheel: (e) => {
       if (!pz) return false;
       const { scale } = pz.getTransform();
-      return e.ctrlKey || scale > 1;
+      
+      // When zoomed in, handle all wheel events
+      if (scale > 1) {
+        if (!e.ctrlKey) {
+          // Handle panning
+          e.preventDefault();
+          pz.pan(e.deltaX * -1, e.deltaY * -1, { relative: true });
+          return false; // Don't let panzoom handle it further
+        }
+        return true; // Let panzoom handle Ctrl+wheel for zooming
+      }
+      
+      // When not zoomed in, only handle Ctrl+wheel for zooming
+      return e.ctrlKey;
     },
     onTouch: (e) => e.touches.length > 1,
     // Panzoom typing is wrong here

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -29,7 +29,7 @@ export function initPanzoom(node: HTMLElement) {
       const nodeName = (e.target as HTMLElement).nodeName;
       return nodeName === 'P';
     },
-    beforeWheel: () => true,
+    beforeWheel: (e) => !e.ctrlKey && e.target.closest('#manga-panel') && $panzoomStore?.getTransform().scale > 1,
     onTouch: (e) => e.touches.length > 1,
     // Panzoom typing is wrong here
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -29,7 +29,11 @@ export function initPanzoom(node: HTMLElement) {
       const nodeName = (e.target as HTMLElement).nodeName;
       return nodeName === 'P';
     },
-    beforeWheel: (e) => !e.ctrlKey,
+    beforeWheel: (e) => {
+      if (!pz) return false;
+      const { scale } = pz.getTransform();
+      return e.ctrlKey || scale > 1;
+    },
     onTouch: (e) => e.touches.length > 1,
     // Panzoom typing is wrong here
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -9,10 +9,12 @@ let container: HTMLElement | undefined;
 export const panzoomStore = writable<PanZoom | undefined>(undefined);
 
 export function initPanzoom(node: HTMLElement) {
-  // Add global event listener to prevent browser zoom
+  // Add global event listener to prevent browser zoom only on manga panel
   window.addEventListener('wheel', (e) => {
-    if (e.ctrlKey) {
+    const mangaPanel = document.getElementById('manga-panel');
+    if (e.ctrlKey && mangaPanel?.contains(e.target as Node)) {
       e.preventDefault();
+      e.stopPropagation();
     }
   }, { passive: false, capture: true });
 

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -29,24 +29,7 @@ export function initPanzoom(node: HTMLElement) {
       const nodeName = (e.target as HTMLElement).nodeName;
       return nodeName === 'P';
     },
-    beforeWheel: (e) => {
-      if (!pz) return false;
-      const { scale } = pz.getTransform();
-      
-      // When zoomed in, handle all wheel events
-      if (scale > 1) {
-        if (!e.ctrlKey) {
-          // Handle panning
-          e.preventDefault();
-          pz.pan(e.deltaX * -1, e.deltaY * -1, { relative: true });
-          return false; // Don't let panzoom handle it further
-        }
-        return true; // Let panzoom handle Ctrl+wheel for zooming
-      }
-      
-      // When not zoomed in, only handle Ctrl+wheel for zooming
-      return e.ctrlKey;
-    },
+    beforeWheel: () => true,
     onTouch: (e) => e.touches.length > 1,
     // Panzoom typing is wrong here
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -29,7 +29,16 @@ export function initPanzoom(node: HTMLElement) {
       const nodeName = (e.target as HTMLElement).nodeName;
       return nodeName === 'P';
     },
-    beforeWheel: () => true,
+    beforeWheel: (e) => {
+      if (!pz) return false;
+      const { scale } = pz.getTransform();
+      if (e.ctrlKey) {
+        pz.setOptions({ wheelMode: 'zoom' });
+      } else {
+        pz.setOptions({ wheelMode: 'transform' });
+      }
+      return scale > 1 || e.ctrlKey;
+    },
     onTouch: (e) => e.touches.length > 1,
     // Panzoom typing is wrong here
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -20,7 +20,7 @@ export function initPanzoom(node: HTMLElement) {
       const nodeName = (e.target as HTMLElement).nodeName;
       return nodeName === 'P';
     },
-    beforeWheel: (e) => e.altKey,
+    beforeWheel: () => true,
     onTouch: (e) => e.touches.length > 1,
     // Panzoom typing is wrong here
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -9,6 +9,13 @@ let container: HTMLElement | undefined;
 export const panzoomStore = writable<PanZoom | undefined>(undefined);
 
 export function initPanzoom(node: HTMLElement) {
+  // Add global event listener to prevent browser zoom
+  window.addEventListener('wheel', (e) => {
+    if (e.ctrlKey) {
+      e.preventDefault();
+    }
+  }, { passive: false, capture: true });
+
   container = node;
   pz = panzoom(node, {
     bounds: false,

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -29,7 +29,7 @@ export function initPanzoom(node: HTMLElement) {
       const nodeName = (e.target as HTMLElement).nodeName;
       return nodeName === 'P';
     },
-    beforeWheel: (e) => !e.ctrlKey && e.target.closest('#manga-panel') && $panzoomStore?.getTransform().scale > 1,
+    beforeWheel: (e) => !e.ctrlKey && e.target.closest('#manga-panel') && pz?.getTransform().scale > 1,
     onTouch: (e) => e.touches.length > 1,
     // Panzoom typing is wrong here
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
This PR improves the scroll behavior in the Reader component to make it more intuitive and user-friendly:

- When zoomed in (scale > 1), use traditional scrolling behavior
- When not zoomed in (full page visible), use scroll for page navigation
- Add Ctrl+scroll for zooming relative to cursor position

These changes make the reading experience more natural and consistent with common document viewer behaviors.