### PR TITLE
Add dependency analysis document

### DIFF
--- a/DEPENDENCY_ANALYSIS.md
+++ b/DEPENDENCY_ANALYSIS.md
@@ -1,0 +1,59 @@
+# Dependency Analysis
+
+This document provides an analysis of the dependencies used in the mokuro-reader project and their current status.
+
+## Major Dependencies
+
+### Svelte
+
+- **Current Version**: 5.21.0
+- **Latest Version**: 5.21.0
+- **Status**: Up to date
+- **Notes**: Svelte 5 is still in beta, but the project is already using the latest version.
+
+### TailwindCSS
+
+- **Current Version**: 3.4.17
+- **Latest Version**: 4.0.9
+- **Status**: Not updated
+- **Notes**: Attempted to update to TailwindCSS v4, but encountered compatibility issues with Flowbite Svelte. The UI was broken with TailwindCSS v4, showing only a few icons and text in a corner with everything else being white. After multiple attempts to fix the issues, we decided to revert to TailwindCSS v3 which works correctly with the current setup.
+
+### Flowbite Svelte
+
+- **Current Version**: 0.48.4
+- **Latest Version**: 0.48.4
+- **Status**: Up to date
+- **Notes**: Flowbite Svelte is not yet fully compatible with TailwindCSS v4.
+
+### Dexie
+
+- **Current Version**: 4.0.11
+- **Latest Version**: 4.0.11 (stable), 4.1.0-beta.43 (beta)
+- **Status**: Up to date
+- **Notes**: There are only alpha and beta versions available for Dexie 4.1.0, so it's best to stick with the current stable version.
+
+### Panzoom
+
+- **Current Version**: 9.4.3
+- **Latest Version**: 9.4.3
+- **Status**: Up to date
+
+### @zip.js/zip.js
+
+- **Current Version**: 2.7.57
+- **Latest Version**: 2.7.57
+- **Status**: Up to date
+
+### @vercel/analytics
+
+- **Current Version**: 1.5.0
+- **Latest Version**: 1.5.0
+- **Status**: Up to date
+
+## Security Vulnerabilities
+
+There are some low severity vulnerabilities in the `cookie` package, but fixing them would require breaking changes to `@sveltejs/kit`. Since these are low severity vulnerabilities, it's recommended to wait for an official update from the SvelteKit team.
+
+## Conclusion
+
+Most of the dependencies are already up to date. The only dependency that could be updated is TailwindCSS from v3 to v4, but it's not compatible with Flowbite Svelte. It's recommended to wait for Flowbite Svelte to provide better support for TailwindCSS v4 before updating.


### PR DESCRIPTION
This PR adds a document that provides an analysis of the dependencies used in the mokuro-reader project and their current status.

The analysis shows that most of the dependencies are already up to date. The only dependency that could be updated is TailwindCSS from v3 to v4, but it is not compatible with Flowbite Svelte. It is recommended to wait for Flowbite Svelte to provide better support for TailwindCSS v4 before updating.