### PR TITLE
Fix storage leak in Google Drive downloads

### DIFF
--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -251,7 +251,49 @@
     }
   }
 
+  // Function to clear service worker cache for Google Drive downloads
+  async function clearServiceWorkerCache() {
+    if ('caches' in window) {
+      try {
+        console.log('Clearing service worker cache for Google Drive downloads...');
+        
+        // Get all cache keys
+        const cacheKeys = await caches.keys();
+        console.log('Found caches:', cacheKeys);
+        
+        for (const cacheName of cacheKeys) {
+          const cache = await caches.open(cacheName);
+          
+          // Get all cache entries
+          const requests = await cache.keys();
+          console.log(`Cache ${cacheName} has ${requests.length} entries`);
+          
+          // Filter for Google Drive API requests
+          const driveRequests = requests.filter(request => 
+            request.url.includes('googleapis.com/drive') || 
+            request.url.includes('alt=media')
+          );
+          
+          console.log(`Found ${driveRequests.length} Google Drive API requests in cache ${cacheName}`);
+          
+          // Delete each Google Drive API request from the cache
+          for (const request of driveRequests) {
+            console.log(`Deleting cached request: ${request.url}`);
+            await cache.delete(request);
+          }
+        }
+        
+        console.log('Service worker cache cleared for Google Drive downloads');
+      } catch (error) {
+        console.error('Error clearing service worker cache:', error);
+      }
+    }
+  }
+
   onMount(() => {
+    // Clear service worker cache for Google Drive downloads
+    clearServiceWorkerCache();
+    
     gapi.load('client', async () => {
       try {
         await gapi.client.init({
@@ -479,6 +521,13 @@
         if (completedFiles + failedFiles === sortedFiles.length) {
           // All files have been processed
           workerPool.terminate();
+
+          // Clear service worker cache to free up storage
+          clearServiceWorkerCache().then(() => {
+            console.log('Service worker cache cleared after downloads');
+          }).catch(error => {
+            console.error('Error clearing service worker cache after downloads:', error);
+          });
 
           // Update the process to show completion
           progressTrackerStore.updateProcess(overallProcessId, {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -48,8 +48,22 @@ self.addEventListener('fetch', (event) => {
     try {
       const response = await fetch(event.request);
 
-      if (response.status === 200) {
-        cache.put(event.request, response.clone());
+      // Only cache if:
+      // 1. Response is successful (status 200)
+      // 2. It's not a Google Drive API request
+      // 3. It's not a large file (>10MB)
+      if (response.status === 200 && 
+          !event.request.url.includes('googleapis.com/drive') && 
+          !event.request.url.includes('alt=media')) {
+        
+        // Check response size before caching
+        const contentLength = response.headers.get('content-length');
+        const sizeInMB = contentLength ? parseInt(contentLength) / (1024 * 1024) : 0;
+        
+        // Only cache if smaller than 10MB
+        if (sizeInMB < 10) {
+          cache.put(event.request, response.clone());
+        }
       }
 
       return response;


### PR DESCRIPTION
This PR fixes the storage leak issue with Google Drive downloads by:

1. Preventing the service worker from caching Google Drive API responses
2. Adding explicit cache clearing when the cloud page loads and after downloads complete

The issue was caused by the service worker caching large file downloads from Google Drive, which were not being properly cleaned up.