### PR TITLE
Add CBZ extraction and individual volume options

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "0.9.1",
   "private": true,
   "scripts": {
-    "predev": "node -e \"if(!process.version.startsWith('v18')){console.error('\\x1b[31mERROR: This project requires Node.js v18.x\\x1b[0m');process.exit(1)}\"",
-    "prebuild": "node -e \"if(!process.version.startsWith('v18')){console.error('\\x1b[31mERROR: This project requires Node.js v18.x\\x1b[0m');process.exit(1)}\"",
-    "prepreview": "node -e \"if(!process.version.startsWith('v18')){console.error('\\x1b[31mERROR: This project requires Node.js v18.x\\x1b[0m');process.exit(1)}\"",
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
@@ -56,6 +53,6 @@
     "svelte-easy-crop": "^2.0.1"
   },
   "engines": {
-    "node": "18.x"
+    "node": ">=18.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.9.1",
   "private": true,
   "scripts": {
+    "predev": "node -e \"if(!process.version.startsWith('v18')){console.error('\\x1b[31mERROR: This project requires Node.js v18.x\\x1b[0m');process.exit(1)}\"",
+    "prebuild": "node -e \"if(!process.version.startsWith('v18')){console.error('\\x1b[31mERROR: This project requires Node.js v18.x\\x1b[0m');process.exit(1)}\"",
+    "prepreview": "node -e \"if(!process.version.startsWith('v18')){console.error('\\x1b[31mERROR: This project requires Node.js v18.x\\x1b[0m');process.exit(1)}\"",
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
@@ -53,6 +56,6 @@
     "svelte-easy-crop": "^2.0.1"
   },
   "engines": {
-    "node": ">=18.x"
+    "node": "18.x"
   }
 }

--- a/src/lib/components/ExtractionModal.svelte
+++ b/src/lib/components/ExtractionModal.svelte
@@ -6,18 +6,36 @@
   let open = false;
   let asCbz = true;
   let individualVolumes = false;
+  let includeSeriesTitle = true;
+  let firstVolumePreview = '';
 
   onMount(() => {
     extractionModalStore.subscribe((value) => {
       if (value) {
         open = value.open;
+        if (value.firstVolume) {
+          updateFilenamePreview(value.firstVolume);
+        }
       }
     });
   });
 
+  function updateFilenamePreview(firstVolume: { series_title: string, volume_title: string }) {
+    if (firstVolume) {
+      const extension = asCbz ? 'cbz' : 'zip';
+      if (includeSeriesTitle && individualVolumes) {
+        firstVolumePreview = `${firstVolume.series_title} - ${firstVolume.volume_title}.${extension}`;
+      } else if (individualVolumes) {
+        firstVolumePreview = `${firstVolume.volume_title}.${extension}`;
+      } else {
+        firstVolumePreview = `${firstVolume.series_title}.${extension}`;
+      }
+    }
+  }
+
   function handleExtract() {
     if ($extractionModalStore?.onConfirm) {
-      $extractionModalStore.onConfirm(asCbz, individualVolumes);
+      $extractionModalStore.onConfirm(asCbz, individualVolumes, includeSeriesTitle);
     }
     open = false;
   }
@@ -28,9 +46,19 @@
     }
     open = false;
   }
+
+  $: if ($extractionModalStore?.firstVolume) {
+    updateFilenamePreview($extractionModalStore.firstVolume);
+  }
+
+  $: if (asCbz !== undefined || includeSeriesTitle !== undefined || individualVolumes !== undefined) {
+    if ($extractionModalStore?.firstVolume) {
+      updateFilenamePreview($extractionModalStore.firstVolume);
+    }
+  }
 </script>
 
-<Modal bind:open size="sm" autoclose outsideclose>
+<Modal bind:open size="md" autoclose outsideclose>
   <div class="text-center">
     <h3 class="mb-5 text-lg font-normal text-gray-700 dark:text-gray-300">
       Extract Options
@@ -43,6 +71,18 @@
       <div class="flex items-center justify-between">
         <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Extract individual volumes</span>
         <Toggle bind:checked={individualVolumes} />
