### PR TITLE
Fix file upload picker in Svelte 5

### DIFF
--- a/src/lib/components/FileUpload.svelte
+++ b/src/lib/components/FileUpload.svelte
@@ -10,26 +10,24 @@
 
   let { files = $bindable(undefined), onUpload = undefined, children, ...rest }: Props = $props();
 
-  let input: HTMLInputElement = $state();
+  // Create a unique ID for the input
+  const inputId = `file-input-${Math.random().toString(36).substring(2, 9)}`;
 
-  function handleChange() {
+  $effect(() => {
     if (files && onUpload) {
       onUpload(files);
     }
-  }
-
-  function onClick() {
-    input.click();
-  }
+  });
 </script>
 
+<label for={inputId} class="inline-flex items-center hover:underline text-primary-600 dark:text-primary-500 cursor-pointer">
+  {#if children}{@render children()}{:else}Upload{/if}
+</label>
+
 <input
+  id={inputId}
   type="file"
   bind:files
-  bind:this={input}
-  onchange={handleChange}
   {...rest}
   class="hidden"
 />
-
-<A on:click={onClick}>{#if children}{@render children()}{:else}Upload{/if}</A>

--- a/src/lib/components/FileUpload.svelte
+++ b/src/lib/components/FileUpload.svelte
@@ -10,8 +10,13 @@
 
   let { files = $bindable(undefined), onUpload = undefined, children, ...rest }: Props = $props();
 
-  // Create a unique ID for the input
-  const inputId = `file-input-${Math.random().toString(36).substring(2, 9)}`;
+  let fileInput: HTMLInputElement;
+
+  function handleClick() {
+    if (fileInput) {
+      fileInput.click();
+    }
+  }
 
   $effect(() => {
     if (files && onUpload) {
@@ -20,14 +25,18 @@
   });
 </script>
 
-<label for={inputId} class="inline-flex items-center hover:underline text-primary-600 dark:text-primary-500 cursor-pointer">
+<button 
+  type="button"
+  onclick={handleClick}
+  class="inline-flex items-center hover:underline text-primary-600 dark:text-primary-500 cursor-pointer bg-transparent border-none p-0 m-0"
+>
   {#if children}{@render children()}{:else}Upload{/if}
-</label>
+</button>
 
 <input
-  id={inputId}
   type="file"
   bind:files
+  bind:this={fileInput}
   {...rest}
   class="hidden"
 />

--- a/src/lib/components/UploadModal.svelte
+++ b/src/lib/components/UploadModal.svelte
@@ -170,9 +170,9 @@
       {:else}
         <p class="mb-2 text-sm text-gray-500 dark:text-gray-400">
           Drag and drop / 
-          <a 
-            href="javascript:void(0)" 
-            class="text-primary-600 dark:text-primary-500 hover:underline cursor-pointer"
+          <button 
+            type="button"
+            class="text-primary-600 dark:text-primary-500 hover:underline bg-transparent border-none p-0 m-0 cursor-pointer inline-flex"
             onclick={() => {
               const input = document.createElement('input');
               input.type = 'file';
@@ -187,10 +187,10 @@
             }}
           >
             choose files
-          </a> /
-          <a 
-            href="javascript:void(0)" 
-            class="text-primary-600 dark:text-primary-500 hover:underline cursor-pointer"
+          </button> /
+          <button 
+            type="button"
+            class="text-primary-600 dark:text-primary-500 hover:underline bg-transparent border-none p-0 m-0 cursor-pointer inline-flex"
             onclick={() => {
               const input = document.createElement('input');
               input.type = 'file';
@@ -204,7 +204,7 @@
             }}
           >
             choose directory
-          </a>
+          </button>
         </p>
       {/if}
     </Dropzone>

--- a/src/lib/components/UploadModal.svelte
+++ b/src/lib/components/UploadModal.svelte
@@ -169,10 +169,36 @@
         <Spinner />
       {:else}
         <p class="mb-2 text-sm text-gray-500 dark:text-gray-400">
-          Drag and drop / <FileUpload bind:files accept=".mokuro,.zip,.cbz" multiple
-            >choose files</FileUpload
-          > /
-          <FileUpload bind:files webkitdirectory>choose directory</FileUpload>
+          Drag and drop / 
+          <button 
+            type="button" 
+            class="text-primary-600 dark:text-primary-500 hover:underline bg-transparent border-none p-0 m-0 cursor-pointer"
+            onclick={() => document.getElementById('file-upload-multiple').click()}
+          >
+            choose files
+          </button> /
+          <button 
+            type="button" 
+            class="text-primary-600 dark:text-primary-500 hover:underline bg-transparent border-none p-0 m-0 cursor-pointer"
+            onclick={() => document.getElementById('directory-upload').click()}
+          >
+            choose directory
+          </button>
+          <input 
+            id="file-upload-multiple" 
+            type="file" 
+            accept=".mokuro,.zip,.cbz" 
+            multiple 
+            bind:files 
+            class="hidden" 
+          />
+          <input 
+            id="directory-upload" 
+            type="file" 
+            webkitdirectory 
+            bind:files 
+            class="hidden" 
+          />
         </p>
       {/if}
     </Dropzone>

--- a/src/lib/components/UploadModal.svelte
+++ b/src/lib/components/UploadModal.svelte
@@ -170,35 +170,41 @@
       {:else}
         <p class="mb-2 text-sm text-gray-500 dark:text-gray-400">
           Drag and drop / 
-          <button 
-            type="button" 
-            class="text-primary-600 dark:text-primary-500 hover:underline bg-transparent border-none p-0 m-0 cursor-pointer"
-            onclick={() => document.getElementById('file-upload-multiple').click()}
+          <a 
+            href="javascript:void(0)" 
+            class="text-primary-600 dark:text-primary-500 hover:underline cursor-pointer"
+            onclick={() => {
+              const input = document.createElement('input');
+              input.type = 'file';
+              input.accept = '.mokuro,.zip,.cbz';
+              input.multiple = true;
+              input.onchange = (e) => {
+                if (e.target.files.length > 0) {
+                  files = e.target.files;
+                }
+              };
+              input.click();
+            }}
           >
             choose files
-          </button> /
-          <button 
-            type="button" 
-            class="text-primary-600 dark:text-primary-500 hover:underline bg-transparent border-none p-0 m-0 cursor-pointer"
-            onclick={() => document.getElementById('directory-upload').click()}
+          </a> /
+          <a 
+            href="javascript:void(0)" 
+            class="text-primary-600 dark:text-primary-500 hover:underline cursor-pointer"
+            onclick={() => {
+              const input = document.createElement('input');
+              input.type = 'file';
+              input.setAttribute('webkitdirectory', '');
+              input.onchange = (e) => {
+                if (e.target.files.length > 0) {
+                  files = e.target.files;
+                }
+              };
+              input.click();
+            }}
           >
             choose directory
-          </button>
-          <input 
-            id="file-upload-multiple" 
-            type="file" 
-            accept=".mokuro,.zip,.cbz" 
-            multiple 
-            bind:files 
-            class="hidden" 
-          />
-          <input 
-            id="directory-upload" 
-            type="file" 
-            webkitdirectory 
-            bind:files 
-            class="hidden" 
-          />
+          </a>
         </p>
       {/if}
     </Dropzone>


### PR DESCRIPTION
This PR fixes the issue with the file upload picker not showing when clicking on 'choose files' or 'choose directory' links in the upload modal.

The issue was related to how file inputs are handled in Svelte 5. The solution uses dynamically created file inputs that are triggered by button clicks, which is a more reliable approach across different browsers and environments.

Changes made:
- Replaced the FileUpload component usage with direct button elements in the UploadModal
- Added dynamic file input creation when buttons are clicked
- Used proper button styling to maintain the same appearance as before
- Fixed accessibility warnings by using proper button elements instead of anchor tags

The drag and drop functionality continues to work as before.