### PR TITLE
Fix Issue #43: Sort files case-insensitively before adding to database

### DIFF
--- a/src/lib/upload/index.ts
+++ b/src/lib/upload/index.ts
@@ -134,6 +134,18 @@ async function uploadVolumeData(
       .first();
 
     if (!existingVolume) {
+      // Sort files by name case-insensitively
+      if (uploadData.files) {
+        uploadData.files = Object.fromEntries(
+          Object.entries(uploadData.files).sort(([aKey, aFile], [bKey, bFile]) =>
+            aKey.localeCompare(bKey, undefined, {
+              numeric: true,
+              sensitivity: 'base'
+            })
+          )
+        );
+      }
+
       uploadMetadata.thumbnail = await generateThumbnail(
         uploadData.files?.[Object.keys(uploadData.files)[0]]
       );


### PR DESCRIPTION
This PR fixes Issue #43 by adding case-insensitive sorting of files before they are added to the database.

Changes:
- Added sorting of `uploadData.files` using `localeCompare` with `sensitivity: "base"` for case-insensitive sorting
- Maintained numeric sorting with `numeric: true`
- Added sorting just before thumbnail generation to ensure consistent order