### PR TITLE
Fix Firefox import issues with chunked download approach

### DIFF
--- a/src/lib/util/worker-pool.ts
+++ b/src/lib/util/worker-pool.ts
@@ -10,6 +10,7 @@ export interface WorkerTask {
   onProgress?: (progress: any) => void;
   onComplete?: (result: any, completeTask: () => void) => void;
   onError?: (error: any) => void;
+  onChunk?: (chunk: any) => void; // New callback for handling chunked downloads (Firefox)
 }
 
 export class WorkerPool {
@@ -57,6 +58,11 @@ export class WorkerPool {
 
       if (data.type === 'progress' && task.onProgress) {
         task.onProgress(data);
+      } else if (data.type === 'chunk' && task.onChunk) {
+        // Handle chunked downloads (Firefox-specific)
+        console.log(`Worker pool: Received chunk ${data.chunkIndex + 1}/${data.totalChunks} for task ${taskId}`);
+        task.onChunk(data);
+        // Note: We don't complete the task here, as more chunks are coming
       } else if (data.type === 'complete' && task.onComplete) {
         console.log(`Worker pool: Calling onComplete for task ${taskId}`, {
           hasData: !!data.data,

--- a/src/lib/workers/download-worker.ts
+++ b/src/lib/workers/download-worker.ts
@@ -4,6 +4,10 @@
 // Define the worker context
 const ctx: Worker = self as any;
 
+// Check if the browser is Firefox
+const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+console.log(`Worker initialized in ${isFirefox ? 'Firefox' : 'non-Firefox'} browser`);
+
 interface DownloadMessage {
   fileId: string;
   fileName: string;
@@ -21,7 +25,16 @@ interface CompleteMessage {
   type: 'complete';
   fileId: string;
   fileName: string;
-  data: ArrayBuffer;
+  data?: ArrayBuffer; // Optional now, as we'll use a different approach for Firefox
+}
+
+interface ChunkMessage {
+  type: 'chunk';
+  fileId: string;
+  fileName: string;
+  chunk: ArrayBuffer;
+  chunkIndex: number;
+  totalChunks: number;
 }
 
 interface ErrorMessage {
@@ -105,21 +118,28 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
               status: xhr.status
             });
 
-            // Create a message with the ArrayBuffer
-            const completeMessage: CompleteMessage = {
-              type: 'complete',
-              fileId,
-              fileName,
-              data: arrayBuffer
-            };
+            if (isFirefox) {
+              // For Firefox, use a chunked approach to avoid memory issues
+              // Firefox has issues with large ArrayBuffer transfers
+              handleFirefoxDownload(arrayBuffer, fileId, fileName);
+            } else {
+              // For other browsers, use the standard approach with transferable objects
+              const completeMessage: CompleteMessage = {
+                type: 'complete',
+                fileId,
+                fileName,
+                data: arrayBuffer
+              };
 
-            console.log(`Worker: Sending complete message for ${fileName}`, {
-              messageType: 'complete',
-              dataSize: arrayBuffer.byteLength
-            });
+              console.log(`Worker: Sending complete message for ${fileName}`, {
+                messageType: 'complete',
+                dataSize: arrayBuffer.byteLength
+              });
 
-            // Post the message with the ArrayBuffer as a transferable object
-            ctx.postMessage(completeMessage, [arrayBuffer]);
+              // Post the message with the ArrayBuffer as a transferable object
+              ctx.postMessage(completeMessage, [arrayBuffer]);
+            }
+            
             console.log(`Worker: Message posted for ${fileName}`);
             resolve();
           } catch (error) {
@@ -153,6 +173,48 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
     };
     ctx.postMessage(errorMessage);
     throw error;
+  }
+}
+
+// Special handling for Firefox to avoid memory issues with large ArrayBuffers
+function handleFirefoxDownload(arrayBuffer: ArrayBuffer, fileId: string, fileName: string) {
+  // Use a smaller chunk size for Firefox to avoid memory issues
+  // 4MB chunks should be safe for Firefox
+  const CHUNK_SIZE = 4 * 1024 * 1024; // 4MB
+  const totalSize = arrayBuffer.byteLength;
+  const totalChunks = Math.ceil(totalSize / CHUNK_SIZE);
+  
+  console.log(`Worker: Processing ${fileName} in ${totalChunks} chunks of ${CHUNK_SIZE / (1024 * 1024)}MB each`);
+  
+  // First send a complete message with no data to signal the start of chunked transfer
+  const completeMessage: CompleteMessage = {
+    type: 'complete',
+    fileId,
+    fileName
+    // No data field - this signals that we're using chunked transfer
+  };
+  
+  ctx.postMessage(completeMessage);
+  
+  // Then send each chunk
+  for (let i = 0; i < totalChunks; i++) {
+    const start = i * CHUNK_SIZE;
+    const end = Math.min(start + CHUNK_SIZE, totalSize);
+    const chunk = arrayBuffer.slice(start, end);
+    
+    const chunkMessage: ChunkMessage = {
+      type: 'chunk',
+      fileId,
+      fileName,
+      chunk,
+      chunkIndex: i,
+      totalChunks
+    };
+    
+    // Use transferable objects for each chunk
+    ctx.postMessage(chunkMessage, [chunk]);
+    
+    console.log(`Worker: Sent chunk ${i + 1}/${totalChunks} for ${fileName}`);
   }
 }
 

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -11,6 +11,20 @@
   import { GoogleSolid } from 'flowbite-svelte-icons';
   import { progressTrackerStore } from '$lib/util/progress-tracker';
 
+  // Add TypeScript declaration for the fileChunks global variable
+  declare global {
+    interface Window {
+      fileChunks?: {
+        [fileId: string]: {
+          chunks: ArrayBuffer[];
+          receivedChunks: number;
+          totalChunks: number;
+          fileName: string;
+        };
+      };
+    }
+  }
+
   interface Props {
     accessToken?: string;
   }
@@ -593,8 +607,99 @@
             fileProgress[fileInfo.id] = data.loaded;
             updateOverallProgress();
           },
+          onChunk: async (data) => {
+            // This handler is for Firefox chunked downloads
+            console.log(`Received chunk ${data.chunkIndex + 1}/${data.totalChunks} for ${data.fileName}`);
+            
+            // Store the chunk in the fileChunks object
+            if (!window.fileChunks || !window.fileChunks[fileInfo.id]) {
+              console.error(`Received chunk for ${data.fileName} but no chunks array initialized`);
+              return;
+            }
+            
+            const fileChunkData = window.fileChunks[fileInfo.id];
+            fileChunkData.chunks[data.chunkIndex] = data.chunk;
+            fileChunkData.receivedChunks++;
+            fileChunkData.totalChunks = data.totalChunks;
+            
+            console.log(`Stored chunk ${data.chunkIndex + 1}/${data.totalChunks} for ${data.fileName}, received ${fileChunkData.receivedChunks}/${data.totalChunks}`);
+            
+            // If we've received all chunks, process the file
+            if (fileChunkData.receivedChunks === data.totalChunks) {
+              console.log(`All ${data.totalChunks} chunks received for ${data.fileName}, processing...`);
+              
+              try {
+                // Combine all chunks into a single ArrayBuffer
+                const totalSize = fileChunkData.chunks.reduce((size, chunk) => size + chunk.byteLength, 0);
+                const combinedBuffer = new Uint8Array(totalSize);
+                
+                let offset = 0;
+                for (const chunk of fileChunkData.chunks) {
+                  combinedBuffer.set(new Uint8Array(chunk), offset);
+                  offset += chunk.byteLength;
+                }
+                
+                // Create a Blob and File from the combined buffer
+                const blob = new Blob([combinedBuffer.buffer]);
+                console.log(`Created blob of size ${blob.size} bytes from ${data.totalChunks} chunks`);
+                
+                const file = new File([blob], data.fileName);
+                console.log(`Created file object: ${file.name}, size: ${file.size} bytes`);
+                
+                // Process the file
+                await processFiles([file]);
+                console.log(`Successfully processed file: ${file.name}`);
+                
+                // Mark as completed
+                completedFiles++;
+                fileProgress[fileInfo.id] = fileSizes[fileInfo.id] || 0;
+                processedFiles[fileInfo.id] = true;
+                
+                // Clean up
+                delete window.fileChunks[fileInfo.id];
+                
+                updateOverallProgress();
+                checkAllComplete();
+              } catch (error) {
+                console.error(`Error processing chunked file ${data.fileName}:`, error);
+                showSnackbar(`Failed to process ${data.fileName}`);
+                
+                // Mark as failed
+                failedFiles++;
+                processedFiles[fileInfo.id] = true;
+                
+                // Clean up
+                delete window.fileChunks[fileInfo.id];
+                
+                updateOverallProgress();
+                checkAllComplete();
+              }
+            }
+          },
           onComplete: async (data, releaseMemory) => {
             try {
+              // Check if this is a chunked download (Firefox-specific)
+              if (!data.data || data.data.byteLength === 0) {
+                console.log(`Received chunked download start signal for ${data.fileName}`);
+                
+                // For Firefox chunked downloads, we'll collect chunks in the fileChunks object
+                // The actual processing will happen in the onChunk handler
+                if (!window.fileChunks) {
+                  window.fileChunks = {};
+                }
+                
+                // Initialize the chunks array for this file
+                window.fileChunks[fileInfo.id] = {
+                  chunks: [],
+                  receivedChunks: 0,
+                  totalChunks: 0,
+                  fileName: data.fileName
+                };
+                
+                // Don't mark as completed yet - we'll do that when all chunks are received
+                return;
+              }
+              
               console.log(`Received complete message for ${data.fileName}`, {
                 dataType: typeof data.data,
                 dataSize: data.data.byteLength,


### PR DESCRIPTION
This PR addresses Firefox-specific issues with importing files from Google Drive by implementing a chunked download approach.

Changes made:

1. Added Firefox detection in the download worker
2. Implemented a chunked download approach for Firefox that breaks large files into 4MB chunks
3. Added handling for chunked downloads in the worker pool and cloud page
4. Added a global fileChunks object to collect and reassemble chunks

This approach should help Firefox handle the import process better by avoiding the need to transfer large ArrayBuffers all at once, which seems to be problematic in Firefox.