### PR TITLE
Add configurable checkbox option to confirmation modals

### DIFF
--- a/src/lib/components/ConfirmationPopup.svelte
+++ b/src/lib/components/ConfirmationPopup.svelte
@@ -6,32 +6,34 @@
   import { browser } from '$app/environment';
 
   let open = $state(false);
-  let deleteStats = $state(false);
+  let checkboxValue = $state(false);
 
-  // Load the user's previous selection from localStorage
   onMount(() => {
-    if (browser) {
-      const savedPreference = localStorage.getItem('deleteStatsPreference');
-      if (savedPreference !== null) {
-        deleteStats = savedPreference === 'true';
-      }
-    }
-
     confirmationPopupStore.subscribe((value) => {
       if (value) {
         open = value.open;
+        
+        // Load the user's previous selection from localStorage if checkbox option is provided
+        if (browser && value.checkboxOption) {
+          const { storageKey, defaultValue } = value.checkboxOption;
+          const savedPreference = localStorage.getItem(storageKey);
+          checkboxValue = savedPreference !== null 
+            ? savedPreference === 'true' 
+            : defaultValue;
+        }
       }
     });
   });
 
   function handleConfirm() {
-    // Save the user's preference
-    if (browser) {
-      localStorage.setItem('deleteStatsPreference', deleteStats.toString());
+    // Save the user's preference if checkbox option is provided
+    if (browser && $confirmationPopupStore?.checkboxOption) {
+      const { storageKey } = $confirmationPopupStore.checkboxOption;
+      localStorage.setItem(storageKey, checkboxValue.toString());
     }
     
     if ($confirmationPopupStore?.onConfirm) {
-      $confirmationPopupStore.onConfirm(deleteStats);
+      $confirmationPopupStore.onConfirm(checkboxValue);
     }
   }
 </script>
@@ -42,11 +44,11 @@
     <h3 class="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">
       {$confirmationPopupStore?.message}
     </h3>
-    {#if $confirmationPopupStore?.showStatsOption}
+    {#if $confirmationPopupStore?.checkboxOption}
       <div class="flex items-center justify-center mb-4">
-        <Checkbox bind:checked={deleteStats} id="delete-stats" />
-        <label for="delete-stats" class="ml-2 text-sm font-medium text-gray-500 dark:text-gray-400">
-          Also delete stats and progress?
+        <Checkbox bind:checked={checkboxValue} id="confirmation-checkbox" />
+        <label for="confirmation-checkbox" class="ml-2 text-sm font-medium text-gray-500 dark:text-gray-400">
+          {$confirmationPopupStore.checkboxOption.label}
         </label>
       </div>
     {/if}

--- a/src/lib/components/ConfirmationPopup.svelte
+++ b/src/lib/components/ConfirmationPopup.svelte
@@ -35,6 +35,18 @@
     if ($confirmationPopupStore?.onConfirm) {
       $confirmationPopupStore.onConfirm(checkboxValue);
     }
+    
+    // Always close the modal after confirmation
+    open = false;
+  }
+  
+  function handleCancel() {
+    if ($confirmationPopupStore?.onCancel) {
+      $confirmationPopupStore.onCancel();
+    }
+    
+    // Always close the modal after cancellation
+    open = false;
   }
 </script>
 
@@ -53,6 +65,6 @@
       </div>
     {/if}
     <Button color="red" class="mr-2" on:click={handleConfirm}>Yes</Button>
-    <Button color="alternative" on:click={$confirmationPopupStore?.onCancel}>No</Button>
+    <Button color="alternative" on:click={handleCancel}>No</Button>
   </div>
 </Modal>

--- a/src/lib/components/ConfirmationPopup.svelte
+++ b/src/lib/components/ConfirmationPopup.svelte
@@ -1,18 +1,39 @@
 <script lang="ts">
   import { confirmationPopupStore } from '$lib/util';
-  import { Button, Modal } from 'flowbite-svelte';
+  import { Button, Modal, Checkbox } from 'flowbite-svelte';
   import { ExclamationCircleOutline } from 'flowbite-svelte-icons';
   import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
 
   let open = $state(false);
+  let deleteStats = $state(false);
 
+  // Load the user's previous selection from localStorage
   onMount(() => {
+    if (browser) {
+      const savedPreference = localStorage.getItem('deleteStatsPreference');
+      if (savedPreference !== null) {
+        deleteStats = savedPreference === 'true';
+      }
+    }
+
     confirmationPopupStore.subscribe((value) => {
       if (value) {
         open = value.open;
       }
     });
   });
+
+  function handleConfirm() {
+    // Save the user's preference
+    if (browser) {
+      localStorage.setItem('deleteStatsPreference', deleteStats.toString());
+    }
+    
+    if ($confirmationPopupStore?.onConfirm) {
+      $confirmationPopupStore.onConfirm(deleteStats);
+    }
+  }
 </script>
 
 <Modal bind:open size="xs" autoclose outsideclose>
@@ -21,7 +42,15 @@
     <h3 class="mb-5 text-lg font-normal text-gray-500 dark:text-gray-400">
       {$confirmationPopupStore?.message}
     </h3>
-    <Button color="red" class="mr-2" on:click={$confirmationPopupStore?.onConfirm}>Yes</Button>
+    {#if $confirmationPopupStore?.showStatsOption}
+      <div class="flex items-center justify-center mb-4">
+        <Checkbox bind:checked={deleteStats} id="delete-stats" />
+        <label for="delete-stats" class="ml-2 text-sm font-medium text-gray-500 dark:text-gray-400">
+          Also delete stats and progress?
+        </label>
+      </div>
+    {/if}
+    <Button color="red" class="mr-2" on:click={handleConfirm}>Yes</Button>
     <Button color="alternative" on:click={$confirmationPopupStore?.onCancel}>No</Button>
   </div>
 </Modal>

--- a/src/lib/components/VolumeItem.svelte
+++ b/src/lib/components/VolumeItem.svelte
@@ -30,27 +30,36 @@
   async function onDeleteClicked(e: Event) {
     e.stopPropagation();
 
-    promptConfirmation(`Delete ${volName}?`, async (deleteStats = false) => {
-      await db.volumes.where('volume_uuid').equals(volume.volume_uuid).delete();
-      await db.volumes_data.where('volume_uuid').equals(volume.volume_uuid).delete();
-      
-      // Only delete stats and progress if the checkbox is checked
-      if (deleteStats) {
-        deleteVolume(volume.volume_uuid);
-      }
+    promptConfirmation(
+      `Delete ${volName}?`, 
+      async (deleteStats = false) => {
+        await db.volumes.where('volume_uuid').equals(volume.volume_uuid).delete();
+        await db.volumes_data.where('volume_uuid').equals(volume.volume_uuid).delete();
+        
+        // Only delete stats and progress if the checkbox is checked
+        if (deleteStats) {
+          deleteVolume(volume.volume_uuid);
+        }
 
-      // Check if this was the last volume for this title
-      const remainingVolumes = await db.volumes
-        .where('series_uuid')
-        .equals(volume.series_uuid)
-        .count();
+        // Check if this was the last volume for this title
+        const remainingVolumes = await db.volumes
+          .where('series_uuid')
+          .equals(volume.series_uuid)
+          .count();
 
-      if (remainingVolumes > 0) {
-        goto(`/${$page.params.manga}`);
-      } else {
-        goto('/');
+        if (remainingVolumes > 0) {
+          goto(`/${$page.params.manga}`);
+        } else {
+          goto('/');
+        }
+      }, 
+      undefined, 
+      {
+        label: "Also delete stats and progress?",
+        storageKey: "deleteStatsPreference",
+        defaultValue: false
       }
-    }, undefined, true);
+    );
   }
 </script>
 

--- a/src/lib/components/VolumeItem.svelte
+++ b/src/lib/components/VolumeItem.svelte
@@ -30,10 +30,14 @@
   async function onDeleteClicked(e: Event) {
     e.stopPropagation();
 
-    promptConfirmation(`Delete ${volName}?`, async () => {
+    promptConfirmation(`Delete ${volName}?`, async (deleteStats = false) => {
       await db.volumes.where('volume_uuid').equals(volume.volume_uuid).delete();
       await db.volumes_data.where('volume_uuid').equals(volume.volume_uuid).delete();
-      deleteVolume(volume.volume_uuid);
+      
+      // Only delete stats and progress if the checkbox is checked
+      if (deleteStats) {
+        deleteVolume(volume.volume_uuid);
+      }
 
       // Check if this was the last volume for this title
       const remainingVolumes = await db.volumes
@@ -46,7 +50,7 @@
       } else {
         goto('/');
       }
-    });
+    }, undefined, true);
   }
 </script>
 

--- a/src/lib/util/modals.ts
+++ b/src/lib/util/modals.ts
@@ -3,15 +3,22 @@ import { writable } from 'svelte/store';
 type ConfirmationPopup = {
   open: boolean;
   message: string;
-  onConfirm?: () => void;
+  showStatsOption?: boolean;
+  onConfirm?: (deleteStats?: boolean) => void;
   onCancel?: () => void;
 };
 export const confirmationPopupStore = writable<ConfirmationPopup | undefined>(undefined);
 
-export function promptConfirmation(message: string, onConfirm?: () => void, onCancel?: () => void) {
+export function promptConfirmation(
+  message: string, 
+  onConfirm?: (deleteStats?: boolean) => void, 
+  onCancel?: () => void,
+  showStatsOption: boolean = false
+) {
   confirmationPopupStore.set({
     open: true,
     message,
+    showStatsOption,
     onConfirm,
     onCancel
   });

--- a/src/lib/util/modals.ts
+++ b/src/lib/util/modals.ts
@@ -1,24 +1,30 @@
 import { writable } from 'svelte/store';
 
+type CheckboxOption = {
+  label: string;
+  storageKey: string;
+  defaultValue: boolean;
+};
+
 type ConfirmationPopup = {
   open: boolean;
   message: string;
-  showStatsOption?: boolean;
-  onConfirm?: (deleteStats?: boolean) => void;
+  checkboxOption?: CheckboxOption;
+  onConfirm?: (checkboxValue?: boolean) => void;
   onCancel?: () => void;
 };
 export const confirmationPopupStore = writable<ConfirmationPopup | undefined>(undefined);
 
 export function promptConfirmation(
   message: string, 
-  onConfirm?: (deleteStats?: boolean) => void, 
+  onConfirm?: (checkboxValue?: boolean) => void, 
   onCancel?: () => void,
-  showStatsOption: boolean = false
+  checkboxOption?: CheckboxOption
 ) {
   confirmationPopupStore.set({
     open: true,
     message,
-    showStatsOption,
+    checkboxOption,
     onConfirm,
     onCancel
   });

--- a/src/routes/[manga]/+page.svelte
+++ b/src/routes/[manga]/+page.svelte
@@ -41,7 +41,16 @@
   }
 
   function onDelete() {
-    promptConfirmation('Are you sure you want to delete this manga?', confirmDelete, undefined, true);
+    promptConfirmation(
+      'Are you sure you want to delete this manga?', 
+      confirmDelete, 
+      undefined, 
+      {
+        label: "Also delete stats and progress?",
+        storageKey: "deleteStatsPreference",
+        defaultValue: false
+      }
+    );
   }
 
   async function onExtract() {

--- a/src/routes/[manga]/+page.svelte
+++ b/src/routes/[manga]/+page.svelte
@@ -23,21 +23,25 @@
 
   let loading = $state(false);
 
-  async function confirmDelete() {
+  async function confirmDelete(deleteStats = false) {
     const seriesUuid = manga?.[0].series_uuid;
     if (seriesUuid) {
       manga?.forEach((vol) => {
         const volId = vol.volume_uuid;
         db.volumes_data.where('volume_uuid').equals(vol.volume_uuid).delete();
         db.volumes.where('volume_uuid').equals(vol.volume_uuid).delete();
-        deleteVolume(volId);
+        
+        // Only delete stats and progress if the checkbox is checked
+        if (deleteStats) {
+          deleteVolume(volId);
+        }
       });
       goto('/');
     }
   }
 
   function onDelete() {
-    promptConfirmation('Are you sure you want to delete this manga?', confirmDelete);
+    promptConfirmation('Are you sure you want to delete this manga?', confirmDelete, undefined, true);
   }
 
   async function onExtract() {


### PR DESCRIPTION
This PR adds a configurable checkbox option to the confirmation modals, with the initial use case being to allow users to choose whether to delete stats and progress data when removing content.

- Added a generic and configurable checkbox option to confirmation modals
- Made the checkbox label, storage key, and default value configurable
- Checkbox state is remembered between sessions using localStorage
- Applied this to volume and series deletion with "Also delete stats and progress?" option
- Default is unchecked (preserves stats)
- Made deleteVolume function only called when stats should be deleted

This implementation is more flexible and can be reused for other confirmation scenarios that need a checkbox option.