### PR TITLE
Fix range slider thumbs visibility after Svelte 5 migration

### DIFF
--- a/src/app.postcss
+++ b/src/app.postcss
@@ -2,3 +2,18 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Custom styles for Range component */
+@layer components {
+  input[type="range"] {
+    @apply appearance-none bg-gray-200 rounded-lg cursor-pointer dark:bg-gray-700;
+  }
+  
+  input[type="range"]::-webkit-slider-thumb {
+    @apply appearance-auto bg-blue-600 h-4 w-4 rounded-full;
+  }
+  
+  input[type="range"]::-moz-range-thumb {
+    @apply bg-blue-600 h-4 w-4 rounded-full border-0;
+  }
+}

--- a/src/lib/components/Reader/Reader.svelte
+++ b/src/lib/components/Reader/Reader.svelte
@@ -330,7 +330,6 @@
           max={pages.length}
           bind:value={manualPage}
           on:change={onManualPageChange}
-          defaultClass=""
         />
       </div>
     </div>


### PR DESCRIPTION
## Description
This PR fixes the issue with the range sliders (Swipe threshold, Edge button width, and fast seek) where the thumb (draggable part) was invisible after the migration to Svelte 5.

## Changes
- Added global CSS styles in app.postcss to properly style all Range components
- Added styles for WebKit browsers (Chrome, Safari) and Firefox
- Removed the defaultClass attribute from the fast seek slider in Reader.svelte

The global CSS approach ensures consistent styling across all Range components in the application.