+      </div>
+      
+      {#if individualVolumes}
+        <div class="flex items-center justify-between">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Include series title in filename</span>
+          <Toggle bind:checked={includeSeriesTitle} />
+        </div>
+      {/if}
+      
+      <div class="mt-2 p-3 bg-gray-100 dark:bg-gray-800 rounded-md">
+        <div class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Filename preview:</div>
+        <div class="text-xs font-mono break-all text-gray-600 dark:text-gray-400">{firstVolumePreview}</div>
       </div>
     </div>
     <div class="flex justify-center gap-2">

--- a/src/lib/components/ExtractionModal.svelte
+++ b/src/lib/components/ExtractionModal.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { Button, Modal, Toggle } from 'flowbite-svelte';
+  import { extractionModalStore } from '$lib/util/modals';
+  import { onMount } from 'svelte';
+
+  let open = false;
+  let asCbz = true;
+  let individualVolumes = false;
+
+  onMount(() => {
+    extractionModalStore.subscribe((value) => {
+      if (value) {
+        open = value.open;
+      }
+    });
+  });
+
+  function handleExtract() {
+    if ($extractionModalStore?.onConfirm) {
+      $extractionModalStore.onConfirm(asCbz, individualVolumes);
+    }
+    open = false;
+  }
+
+  function handleCancel() {
+    if ($extractionModalStore?.onCancel) {
+      $extractionModalStore.onCancel();
+    }
+    open = false;
+  }
+</script>
+
+<Modal bind:open size="sm" autoclose outsideclose>
+  <div class="text-center">
+    <h3 class="mb-5 text-lg font-normal text-gray-700 dark:text-gray-300">
+      Extract Options
+    </h3>
+    <div class="flex flex-col gap-4 mb-5">
+      <div class="flex items-center justify-between">
+        <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Extract as CBZ</span>
+        <Toggle bind:checked={asCbz} />
+      </div>
+      <div class="flex items-center justify-between">
+        <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Extract individual volumes</span>
+        <Toggle bind:checked={individualVolumes} />
+      </div>
+    </div>
+    <div class="flex justify-center gap-2">
+      <Button color="blue" on:click={handleExtract}>Extract</Button>
+      <Button color="alternative" on:click={handleCancel}>Cancel</Button>
+    </div>
+  </div>
+</Modal>

--- a/src/lib/util/modals.ts
+++ b/src/lib/util/modals.ts
@@ -19,14 +19,20 @@ export function promptConfirmation(message: string, onConfirm?: () => void, onCa
 
 type ExtractionModal = {
   open: boolean;
-  onConfirm?: (asCbz: boolean, individualVolumes: boolean) => void;
+  firstVolume?: { series_title: string, volume_title: string };
+  onConfirm?: (asCbz: boolean, individualVolumes: boolean, includeSeriesTitle: boolean) => void;
   onCancel?: () => void;
 };
 export const extractionModalStore = writable<ExtractionModal | undefined>(undefined);
 
-export function promptExtraction(onConfirm?: (asCbz: boolean, individualVolumes: boolean) => void, onCancel?: () => void) {
+export function promptExtraction(
+  firstVolume: { series_title: string, volume_title: string },
+  onConfirm?: (asCbz: boolean, individualVolumes: boolean, includeSeriesTitle: boolean) => void, 
+  onCancel?: () => void
+) {
   extractionModalStore.set({
     open: true,
+    firstVolume,
     onConfirm,
     onCancel
   });

--- a/src/lib/util/modals.ts
+++ b/src/lib/util/modals.ts
@@ -16,3 +16,18 @@ export function promptConfirmation(message: string, onConfirm?: () => void, onCa
     onCancel
   });
 }
+
+type ExtractionModal = {
+  open: boolean;
+  onConfirm?: (asCbz: boolean, individualVolumes: boolean) => void;
+  onCancel?: () => void;
+};
+export const extractionModalStore = writable<ExtractionModal | undefined>(undefined);
+
+export function promptExtraction(onConfirm?: (asCbz: boolean, individualVolumes: boolean) => void, onCancel?: () => void) {
+  extractionModalStore.set({
+    open: true,
+    onConfirm,
+    onCancel
+  });
+}

--- a/src/lib/util/zip.test.ts
+++ b/src/lib/util/zip.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { zipManga } from './zip';
+import { db } from '$lib/catalog/db';
+
+// Mock the database
+vi.mock('$lib/catalog/db', () => ({
+  db: {
+    volumes_data: {
+      get: vi.fn()
+    }
+  }
+}));
+
+// Mock the DOM APIs
+global.URL.createObjectURL = vi.fn(() => 'blob:test');
+global.URL.revokeObjectURL = vi.fn();
+
+// Mock document.createElement
+document.createElement = vi.fn().mockImplementation((tag) => {
+  if (tag === 'a') {
+    return {
+      href: '',
+      download: '',
+      click: vi.fn()
+    };
+  }
+  return {};
+});
+
+describe('zipManga', () => {
+  const mockVolume = {
+    volume_uuid: 'test-uuid',
+    series_uuid: 'series-uuid',
+    series_title: 'Test Manga',
+    volume_title: 'Volume 1',
+    mokuro_version: '1.0',
+    character_count: 100
+  };
+
+  const mockVolumeData = {
+    pages: [{ width: 100, height: 100 }],
+    files: {
+      'page1.jpg': new Blob(['test'], { type: 'image/jpeg' })
+    }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // @ts-ignore
+    db.volumes_data.get.mockResolvedValue(mockVolumeData);
+  });
+
+  it('should call zipAllVolumes when individualVolumes is false', async () => {
+    const result = await zipManga([mockVolume], false, false);
+    expect(result).toBe(false);
+    expect(document.createElement).toHaveBeenCalledWith('a');
+    const link = document.createElement('a');
+    expect(link.download).toContain('.zip');
+  });
+
+  it('should call zipSingleVolume when individualVolumes is true', async () => {
+    const result = await zipManga([mockVolume], false, true);
+    expect(result).toBe(false);
+    expect(document.createElement).toHaveBeenCalledWith('a');
+    const link = document.createElement('a');
+    expect(link.download).toContain('.zip');
+  });
+
+  it('should use cbz extension when asCbz is true', async () => {
+    const result = await zipManga([mockVolume], true, false);
+    expect(result).toBe(false);
+    expect(document.createElement).toHaveBeenCalledWith('a');
+    const link = document.createElement('a');
+    expect(link.download).toContain('.cbz');
+  });
+});

--- a/src/lib/util/zip.test.ts
+++ b/src/lib/util/zip.test.ts
@@ -51,7 +51,7 @@ describe('zipManga', () => {
   });
 
   it('should call zipAllVolumes when individualVolumes is false', async () => {
-    const result = await zipManga([mockVolume], false, false);
+    const result = await zipManga([mockVolume], false, false, true);
     expect(result).toBe(false);
     expect(document.createElement).toHaveBeenCalledWith('a');
     const link = document.createElement('a');
@@ -59,7 +59,7 @@ describe('zipManga', () => {
   });
 
   it('should call zipSingleVolume when individualVolumes is true', async () => {
-    const result = await zipManga([mockVolume], false, true);
+    const result = await zipManga([mockVolume], false, true, true);
     expect(result).toBe(false);
     expect(document.createElement).toHaveBeenCalledWith('a');
     const link = document.createElement('a');
@@ -67,10 +67,27 @@ describe('zipManga', () => {
   });
 
   it('should use cbz extension when asCbz is true', async () => {
-    const result = await zipManga([mockVolume], true, false);
+    const result = await zipManga([mockVolume], true, false, true);
     expect(result).toBe(false);
     expect(document.createElement).toHaveBeenCalledWith('a');
     const link = document.createElement('a');
     expect(link.download).toContain('.cbz');
+  });
+  
+  it('should include series title in filename when includeSeriesTitle is true', async () => {
+    const result = await zipManga([mockVolume], false, true, true);
+    expect(result).toBe(false);
+    expect(document.createElement).toHaveBeenCalledWith('a');
+    const link = document.createElement('a');
+    expect(link.download).toContain('Test Manga - Volume 1');
+  });
+  
+  it('should exclude series title from filename when includeSeriesTitle is false', async () => {
+    const result = await zipManga([mockVolume], false, true, false);
+    expect(result).toBe(false);
+    expect(document.createElement).toHaveBeenCalledWith('a');
+    const link = document.createElement('a');
+    expect(link.download).not.toContain('Test Manga -');
+    expect(link.download).toContain('Volume 1');
   });
 });

--- a/src/lib/util/zip.test.ts
+++ b/src/lib/util/zip.test.ts
@@ -50,20 +50,22 @@ describe('zipManga', () => {
     db.volumes_data.get.mockResolvedValue(mockVolumeData);
   });
 
-  it('should call zipAllVolumes when individualVolumes is false', async () => {
+  it('should create a single archive when individualVolumes is false', async () => {
     const result = await zipManga([mockVolume], false, false, true);
     expect(result).toBe(false);
     expect(document.createElement).toHaveBeenCalledWith('a');
     const link = document.createElement('a');
     expect(link.download).toContain('.zip');
+    expect(link.download).toBe('Test Manga.zip');
   });
 
-  it('should call zipSingleVolume when individualVolumes is true', async () => {
+  it('should create individual archives when individualVolumes is true', async () => {
     const result = await zipManga([mockVolume], false, true, true);
     expect(result).toBe(false);
     expect(document.createElement).toHaveBeenCalledWith('a');
     const link = document.createElement('a');
     expect(link.download).toContain('.zip');
+    expect(link.download).toBe('Test Manga - Volume 1.zip');
   });
 
   it('should use cbz extension when asCbz is true', async () => {
@@ -72,6 +74,7 @@ describe('zipManga', () => {
     expect(document.createElement).toHaveBeenCalledWith('a');
     const link = document.createElement('a');
     expect(link.download).toContain('.cbz');
+    expect(link.download).toBe('Test Manga.cbz');
   });
   
   it('should include series title in filename when includeSeriesTitle is true', async () => {
@@ -79,7 +82,7 @@ describe('zipManga', () => {
     expect(result).toBe(false);
     expect(document.createElement).toHaveBeenCalledWith('a');
     const link = document.createElement('a');
-    expect(link.download).toContain('Test Manga - Volume 1');
+    expect(link.download).toBe('Test Manga - Volume 1.zip');
   });
   
   it('should exclude series title from filename when includeSeriesTitle is false', async () => {
@@ -88,6 +91,20 @@ describe('zipManga', () => {
     expect(document.createElement).toHaveBeenCalledWith('a');
     const link = document.createElement('a');
     expect(link.download).not.toContain('Test Manga -');
-    expect(link.download).toContain('Volume 1');
+    expect(link.download).toBe('Volume 1.zip');
+  });
+  
+  it('should use the same internal structure for both single and multiple archives', async () => {
+    // This test verifies that we're using the same function to add files to the archive
+    // regardless of whether we're creating a single archive or multiple archives
+    const singleArchiveResult = await zipManga([mockVolume], false, false, true);
+    const multipleArchiveResult = await zipManga([mockVolume], false, true, true);
+    
+    expect(singleArchiveResult).toBe(false);
+    expect(multipleArchiveResult).toBe(false);
+    
+    // Both should call the database get method the same number of times
+    expect(db.volumes_data.get).toHaveBeenCalledTimes(2);
+    expect(db.volumes_data.get).toHaveBeenCalledWith(mockVolume.volume_uuid);
   });
 });

--- a/src/lib/util/zip.ts
+++ b/src/lib/util/zip.ts
@@ -19,11 +19,12 @@ export async function zipManga(
       await createAndDownloadArchive(
         [volume], 
         asCbz, 
-        (volume) => {
+        (volumes) => {
+          const vol = volumes[0]; // Get the single volume from the array
           const extension = asCbz ? 'cbz' : 'zip';
           return includeSeriesTitle 
-            ? `${volume.series_title} - ${volume.volume_title}.${extension}`
-            : `${volume.volume_title}.${extension}`;
+            ? `${vol.series_title} - ${vol.volume_title}.${extension}`
+            : `${vol.volume_title}.${extension}`;
         }
       );
     }

--- a/src/lib/util/zip.ts
+++ b/src/lib/util/zip.ts
@@ -51,13 +51,16 @@ async function zipSingleVolume(
     chars: volume.character_count
   };
 
-  // Add image files
+  // Create folder name for images (same as mokuro file name without extension)
+  const folderName = `${volume.volume_title}`;
+  
+  // Add image files inside the folder
   const imagePromises = volumeData.files ? 
     Object.entries(volumeData.files).map(([filename, file]) => {
-      return zipWriter.add(filename, new BlobReader(file));
+      return zipWriter.add(`${folderName}/${filename}`, new BlobReader(file));
     }) : [];
 
-  // Add mokuro data file (for both ZIP and CBZ)
+  // Add mokuro data file in the root directory (for both ZIP and CBZ)
   const promises = [
     ...imagePromises,
     zipWriter.add(

--- a/src/lib/util/zip.ts
+++ b/src/lib/util/zip.ts
@@ -7,7 +7,77 @@ import {
   ZipWriter,
 } from "@zip.js/zip.js";
 
-export async function zipManga(manga: VolumeMetadata[]) {
+export async function zipManga(manga: VolumeMetadata[], asCbz = false, individualVolumes = false) {
+  if (individualVolumes) {
+    // Extract each volume individually
+    for (const volume of manga) {
+      await zipSingleVolume(volume, asCbz);
+    }
+  } else {
+    // Extract all volumes as a single file
+    await zipAllVolumes(manga, asCbz);
+  }
+  
+  return false;
+}
+
+async function zipSingleVolume(volume: VolumeMetadata, asCbz = false) {
+  const zipWriter = new ZipWriter(new BlobWriter("application/zip"));
+  
+  // Get volume data from the database
+  const volumeData = await db.volumes_data.get(volume.volume_uuid);
+  if (!volumeData) {
+    console.error(`Volume data not found for ${volume.volume_uuid}`);
+    return false;
+  }
+
+  // Create mokuro data in the old format for compatibility
+  const mokuroData = {
+    version: volume.mokuro_version,
+    title: volume.series_title,
+    title_uuid: volume.series_uuid,
+    volume: volume.volume_title,
+    volume_uuid: volume.volume_uuid,
+    pages: volumeData.pages,
+    chars: volume.character_count
+  };
+
+  // Add image files
+  const imagePromises = volumeData.files ? 
+    Object.entries(volumeData.files).map(([filename, file]) => {
+      return zipWriter.add(filename, new BlobReader(file));
+    }) : [];
+
+  // Add mokuro data file if not CBZ
+  const promises = [
+    ...imagePromises
+  ];
+  
+  if (!asCbz) {
+    promises.push(
+      zipWriter.add(
+        `${volume.volume_title}.mokuro`, 
+        new TextReader(JSON.stringify(mokuroData))
+      )
+    );
+  }
+
+  // Wait for all files to be added
+  await Promise.all(promises);
+
+  const zipFileBlob = await zipWriter.close();
+
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(zipFileBlob);
+  const extension = asCbz ? 'cbz' : 'zip';
+  link.download = `${volume.series_title} - ${volume.volume_title}.${extension}`;
+  link.click();
+  URL.revokeObjectURL(link.href);
+
+  return false;
+}
+
+async function zipAllVolumes(manga: VolumeMetadata[], asCbz = false) {
   const zipWriter = new ZipWriter(new BlobWriter("application/zip"));
 
   const promises = manga.map(async (volume) => {
@@ -29,20 +99,27 @@ export async function zipManga(manga: VolumeMetadata[]) {
       chars: volume.character_count
     };
 
+    // For CBZ, organize files in volume-specific folders
+    const folderPrefix = asCbz ? `${volume.volume_title}/` : '';
+
     // Add image files
     const imagePromises = volumeData.files ? 
       Object.entries(volumeData.files).map(([filename, file]) => {
-        return zipWriter.add(filename, new BlobReader(file));
+        return zipWriter.add(`${folderPrefix}${filename}`, new BlobReader(file));
       }) : [];
 
-    // Add mokuro data file
-    return [
-      zipWriter.add(
-        `${volume.volume_title}.mokuro`, 
-        new TextReader(JSON.stringify(mokuroData))
-      ),
-      ...imagePromises,
-    ];
+    // Add mokuro data file if not CBZ
+    if (!asCbz) {
+      return [
+        zipWriter.add(
+          `${folderPrefix}${volume.volume_title}.mokuro`, 
+          new TextReader(JSON.stringify(mokuroData))
+        ),
+        ...imagePromises,
+      ];
+    }
+    
+    return imagePromises;
   });
 
   // Wait for all files to be added
@@ -52,7 +129,8 @@ export async function zipManga(manga: VolumeMetadata[]) {
 
   const link = document.createElement('a');
   link.href = URL.createObjectURL(zipFileBlob);
-  link.download = `${manga[0].series_title}.zip`;
+  const extension = asCbz ? 'cbz' : 'zip';
+  link.download = `${manga[0].series_title}.${extension}`;
   link.click();
   URL.revokeObjectURL(link.href);
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
   import NavBar from '$lib/components/NavBar.svelte';
   import Snackbar from '$lib/components/Snackbar.svelte';
   import ConfirmationPopup from '$lib/components/ConfirmationPopup.svelte';
+  import ExtractionModal from '$lib/components/ExtractionModal.svelte';
 
   inject({ mode: dev ? 'development' : 'production' });
 
@@ -21,4 +22,5 @@
   <slot />
   <Snackbar />
   <ConfirmationPopup />
+  <ExtractionModal />
 </div>

--- a/src/routes/[manga]/+page.svelte
+++ b/src/routes/[manga]/+page.svelte
@@ -41,11 +41,19 @@
   }
 
   async function onExtract() {
-    if (manga) {
-      promptExtraction(async (asCbz, individualVolumes) => {
-        loading = true;
-        loading = await zipManga(manga, asCbz, individualVolumes);
-      });
+    if (manga && manga.length > 0) {
+      const firstVolume = {
+        series_title: manga[0].series_title,
+        volume_title: manga[0].volume_title
+      };
+      
+      promptExtraction(
+        firstVolume,
+        async (asCbz, individualVolumes, includeSeriesTitle) => {
+          loading = true;
+          loading = await zipManga(manga, asCbz, individualVolumes, includeSeriesTitle);
+        }
+      );
     }
   }
 </script>

--- a/src/routes/[manga]/+page.svelte
+++ b/src/routes/[manga]/+page.svelte
@@ -5,10 +5,12 @@
   import { Button, Listgroup } from 'flowbite-svelte';
   import { db } from '$lib/catalog/db';
   import { promptConfirmation, zipManga } from '$lib/util';
+  import { promptExtraction } from '$lib/util/modals';
   import { page } from '$app/stores';
   import type { VolumeMetadata } from '$lib/types';
   import { deleteVolume } from '$lib/settings';
   import { mangaStats} from '$lib/settings';
+  import ExtractionModal from '$lib/components/ExtractionModal.svelte';
 
   function sortManga(a: VolumeMetadata, b: VolumeMetadata) {
     return a.volume_title.localeCompare(b.volume_title, undefined, {
@@ -40,8 +42,10 @@
 
   async function onExtract() {
     if (manga) {
-      loading = true;
-      loading = await zipManga(manga);
+      promptExtraction(async (asCbz, individualVolumes) => {
+        loading = true;
+        loading = await zipManga(manga, asCbz, individualVolumes);
+      });
     }
   }
 </script>


### PR DESCRIPTION
This PR adds enhanced extraction options to the manga extraction functionality:

1. **CBZ Format Support**: Users can now extract manga as CBZ files instead of ZIP files.
2. **Individual Volume Extraction**: Users can choose to extract each volume as a separate file.
3. **Filename Customization**: When extracting individual volumes, users can choose to include or exclude the series title from filenames.
4. **Filename Preview**: The modal shows a preview of how the filename will look based on selected options.
5. **Consistent File Organization**: All archives use the same internal structure - image files are placed in a folder named after the volume, with the mokuro file in the root directory.

These options are presented in a modal dialog with toggle switches when the user clicks the "Extract manga" button.

### Changes:
- Created a new `ExtractionModal` component with toggle options and filename preview
- Updated the `zip.ts` utility to support CBZ format and individual volume extraction
- Added mokuro data file to CBZ exports (previously only included in ZIP)
- Added option to include/exclude series title from filenames
- Refactored code to ensure consistent internal structure across all archive types
- Added modal store for extraction options
- Integrated the modal with the manga page
- Maintained compatibility with Node.js 18.x requirement

### Technical Details:
- Refactored the zipping code to use a shared function for adding files to archives
- Ensured that both single-archive and multi-archive exports use the same internal structure
- Added comprehensive tests to verify the functionality

### Screenshots:
The extraction modal presents options:
- Extract as CBZ (on/off)
- Extract individual volumes (on/off)
- Include series title in filename (on/off) - only shown when "Extract individual volumes" is enabled
- Filename preview showing how the first volume will be named