### PR TITLE
Fix top menu buttons in Svelte 5 migration

### DIFF
--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -7,12 +7,22 @@
   import UploadModal from './UploadModal.svelte';
   import Icon from '$lib/assets/icon.webp';
 
+  // Use $state to make these reactive
   let settingsHidden = $state(true);
   let uploadModalOpen = $state(false);
   let isReader = $state(false);
 
+  // Define event handlers
   function openSettings() {
     settingsHidden = false;
+  }
+
+  function openUploadModal() {
+    uploadModalOpen = true;
+  }
+
+  function navigateToCloud() {
+    goto('/cloud');
   }
 
   afterNavigate(() => {
@@ -35,9 +45,9 @@
       </div>
     </NavBrand>
     <div class="flex md:order-2 gap-5">
-      <UserSettingsSolid class="hover:text-primary-700" on:click={openSettings} />
-      <UploadSolid class="hover:text-primary-700" on:click={() => (uploadModalOpen = true)} />
-      <CloudArrowUpOutline class="hover:text-primary-700" on:click={() => goto('/cloud')} />
+      <UserSettingsSolid withEvents class="hover:text-primary-700 cursor-pointer" on:click={openSettings} />
+      <UploadSolid withEvents class="hover:text-primary-700 cursor-pointer" on:click={openUploadModal} />
+      <CloudArrowUpOutline withEvents class="hover:text-primary-700 cursor-pointer" on:click={navigateToCloud} />
     </div>
   </Navbar>
 </div>

--- a/src/lib/components/ProgressTracker.svelte
+++ b/src/lib/components/ProgressTracker.svelte
@@ -47,7 +47,7 @@
             <div class="flex justify-between items-center mb-1">
               <div class="text-sm font-medium">{process.description}</div>
               <Button size="xs" color="none" class="p-1" on:click={() => removeProcess(process.id)}>
-                <CloseCircleSolid class="w-3 h-3" />
+                <CloseCircleSolid withEvents class="w-3 h-3" />
               </Button>
             </div>
             

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -286,11 +286,13 @@
     <div class="flex flex-col gap-3">
       <div class="flex flex-row items-center gap-5 z-10">
         <BackwardStepSolid
+          withEvents
           on:click={() => changePage(volumeSettings.rightToLeft ? pages.length : 1, true)}
           class="hover:text-primary-600"
           size="sm"
         />
         <CaretLeftSolid
+          withEvents
           on:click={(e) => left(e, true)}
           class="hover:text-primary-600"
           size="sm"
@@ -310,11 +312,13 @@
           on:blur={onManualPageChange}
         />
         <CaretRightSolid
+          withEvents
           on:click={(e) => right(e, true)}
           class="hover:text-primary-600"
           size="sm"
         />
         <ForwardStepSolid
+          withEvents
           on:click={() => changePage(volumeSettings.rightToLeft ? 1 : pages.length, true)}
           class="hover:text-primary-600"
           size="sm"

--- a/src/lib/components/Reader/SettingsButton.svelte
+++ b/src/lib/components/Reader/SettingsButton.svelte
@@ -13,7 +13,7 @@
   onclick={openSettings}
   class="hover:text-primary-700 hover:mix-blend-normal mix-blend-difference z-10 fixed opacity-50 hover:opacity-100 right-10 top-5 p-10 m-[-2.5rem]"
 >
-  <UserSettingsSolid />
+  <UserSettingsSolid withEvents />
 </button>
 
 <Settings bind:hidden={settingsHidden} />

--- a/src/lib/components/Settings/Settings.svelte
+++ b/src/lib/components/Settings/Settings.svelte
@@ -25,6 +25,7 @@
     hidden?: boolean;
   }
 
+  // In Svelte 5, we need to make sure the hidden prop is properly bindable
   let { hidden = $bindable(true) }: Props = $props();
 
   function onReset() {

--- a/src/lib/components/UploadModal.svelte
+++ b/src/lib/components/UploadModal.svelte
@@ -11,6 +11,7 @@
     open?: boolean;
   }
 
+  // In Svelte 5, we need to make sure the open prop is properly bindable
   let { open = $bindable(false) }: Props = $props();
 
   let promise: Promise<void> = $state();

--- a/src/lib/components/VolumeItem.svelte
+++ b/src/lib/components/VolumeItem.svelte
@@ -73,6 +73,7 @@
         </div>
         <div class="flex gap-2">
           <TrashBinSolid
+            withEvents
             class="text-red-400 hover:text-red-500 z-10 poin"
             on:click={onDeleteClicked}
           />


### PR DESCRIPTION
This PR fixes the issue with the top menu buttons (settings, upload, and cloud) not working after migrating to Svelte 5, and also updates all other flowbite-svelte-icons components that use event handlers.

### Changes:

1. Added `withEvents` prop to all flowbite-svelte-icons components that use event handlers to properly handle events in Svelte 5:
   - NavBar.svelte: UserSettingsSolid, UploadSolid, CloudArrowUpOutline
   - VolumeItem.svelte: TrashBinSolid
   - Reader/Reader.svelte: BackwardStepSolid, CaretLeftSolid, CaretRightSolid, ForwardStepSolid
   - Reader/SettingsButton.svelte: UserSettingsSolid
   - ProgressTracker.svelte: CloseCircleSolid
2. Added comments to explain the changes in the Settings and UploadModal components.

### Testing:

All buttons with event handlers are now working correctly, including:
- The top menu buttons (settings, upload, cloud)
- The navigation buttons in the reader
- The delete button in volume items
- The close button in progress tracker