### PR TITLE
Add download throttling toggle to cloud page

### DIFF
--- a/src/lib/settings/misc.ts
+++ b/src/lib/settings/misc.ts
@@ -4,13 +4,15 @@ import { writable } from 'svelte/store';
 export type MiscSettings = {
   galleryLayout: 'grid' | 'list';
   gallerySorting: 'ASC' | 'DESC' | 'SMART';
+  turboDownload: boolean;
 };
 
 export type MiscSettingsKey = keyof MiscSettings;
 
 const defaultSettings: MiscSettings = {
   galleryLayout: 'grid',
-  gallerySorting: 'SMART'
+  gallerySorting: 'SMART',
+  turboDownload: false
 };
 
 const stored = browser ? window.localStorage.getItem('miscSettings') : undefined;

--- a/src/lib/settings/misc.ts
+++ b/src/lib/settings/misc.ts
@@ -4,7 +4,7 @@ import { writable } from 'svelte/store';
 export type MiscSettings = {
   galleryLayout: 'grid' | 'list';
   gallerySorting: 'ASC' | 'DESC' | 'SMART';
-  turboDownload: boolean;
+  throttleDownloads: boolean;
 };
 
 export type MiscSettingsKey = keyof MiscSettings;
@@ -12,7 +12,7 @@ export type MiscSettingsKey = keyof MiscSettings;
 const defaultSettings: MiscSettings = {
   galleryLayout: 'grid',
   gallerySorting: 'SMART',
-  turboDownload: false
+  throttleDownloads: true
 };
 
 const stored = browser ? window.localStorage.getItem('miscSettings') : undefined;

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -428,7 +428,7 @@
     if (turboDownload) {
       // In turbo mode, use more workers and disable memory limits
       maxWorkers = Math.min(navigator.hardwareConcurrency || 4, 12);
-      memoryLimitMB = 0; // No memory limit in turbo mode
+      memoryLimitMB = 100000; // Very high memory limit (100GB) effectively disables the constraint
       console.log(`Turbo download enabled: Using ${maxWorkers} workers with no memory limit`);
     } else {
       // Standard mode with reasonable limits

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -931,9 +931,11 @@
               checked={$miscSettings.turboDownload} 
               on:change={() => updateMiscSetting('turboDownload', !$miscSettings.turboDownload)}
             >
-              Turbo Download
+              <span class="flex items-center gap-2">
+                Turbo Download
+                <Badge color="red">Experimental</Badge>
+              </span>
             </Toggle>
-            <Badge color="red" class="text-xs">Experimental</Badge>
           </div>
           <p class="text-xs text-gray-500 ml-1">
             May cause crashes on lower-end devices or for very large downloads.

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -933,12 +933,12 @@
             >
               <span class="flex items-center gap-2">
                 Turbo Download
-                <Badge color="red">Experimental</Badge>
+                <Badge color="blue">High-End</Badge>
               </span>
             </Toggle>
           </div>
           <p class="text-xs text-gray-500 ml-1">
-            May cause crashes on lower-end devices or for very large downloads.
+            Recommended for powerful devices with fast internet connections.
           </p>
         </div>
         

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -935,7 +935,7 @@
             </Toggle>
           </div>
           <Tooltip triggeredBy="#turbo-toggle-container" placement="right">
-            Disables memory limits and increases thread count for faster downloads. May cause instability on memory-constrained devices. Only speeds up downloads significantly if you have a fast internet connection.
+            May cause crashes on lower-end devices or for very large downloads.
           </Tooltip>
         </div>
         

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -3,6 +3,7 @@
 
   import { processFiles } from '$lib/upload';
   import { parseVolumesFromJson, profiles, volumes } from '$lib/settings';
+  import { miscSettings, updateMiscSetting } from '$lib/settings/misc';
 
   import { promptConfirmation, showSnackbar, uploadFile } from '$lib/util';
   import { Button, Toggle, Tooltip } from 'flowbite-svelte';
@@ -54,7 +55,6 @@
   let readerFolderId = '';
   let volumeDataId = $state('');
   let profilesId = $state('');
-  let turboDownload = $state(false);
 
   // This variable is used to track if we're connected to Google Drive
   // and is used in the UI to show/hide the login button
@@ -425,7 +425,7 @@
     let maxWorkers;
     let memoryLimitMB;
     
-    if (turboDownload) {
+    if ($miscSettings.turboDownload) {
       // In turbo mode, use more workers and disable memory limits
       maxWorkers = Math.min(navigator.hardwareConcurrency || 4, 12);
       memoryLimitMB = 100000; // Very high memory limit (100GB) effectively disables the constraint
@@ -925,10 +925,16 @@
         <Button color="blue" on:click={createPicker}>Download Manga</Button>
         
         <div class="flex items-center gap-2">
-          <Toggle size="small" checked={turboDownload} on:change={() => turboDownload = !turboDownload} id="turbo-toggle">
-            Turbo Download
-          </Toggle>
-          <Tooltip triggeredBy="#turbo-toggle" placement="right">
+          <div id="turbo-toggle-container">
+            <Toggle 
+              size="small" 
+              checked={$miscSettings.turboDownload} 
+              on:change={() => updateMiscSetting('turboDownload', !$miscSettings.turboDownload)}
+            >
+              Turbo Download
+            </Toggle>
+          </div>
+          <Tooltip triggeredBy="#turbo-toggle-container" placement="right">
             Disables memory limits and increases thread count for faster downloads. May cause instability on memory-constrained devices. Only speeds up downloads significantly if you have a fast internet connection.
           </Tooltip>
         </div>

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -425,21 +425,21 @@
     let maxWorkers;
     let memoryLimitMB;
     
-    if ($miscSettings.turboDownload) {
-      // In turbo mode, use more workers and disable memory limits
-      maxWorkers = Math.min(navigator.hardwareConcurrency || 4, 12);
-      memoryLimitMB = 100000; // Very high memory limit (100GB) effectively disables the constraint
-      console.log(`Turbo download enabled: Using ${maxWorkers} workers with no memory limit`);
-    } else {
-      // Standard mode with reasonable limits
+    if ($miscSettings.throttleDownloads) {
+      // Throttled mode with reasonable limits
       maxWorkers = Math.min(navigator.hardwareConcurrency || 4, 6);
       // Set memory threshold to 500MB to prevent excessive memory usage on mobile devices
       // This is not a hard limit - tasks that individually need more than 500MB can still run
       // It just prevents starting new tasks when the current pool already exceeds 500MB
       memoryLimitMB = 500; // 500 MB memory threshold
       console.log(
-        `Creating worker pool with ${maxWorkers} workers and ${memoryLimitMB}MB memory threshold`
+        `Throttled downloads: Using ${maxWorkers} workers and ${memoryLimitMB}MB memory threshold`
       );
+    } else {
+      // Unthrottled mode, use more workers and disable memory limits
+      maxWorkers = Math.min(navigator.hardwareConcurrency || 4, 12);
+      memoryLimitMB = 100000; // Very high memory limit (100GB) effectively disables the constraint
+      console.log(`Unthrottled downloads: Using ${maxWorkers} workers with no memory limit`);
     }
     
     const workerPool = new WorkerPool(undefined, maxWorkers, memoryLimitMB);
@@ -928,17 +928,16 @@
           <div class="flex items-center gap-2">
             <Toggle 
               size="small" 
-              checked={$miscSettings.turboDownload} 
-              on:change={() => updateMiscSetting('turboDownload', !$miscSettings.turboDownload)}
+              checked={$miscSettings.throttleDownloads} 
+              on:change={() => updateMiscSetting('throttleDownloads', !$miscSettings.throttleDownloads)}
             >
               <span class="flex items-center gap-2">
-                Turbo Download
-                <Badge color="blue">High-End</Badge>
+                Throttle downloads for stability
               </span>
             </Toggle>
           </div>
           <p class="text-xs text-gray-500 ml-1">
-            Recommended for powerful devices with fast internet connections.
+            Helps prevent crashes on low memory devices or for extremely large downloads.
           </p>
         </div>
         

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -6,7 +6,7 @@
   import { miscSettings, updateMiscSetting } from '$lib/settings/misc';
 
   import { promptConfirmation, showSnackbar, uploadFile } from '$lib/util';
-  import { Button, Toggle, Tooltip } from 'flowbite-svelte';
+  import { Badge, Button, Toggle } from 'flowbite-svelte';
   import { onMount } from 'svelte';
   import { GoogleSolid } from 'flowbite-svelte-icons';
   import { progressTrackerStore } from '$lib/util/progress-tracker';
@@ -924,8 +924,8 @@
       <div class="flex flex-col gap-4 w-full max-w-3xl">
         <Button color="blue" on:click={createPicker}>Download Manga</Button>
         
-        <div class="flex items-center gap-2">
-          <div id="turbo-toggle-container">
+        <div class="flex flex-col gap-2">
+          <div class="flex items-center gap-2">
             <Toggle 
               size="small" 
               checked={$miscSettings.turboDownload} 
@@ -933,10 +933,11 @@
             >
               Turbo Download
             </Toggle>
+            <Badge color="red" class="text-xs">Experimental</Badge>
           </div>
-          <Tooltip triggeredBy="#turbo-toggle-container" placement="right">
+          <p class="text-xs text-gray-500 ml-1">
             May cause crashes on lower-end devices or for very large downloads.
-          </Tooltip>
+          </p>
         </div>
         
         <div class="flex-col gap-2 flex">


### PR DESCRIPTION
This PR adds a "Throttle downloads for stability" toggle to the cloud page. When disabled, it increases the thread count and removes memory constraints for faster downloads.

Features:
- Added a download throttling toggle to the cloud page (enabled by default)
- The toggle includes informational text about preventing crashes
- The setting persists between sessions using localStorage
- When disabled, thread count is increased from 6 to 12 and memory limits are effectively removed

Disabling throttling is useful for users with fast internet connections and powerful devices who want to download manga faster.