### PR TITLE
fix: improve memory efficiency in file processing

### DIFF
--- a/src/lib/upload/index.ts
+++ b/src/lib/upload/index.ts
@@ -208,7 +208,7 @@ async function processStandaloneImage(
 
   if (!path) return;
 
-  const imageName = path.split('/').at(-1);
+  const relativePath = file.file.webkitRelativePath;
   const vol = Object.keys(volumesDataByPath).find(key => path.startsWith(key));
 
   if(!vol){
@@ -219,17 +219,17 @@ async function processStandaloneImage(
     if (!pendingImagesByPath[dirPath]) {
       pendingImagesByPath[dirPath] = {};
     }
-    pendingImagesByPath[dirPath][imageName] = file.file;
+    pendingImagesByPath[dirPath][relativePath] = file.file;
     return;
   }
 
-  if (!vol || !imageName) return;
+  if (!vol || !relativePath) return;
 
   // Add image to volume data
   if (!volumesDataByPath[vol].files) {
     volumesDataByPath[vol].files = {};
   }
-  volumesDataByPath[vol].files![imageName] = file.file;
+  volumesDataByPath[vol].files![relativePath] = file.file;
 
   // Check if volume is complete
   if (volumesDataByPath[vol].pages?.length === Object.keys(volumesDataByPath[vol].files!).length) {


### PR DESCRIPTION
This PR fixes potential out-of-memory issues when processing large bulk uploads, particularly when dealing with nested zip/cbz files.

Changes:
- Use stack-based processing to handle files efficiently
- Simplify zip extraction to just return a list of files
- Let main loop handle file type identification
- Release memory from zip files immediately after processing
- Handle both embedded and external mokuro files
- Maintain proper path relationships for nested files

The previous implementation would keep all extracted files in memory, which could cause browser crashes with large uploads. The new version:
1. Processes one file at a time using a stack
2. Extracts files without pre-categorizing them
3. Releases memory as soon as possible
4. Handles nested archives without recursion
5. Supports both embedded and external mokuro files

This should prevent browser crashes even with large bulk uploads containing nested archives.