### PR TITLE
Fix extraction modal settings persistence and preview updates

### DIFF
--- a/src/lib/components/ExtractionModal.svelte
+++ b/src/lib/components/ExtractionModal.svelte
@@ -4,18 +4,21 @@
   import { Button, Modal, Toggle } from 'flowbite-svelte';
   import { extractionModalStore } from '$lib/util/modals';
   import { onMount } from 'svelte';
+  import { extractionSettings, updateExtractionSetting } from '$lib/settings';
 
   let open = $state(false);
-  let asCbz = $state(true);
-  let individualVolumes = $state(false);
-  let includeSeriesTitle = $state(true);
+  let asCbz = $state($extractionSettings.asCbz);
+  let individualVolumes = $state($extractionSettings.individualVolumes);
+  let includeSeriesTitle = $state($extractionSettings.includeSeriesTitle);
   let firstVolumePreview = $state('');
+  let currentVolume = $state<{ series_title: string; volume_title: string } | null>(null);
 
   onMount(() => {
     extractionModalStore.subscribe((value) => {
       if (value) {
         open = value.open;
         if (value.firstVolume) {
+          currentVolume = value.firstVolume;
           updateFilenamePreview(value.firstVolume);
         }
       }
@@ -49,21 +52,27 @@
     open = false;
   }
 
+  function updateAsCbz(value: boolean) {
+    asCbz = value;
+    updateExtractionSetting('asCbz', value);
+    if (currentVolume) updateFilenamePreview(currentVolume);
+  }
+
+  function updateIndividualVolumes(value: boolean) {
+    individualVolumes = value;
+    updateExtractionSetting('individualVolumes', value);
+    if (currentVolume) updateFilenamePreview(currentVolume);
+  }
+
+  function updateIncludeSeriesTitle(value: boolean) {
+    includeSeriesTitle = value;
+    updateExtractionSetting('includeSeriesTitle', value);
+    if (currentVolume) updateFilenamePreview(currentVolume);
+  }
+
   run(() => {
     if ($extractionModalStore?.firstVolume) {
       updateFilenamePreview($extractionModalStore.firstVolume);
-    }
-  });
-
-  run(() => {
-    if (
-      asCbz !== undefined ||
-      includeSeriesTitle !== undefined ||
-      individualVolumes !== undefined
-    ) {
-      if ($extractionModalStore?.firstVolume) {
-        updateFilenamePreview($extractionModalStore.firstVolume);
-      }
     }
   });
 </script>
@@ -74,13 +83,13 @@
     <div class="flex flex-col gap-4 mb-5">
       <div class="flex items-center justify-between">
         <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Extract as CBZ</span>
-        <Toggle bind:checked={asCbz} />
+        <Toggle checked={asCbz} on:change={(e) => updateAsCbz(e.target.checked)} />
       </div>
       <div class="flex items-center justify-between">
         <span class="text-sm font-medium text-gray-700 dark:text-gray-300"
           >Extract individual volumes</span
         >
-        <Toggle bind:checked={individualVolumes} />
+        <Toggle checked={individualVolumes} on:change={(e) => updateIndividualVolumes(e.target.checked)} />
       </div>
 
       {#if individualVolumes}
@@ -88,7 +97,7 @@
           <span class="text-sm font-medium text-gray-700 dark:text-gray-300"
             >Include series title in filename</span
           >
-          <Toggle bind:checked={includeSeriesTitle} />
+          <Toggle checked={includeSeriesTitle} on:change={(e) => updateIncludeSeriesTitle(e.target.checked)} />
         </div>
       {/if}
 

--- a/src/lib/settings/extraction.ts
+++ b/src/lib/settings/extraction.ts
@@ -1,0 +1,37 @@
+import { browser } from '$app/environment';
+import { writable } from 'svelte/store';
+
+export type ExtractionSettings = {
+  asCbz: boolean;
+  individualVolumes: boolean;
+  includeSeriesTitle: boolean;
+};
+
+export type ExtractionSettingsKey = keyof ExtractionSettings;
+
+const defaultSettings: ExtractionSettings = {
+  asCbz: true,
+  individualVolumes: false,
+  includeSeriesTitle: true
+};
+
+const stored = browser ? window.localStorage.getItem('extractionSettings') : undefined;
+
+export const extractionSettings = writable<ExtractionSettings>(
+  stored ? JSON.parse(stored) : defaultSettings
+);
+
+extractionSettings.subscribe((settings) => {
+  if (browser) {
+    window.localStorage.setItem('extractionSettings', JSON.stringify(settings));
+  }
+});
+
+export function updateExtractionSetting(key: ExtractionSettingsKey, value: any) {
+  extractionSettings.update((settings) => {
+    return {
+      ...settings,
+      [key]: value
+    };
+  });
+}

--- a/src/lib/settings/index.ts
+++ b/src/lib/settings/index.ts
@@ -1,3 +1,4 @@
 export * from './volume-data';
 export * from './settings';
 export * from './misc';
+export * from './extraction';


### PR DESCRIPTION
This PR fixes two issues with the extraction modal:

1. **Settings Persistence**: The extraction modal now remembers user preferences between uses by storing them in localStorage.

2. **Filename Preview Updates**: The filename preview now updates immediately when settings are changed.

Changes made:
- Created a new extraction settings store to persist user preferences
- Updated the ExtractionModal component to initialize from and save to the settings store
- Added event handlers to update the filename preview when settings change