### PR TITLE
Fix close reader button navigation (#45)

### DIFF
--- a/src/lib/components/Settings/QuickAccess.svelte
+++ b/src/lib/components/Settings/QuickAccess.svelte
@@ -8,7 +8,10 @@
 
   function onClose() {
     hidden = true;
-    history.back();
+    // Extract series UUID from current URL and navigate to series page
+    const pathname = window.location.pathname || '';
+    const seriesUuid = pathname.split('/')[1] || '';
+    window.location.href = `/${seriesUuid}`;
   }
 </script>
 

--- a/src/lib/components/Settings/__tests__/QuickAccess.test.ts
+++ b/src/lib/components/Settings/__tests__/QuickAccess.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/svelte';
+import QuickAccess from '../QuickAccess.svelte';
+import { isReader } from '$lib/util';
+
+vi.mock('$lib/util', () => ({
+  isReader: vi.fn()
+}));
+
+describe('QuickAccess', () => {
+  it('should navigate to series page when closing reader', async () => {
+    // Mock isReader to return true
+    vi.mocked(isReader).mockReturnValue(true);
+
+    // Mock window.location
+    const originalLocation = window.location;
+    delete window.location;
+    window.location = { 
+      href: '/series-uuid/volume-uuid',
+      pathname: '/series-uuid/volume-uuid'
+    } as any;
+
+    const { getByText } = render(QuickAccess);
+    const closeButton = getByText('Close reader');
+    
+    await fireEvent.click(closeButton);
+    
+    // Should navigate to /series-uuid
+    expect(window.location.href).toBe('/series-uuid');
+
+    // Restore window.location
+    window.location = originalLocation;
+  });
+});


### PR DESCRIPTION
This PR fixes issue #45 where the "Close reader" button in the menu within the reader was issuing a back command instead of navigating up to the volumes page.

Changes:
1. Extracts the series UUID from the current URL
2. Navigates directly to the volumes page using the series UUID
3. Adds tests to ensure the navigation works correctly

Fixes #45