### PR TITLE
Restore caching for Google Drive downloads with proper cleanup

### DIFF
--- a/src/lib/workers/download-worker.ts
+++ b/src/lib/workers/download-worker.ts
@@ -21,7 +21,7 @@ interface CompleteMessage {
   type: 'complete';
   fileId: string;
   fileName: string;
-  data: ArrayBuffer;
+  data?: ArrayBuffer; // Optional now, as we'll get the data from cache
 }
 
 interface ErrorMessage {
@@ -50,55 +50,8 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
     const sizeData = await sizeResponse.json();
     const totalSize = parseInt(sizeData.size, 10);
 
-    // Check if the file is already in the cache
-    if ('caches' in self) {
-      try {
-        const cacheKeys = await caches.keys();
-        for (const cacheName of cacheKeys) {
-          const cache = await caches.open(cacheName);
-          const url = `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`;
-          const cachedResponse = await cache.match(new Request(url, {
-            headers: {
-              Authorization: `Bearer ${accessToken}`
-            }
-          }));
-          
-          if (cachedResponse) {
-            console.log(`Worker: Found ${fileName} in cache`);
-            const arrayBuffer = await cachedResponse.arrayBuffer();
-            
-            // Create a progress message to show we're at 100%
-            const progressMessage: ProgressMessage = {
-              type: 'progress',
-              fileId,
-              loaded: totalSize,
-              total: totalSize
-            };
-            ctx.postMessage(progressMessage);
-            
-            // Create a complete message with the cached data
-            const completeMessage: CompleteMessage = {
-              type: 'complete',
-              fileId,
-              fileName,
-              data: arrayBuffer
-            };
-            
-            console.log(`Worker: Sending cached data for ${fileName}`, {
-              messageType: 'complete',
-              dataSize: arrayBuffer.byteLength
-            });
-            
-            // Post the message with the ArrayBuffer as a transferable object
-            ctx.postMessage(completeMessage, [arrayBuffer]);
-            return;
-          }
-        }
-      } catch (error) {
-        console.error('Worker: Error checking cache:', error);
-        // Continue with normal download if cache check fails
-      }
-    }
+    // We don't check the cache before downloading
+    // The cache is used as a RAM-friendly queue for processing, not to avoid downloads
 
     // Now download the file with progress tracking
     const xhr = new XMLHttpRequest();
@@ -147,29 +100,29 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
       xhr.onload = () => {
         if (xhr.status >= 200 && xhr.status < 300) {
           try {
-            // Get the ArrayBuffer response
-            const arrayBuffer = xhr.response;
+            // The response is now in the cache, we don't need to transfer the ArrayBuffer
+            // This reduces memory usage by not having two copies of the data
             console.log(`Worker: Download complete for ${fileName}`, {
               responseType: xhr.responseType,
-              responseSize: arrayBuffer.byteLength,
+              responseSize: xhr.response.byteLength,
               status: xhr.status
             });
 
-            // Create a message with the ArrayBuffer
+            // Create a message without the ArrayBuffer
             const completeMessage: CompleteMessage = {
               type: 'complete',
               fileId,
               fileName,
-              data: arrayBuffer
+              data: new ArrayBuffer(0) // Empty ArrayBuffer, we'll get the data from cache
             };
 
             console.log(`Worker: Sending complete message for ${fileName}`, {
               messageType: 'complete',
-              dataSize: arrayBuffer.byteLength
+              note: 'Data will be retrieved from cache'
             });
 
-            // Post the message with the ArrayBuffer as a transferable object
-            ctx.postMessage(completeMessage, [arrayBuffer]);
+            // Post the message without transferring the ArrayBuffer
+            ctx.postMessage(completeMessage);
             console.log(`Worker: Message posted for ${fileName}`);
             resolve();
           } catch (error) {

--- a/src/lib/workers/download-worker.ts
+++ b/src/lib/workers/download-worker.ts
@@ -50,6 +50,56 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
     const sizeData = await sizeResponse.json();
     const totalSize = parseInt(sizeData.size, 10);
 
+    // Check if the file is already in the cache
+    if ('caches' in self) {
+      try {
+        const cacheKeys = await caches.keys();
+        for (const cacheName of cacheKeys) {
+          const cache = await caches.open(cacheName);
+          const url = `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`;
+          const cachedResponse = await cache.match(new Request(url, {
+            headers: {
+              Authorization: `Bearer ${accessToken}`
+            }
+          }));
+          
+          if (cachedResponse) {
+            console.log(`Worker: Found ${fileName} in cache`);
+            const arrayBuffer = await cachedResponse.arrayBuffer();
+            
+            // Create a progress message to show we're at 100%
+            const progressMessage: ProgressMessage = {
+              type: 'progress',
+              fileId,
+              loaded: totalSize,
+              total: totalSize
+            };
+            ctx.postMessage(progressMessage);
+            
+            // Create a complete message with the cached data
+            const completeMessage: CompleteMessage = {
+              type: 'complete',
+              fileId,
+              fileName,
+              data: arrayBuffer
+            };
+            
+            console.log(`Worker: Sending cached data for ${fileName}`, {
+              messageType: 'complete',
+              dataSize: arrayBuffer.byteLength
+            });
+            
+            // Post the message with the ArrayBuffer as a transferable object
+            ctx.postMessage(completeMessage, [arrayBuffer]);
+            return;
+          }
+        }
+      } catch (error) {
+        console.error('Worker: Error checking cache:', error);
+        // Continue with normal download if cache check fails
+      }
+    }
+
     // Now download the file with progress tracking
     const xhr = new XMLHttpRequest();
     xhr.open('GET', `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`);

--- a/src/lib/workers/download-worker.ts
+++ b/src/lib/workers/download-worker.ts
@@ -21,7 +21,6 @@ interface CompleteMessage {
   type: 'complete';
   fileId: string;
   fileName: string;
-  data?: ArrayBuffer; // Optional now, as we'll get the data from cache
 }
 
 interface ErrorMessage {
@@ -100,20 +99,19 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
       xhr.onload = () => {
         if (xhr.status >= 200 && xhr.status < 300) {
           try {
-            // The response is now in the cache, we don't need to transfer the ArrayBuffer
-            // This reduces memory usage by not having two copies of the data
+            // The response is now in the cache, we don't need to transfer any ArrayBuffer
+            // This reduces memory usage significantly
             console.log(`Worker: Download complete for ${fileName}`, {
               responseType: xhr.responseType,
               responseSize: xhr.response.byteLength,
               status: xhr.status
             });
 
-            // Create a message without the ArrayBuffer
+            // Create a message with just the file information
             const completeMessage: CompleteMessage = {
               type: 'complete',
               fileId,
-              fileName,
-              data: new ArrayBuffer(0) // Empty ArrayBuffer, we'll get the data from cache
+              fileName
             };
 
             console.log(`Worker: Sending complete message for ${fileName}`, {
@@ -121,7 +119,7 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
               note: 'Data will be retrieved from cache'
             });
 
-            // Post the message without transferring the ArrayBuffer
+            // Post the message
             ctx.postMessage(completeMessage);
             console.log(`Worker: Message posted for ${fileName}`);
             resolve();

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -252,6 +252,39 @@
     }
   }
 
+  // Function to clear a specific file from the service worker cache
+  async function clearSpecificFileFromCache(fileId: string, accessToken: string) {
+    if ('caches' in window) {
+      try {
+        console.log(`Clearing cache for file ID: ${fileId}`);
+        
+        // Get all cache keys
+        const cacheKeys = await caches.keys();
+        
+        for (const cacheName of cacheKeys) {
+          const cache = await caches.open(cacheName);
+          
+          // Get all cache entries
+          const requests = await cache.keys();
+          
+          // Find the specific file request
+          const fileRequest = requests.find(request => 
+            request.url.includes(`${fileId}?alt=media`)
+          );
+          
+          if (fileRequest) {
+            console.log(`Deleting cached request: ${fileRequest.url}`);
+            await cache.delete(fileRequest);
+          }
+        }
+        
+        console.log(`Cache cleared for file ID: ${fileId}`);
+      } catch (error) {
+        console.error(`Error clearing cache for file ID ${fileId}:`, error);
+      }
+    }
+  }
+
   // Function to clear service worker cache for Google Drive downloads
   async function clearServiceWorkerCache() {
     if ('caches' in window) {
@@ -292,8 +325,7 @@
   }
 
   onMount(() => {
-    // Clear service worker cache for Google Drive downloads
-    clearServiceWorkerCache();
+    // We no longer clear the cache on startup since we're using it for downloads
     
     gapi.load('client', async () => {
       try {
@@ -535,13 +567,6 @@
           // All files have been processed
           workerPool.terminate();
 
-          // Clear service worker cache to free up storage
-          clearServiceWorkerCache().then(() => {
-            console.log('Service worker cache cleared after downloads');
-          }).catch(error => {
-            console.error('Error clearing service worker cache after downloads:', error);
-          });
-
           // Update the process to show completion
           progressTrackerStore.updateProcess(overallProcessId, {
             status: `All downloads complete (${failedFiles} failed)`,
@@ -612,6 +637,10 @@
               // Process the file
               await processFiles([file]);
               console.log(`Successfully processed file: ${file.name}`);
+
+              // Clear this specific file from the cache
+              await clearSpecificFileFromCache(fileInfo.id, accessToken);
+              console.log(`Cleared cache for file: ${file.name}`);
 
               // Mark as completed
               completedFiles++;

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -663,8 +663,7 @@
             try {
               console.log(`Received complete message for ${data.fileName}`);
               
-              // Get the file from the cache instead of using the ArrayBuffer directly
-              // This reduces memory usage by not having two copies of the data in memory
+              // Get the file from the cache
               const fileBlob = await getFileFromCache(fileInfo.id, accessToken);
               
               if (!fileBlob) {

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -325,7 +325,8 @@
   }
 
   onMount(() => {
-    // We no longer clear the cache on startup since we're using it for downloads
+    // Clear service worker cache for Google Drive downloads
+    clearServiceWorkerCache();
     
     gapi.load('client', async () => {
       try {

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -252,6 +252,46 @@
     }
   }
 
+  // Function to get a file from the service worker cache
+  async function getFileFromCache(fileId: string, accessToken: string): Promise<Blob | null> {
+    if ('caches' in window) {
+      try {
+        console.log(`Getting file from cache for file ID: ${fileId}`);
+        
+        // Get all cache keys
+        const cacheKeys = await caches.keys();
+        
+        for (const cacheName of cacheKeys) {
+          const cache = await caches.open(cacheName);
+          
+          // Get all cache entries
+          const requests = await cache.keys();
+          
+          // Find the specific file request
+          const fileRequest = requests.find(request => 
+            request.url.includes(`${fileId}?alt=media`)
+          );
+          
+          if (fileRequest) {
+            console.log(`Found cached request: ${fileRequest.url}`);
+            const cachedResponse = await cache.match(fileRequest);
+            
+            if (cachedResponse) {
+              return await cachedResponse.blob();
+            }
+          }
+        }
+        
+        console.log(`File not found in cache for file ID: ${fileId}`);
+        return null;
+      } catch (error) {
+        console.error(`Error getting file from cache for file ID ${fileId}:`, error);
+        return null;
+      }
+    }
+    return null;
+  }
+
   // Function to clear a specific file from the service worker cache
   async function clearSpecificFileFromCache(fileId: string, accessToken: string) {
     if ('caches' in window) {
@@ -621,24 +661,27 @@
           },
           onComplete: async (data, releaseMemory) => {
             try {
-              console.log(`Received complete message for ${data.fileName}`, {
-                dataType: typeof data.data,
-                dataSize: data.data.byteLength,
-                hasData: !!data.data
-              });
-
-              // Create a Blob from the ArrayBuffer
-              const blob = new Blob([data.data]);
-              console.log(`Created blob of size ${blob.size} bytes`);
-
+              console.log(`Received complete message for ${data.fileName}`);
+              
+              // Get the file from the cache instead of using the ArrayBuffer directly
+              // This reduces memory usage by not having two copies of the data in memory
+              const fileBlob = await getFileFromCache(fileInfo.id, accessToken);
+              
+              if (!fileBlob) {
+                console.error(`Failed to get file from cache: ${data.fileName}`);
+                throw new Error(`Failed to get file from cache: ${data.fileName}`);
+              }
+              
+              console.log(`Retrieved file from cache: ${data.fileName}, size: ${fileBlob.size} bytes`);
+              
               // Create a File object from the blob
-              const file = new File([blob], data.fileName);
+              const file = new File([fileBlob], data.fileName);
               console.log(`Created file object: ${file.name}, size: ${file.size} bytes`);
-
+              
               // Process the file
               await processFiles([file]);
               console.log(`Successfully processed file: ${file.name}`);
-
+              
               // Clear this specific file from the cache
               await clearSpecificFileFromCache(fileInfo.id, accessToken);
               console.log(`Cleared cache for file: ${file.name}`);

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -48,18 +48,10 @@ self.addEventListener('fetch', (event) => {
     try {
       const response = await fetch(event.request);
 
-      // Only cache if:
-      // 1. Response is successful (status 200)
-      // 2. It's not a large file (>50MB)
+      // Cache all successful responses
+      // This is especially important for large files to reduce RAM usage
       if (response.status === 200) {
-        // Check response size before caching
-        const contentLength = response.headers.get('content-length');
-        const sizeInMB = contentLength ? parseInt(contentLength) / (1024 * 1024) : 0;
-        
-        // Only cache if smaller than 50MB
-        if (sizeInMB < 50) {
-          cache.put(event.request, response.clone());
-        }
+        cache.put(event.request, response.clone());
       }
 
       return response;

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -50,18 +50,14 @@ self.addEventListener('fetch', (event) => {
 
       // Only cache if:
       // 1. Response is successful (status 200)
-      // 2. It's not a Google Drive API request
-      // 3. It's not a large file (>10MB)
-      if (response.status === 200 && 
-          !event.request.url.includes('googleapis.com/drive') && 
-          !event.request.url.includes('alt=media')) {
-        
+      // 2. It's not a large file (>50MB)
+      if (response.status === 200) {
         // Check response size before caching
         const contentLength = response.headers.get('content-length');
         const sizeInMB = contentLength ? parseInt(contentLength) / (1024 * 1024) : 0;
         
-        // Only cache if smaller than 10MB
-        if (sizeInMB < 10) {
+        // Only cache if smaller than 50MB
+        if (sizeInMB < 50) {
           cache.put(event.request, response.clone());
         }
       }


### PR DESCRIPTION
This PR restores caching for Google Drive downloads that was disabled in commit 029a906ebe29a50333dc6e3bbad531b5561a1e08 due to cache leaking issues.

Changes made:

1. Modified the service worker to cache all files, especially large ones
2. Implemented a RAM-efficient approach that uses the cache as a queue for processing
3. Added functions to retrieve files from the cache and clear them after processing
4. Kept the cache purge on startup to prevent orphaned cache entries
5. Removed ArrayBuffer from worker messages to further reduce RAM usage

This approach should help with RAM constraints during the import process while preventing cache leaking in persistent storage.