### PR TITLE
Move zip extraction to worker thread

### DIFF
--- a/src/lib/util/worker-pool.ts
+++ b/src/lib/util/worker-pool.ts
@@ -59,11 +59,7 @@ export class WorkerPool {
         task.onProgress(data);
       } else if (data.type === 'complete' && task.onComplete) {
         console.log(`Worker pool: Calling onComplete for task ${taskId}`, {
-          hasData: !!data.data,
-          dataType: typeof data.data,
-          dataSize: data.data?.byteLength,
-          isExtracted: data.isExtracted,
-          extractedFilesCount: data.extractedFiles?.length || 0
+          extractedFilesCount: data.extractedFiles.length
         });
 
         task.onComplete(data, () => {

--- a/src/lib/util/worker-pool.ts
+++ b/src/lib/util/worker-pool.ts
@@ -61,7 +61,9 @@ export class WorkerPool {
         console.log(`Worker pool: Calling onComplete for task ${taskId}`, {
           hasData: !!data.data,
           dataType: typeof data.data,
-          dataSize: data.data?.byteLength
+          dataSize: data.data?.byteLength,
+          isExtracted: data.isExtracted,
+          extractedFilesCount: data.extractedFiles?.length || 0
         });
 
         task.onComplete(data, () => {

--- a/src/lib/workers/download-worker.ts
+++ b/src/lib/workers/download-worker.ts
@@ -59,12 +59,6 @@ async function extractZipFiles(arrayBuffer: ArrayBuffer): Promise<ExtractedFile[
       // Skip directories
       if (entry.directory) continue;
       
-      // Skip problematic paths (same logic as in upload/index.ts)
-      if (isProblematicPath(entry.filename)) {
-        console.log(`Worker: Skipping file in problematic directory: ${entry.filename}`);
-        continue;
-      }
-      
       // Extract the file data
       if (entry.readable) {
         try {
@@ -94,64 +88,6 @@ async function extractZipFiles(arrayBuffer: ArrayBuffer): Promise<ExtractedFile[
     console.error('Worker: Error extracting zip:', error);
     throw new Error(`Error extracting zip: ${error.toString()}`);
   }
-}
-
-// List of problematic directory patterns to exclude (copied from upload/index.ts)
-const excludedDirPatterns = [
-  // macOS system directories
-  '__MACOSX',
-  '.DS_Store',
-  '.Trashes',
-  '.Spotlight-V100',
-  '.fseventsd',
-  '.TemporaryItems',
-  '.Trash',
-  
-  // Windows system directories
-  'System Volume Information',
-  '$RECYCLE.BIN',
-  'Thumbs.db',
-  'desktop.ini',
-  'Desktop.ini',
-  'RECYCLER',
-  'RECYCLED',
-  
-  // Linux/Unix system directories
-  '.Trash-1000',
-  '.thumbnails',
-  '.directory',
-  
-  // Cloud storage special folders
-  '.dropbox',
-  '.dropbox.cache',
-  
-  // Version control
-  '.git',
-  '.svn',
-  
-  // General backup/temp files
-  '~$',
-  '.bak',
-  '.tmp',
-  '.temp'
-];
-
-// Function to check if a path contains any problematic directory patterns (copied from upload/index.ts)
-function isProblematicPath(path: string): boolean {
-  if (!path) return false;
-  
-  // Check for macOS hidden files that start with "._"
-  const pathParts = path.split('/');
-  const fileName = pathParts[pathParts.length - 1];
-  if (fileName.startsWith('._')) {
-    return true;
-  }
-  
-  return excludedDirPatterns.some(pattern => 
-    path.includes('/' + pattern + '/') || 
-    path.endsWith('/' + pattern) || 
-    path === pattern
-  );
 }
 
 // Function to download a file from Google Drive

--- a/src/lib/workers/download-worker.ts
+++ b/src/lib/workers/download-worker.ts
@@ -29,9 +29,7 @@ interface CompleteMessage {
   type: 'complete';
   fileId: string;
   fileName: string;
-  data: ArrayBuffer;
-  extractedFiles?: ExtractedFile[];
-  isExtracted: boolean;
+  extractedFiles: ExtractedFile[];
 }
 
 interface ErrorMessage {
@@ -40,11 +38,7 @@ interface ErrorMessage {
   error: string;
 }
 
-// Function to check if a file is a zip or cbz
-function isZipFile(fileName: string): boolean {
-  const ext = fileName.split('.').pop()?.toLowerCase();
-  return ext === 'zip' || ext === 'cbz';
-}
+// All files from Google Drive are zip or cbz, so we don't need to check
 
 // Function to extract files from a zip/cbz
 async function extractZipFiles(arrayBuffer: ArrayBuffer): Promise<ExtractedFile[]> {
@@ -235,52 +229,45 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
               status: xhr.status
             });
 
-            // Check if this is a zip/cbz file that needs extraction
-            const shouldExtract = isZipFile(fileName);
-            let extractedFiles: ExtractedFile[] | undefined;
+            // Extract the contents (all files from Drive are zip/cbz)
+            let extractedFiles: ExtractedFile[] = [];
             let transferables: ArrayBuffer[] = [];
             
-            // If it's a zip/cbz file, extract its contents
-            if (shouldExtract) {
-              try {
-                console.log(`Worker: Starting extraction for ${fileName}`);
-                // Clone the array buffer since we'll be transferring the original
-                const arrayBufferClone = arrayBuffer.slice(0);
-                extractedFiles = await extractZipFiles(arrayBufferClone);
-                
-                // Add all extracted file buffers to transferables
-                if (extractedFiles) {
-                  extractedFiles.forEach(file => {
-                    transferables.push(file.data);
-                  });
-                }
-                
-                console.log(`Worker: Extraction complete for ${fileName}, found ${extractedFiles.length} files`);
-              } catch (error) {
-                console.error(`Worker: Error extracting ${fileName}:`, error);
-                // If extraction fails, we'll still send the original file
-                extractedFiles = undefined;
-              }
+            try {
+              console.log(`Worker: Starting extraction for ${fileName}`);
+              extractedFiles = await extractZipFiles(arrayBuffer);
+              
+              // Add all extracted file buffers to transferables
+              extractedFiles.forEach(file => {
+                transferables.push(file.data);
+              });
+              
+              console.log(`Worker: Extraction complete for ${fileName}, found ${extractedFiles.length} files`);
+            } catch (error) {
+              console.error(`Worker: Error extracting ${fileName}:`, error);
+              // Send an error message if extraction fails
+              const errorMessage: ErrorMessage = {
+                type: 'error',
+                fileId,
+                error: `Error extracting file: ${error.toString()}`
+              };
+              ctx.postMessage(errorMessage);
+              reject(error);
+              return;
             }
 
-            // Create a message with the ArrayBuffer and extracted files if available
+            // Create a message with the extracted files
             const completeMessage: CompleteMessage = {
               type: 'complete',
               fileId,
               fileName,
-              data: arrayBuffer,
-              extractedFiles,
-              isExtracted: !!extractedFiles
+              extractedFiles
             };
 
             console.log(`Worker: Sending complete message for ${fileName}`, {
               messageType: 'complete',
-              dataSize: arrayBuffer.byteLength,
-              extractedFiles: extractedFiles ? extractedFiles.length : 0
+              extractedFiles: extractedFiles.length
             });
-
-            // Add the original array buffer to transferables
-            transferables.push(arrayBuffer);
 
             // Post the message with all ArrayBuffers as transferable objects
             ctx.postMessage(completeMessage, transferables);

--- a/src/lib/workers/download-worker.ts
+++ b/src/lib/workers/download-worker.ts
@@ -1,5 +1,8 @@
-// Web worker for downloading files from Google Drive
+// Web worker for downloading files from Google Drive and extracting zip/cbz files
 // This file will be bundled by Vite as a web worker
+
+// Import zip.js for decompression
+import { ZipReader } from '@zip.js/zip.js';
 
 // Define the worker context
 const ctx: Worker = self as any;
@@ -17,17 +20,144 @@ interface ProgressMessage {
   total: number;
 }
 
+interface ExtractedFile {
+  name: string;
+  data: ArrayBuffer;
+}
+
 interface CompleteMessage {
   type: 'complete';
   fileId: string;
   fileName: string;
   data: ArrayBuffer;
+  extractedFiles?: ExtractedFile[];
+  isExtracted: boolean;
 }
 
 interface ErrorMessage {
   type: 'error';
   fileId: string;
   error: string;
+}
+
+// Function to check if a file is a zip or cbz
+function isZipFile(fileName: string): boolean {
+  const ext = fileName.split('.').pop()?.toLowerCase();
+  return ext === 'zip' || ext === 'cbz';
+}
+
+// Function to extract files from a zip/cbz
+async function extractZipFiles(arrayBuffer: ArrayBuffer): Promise<ExtractedFile[]> {
+  console.log('Worker: Starting zip extraction');
+  
+  try {
+    // Create a blob from the array buffer
+    const blob = new Blob([arrayBuffer]);
+    
+    // Create a zip reader
+    const zipReader = new ZipReader(new Response(blob).body);
+    
+    // Extract all entries
+    const extractedFiles: ExtractedFile[] = [];
+    
+    // Process file entries
+    for await (const entry of zipReader) {
+      // Skip directories
+      if (entry.directory) continue;
+      
+      // Skip problematic paths (same logic as in upload/index.ts)
+      if (isProblematicPath(entry.filename)) {
+        console.log(`Worker: Skipping file in problematic directory: ${entry.filename}`);
+        continue;
+      }
+      
+      // Extract the file data
+      if (entry.readable) {
+        try {
+          // Convert readable stream to blob
+          const blob = await new Response(entry.readable).blob();
+          
+          // Convert blob to ArrayBuffer
+          const buffer = await blob.arrayBuffer();
+          
+          // Add to extracted files
+          extractedFiles.push({
+            name: entry.filename,
+            data: buffer
+          });
+        } catch (error) {
+          console.error(`Worker: Error extracting file ${entry.filename}:`, error);
+        }
+      }
+    }
+    
+    // Close the zip reader
+    await zipReader.close();
+    
+    console.log(`Worker: Extracted ${extractedFiles.length} files from zip`);
+    return extractedFiles;
+  } catch (error) {
+    console.error('Worker: Error extracting zip:', error);
+    throw new Error(`Error extracting zip: ${error.toString()}`);
+  }
+}
+
+// List of problematic directory patterns to exclude (copied from upload/index.ts)
+const excludedDirPatterns = [
+  // macOS system directories
+  '__MACOSX',
+  '.DS_Store',
+  '.Trashes',
+  '.Spotlight-V100',
+  '.fseventsd',
+  '.TemporaryItems',
+  '.Trash',
+  
+  // Windows system directories
+  'System Volume Information',
+  '$RECYCLE.BIN',
+  'Thumbs.db',
+  'desktop.ini',
+  'Desktop.ini',
+  'RECYCLER',
+  'RECYCLED',
+  
+  // Linux/Unix system directories
+  '.Trash-1000',
+  '.thumbnails',
+  '.directory',
+  
+  // Cloud storage special folders
+  '.dropbox',
+  '.dropbox.cache',
+  
+  // Version control
+  '.git',
+  '.svn',
+  
+  // General backup/temp files
+  '~$',
+  '.bak',
+  '.tmp',
+  '.temp'
+];
+
+// Function to check if a path contains any problematic directory patterns (copied from upload/index.ts)
+function isProblematicPath(path: string): boolean {
+  if (!path) return false;
+  
+  // Check for macOS hidden files that start with "._"
+  const pathParts = path.split('/');
+  const fileName = pathParts[pathParts.length - 1];
+  if (fileName.startsWith('._')) {
+    return true;
+  }
+  
+  return excludedDirPatterns.some(pattern => 
+    path.includes('/' + pattern + '/') || 
+    path.endsWith('/' + pattern) || 
+    path === pattern
+  );
 }
 
 // Function to download a file from Google Drive
@@ -94,7 +224,7 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
     };
 
     return new Promise<void>((resolve, reject) => {
-      xhr.onload = () => {
+      xhr.onload = async () => {
         if (xhr.status >= 200 && xhr.status < 300) {
           try {
             // Get the ArrayBuffer response
@@ -105,21 +235,55 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
               status: xhr.status
             });
 
-            // Create a message with the ArrayBuffer
+            // Check if this is a zip/cbz file that needs extraction
+            const shouldExtract = isZipFile(fileName);
+            let extractedFiles: ExtractedFile[] | undefined;
+            let transferables: ArrayBuffer[] = [];
+            
+            // If it's a zip/cbz file, extract its contents
+            if (shouldExtract) {
+              try {
+                console.log(`Worker: Starting extraction for ${fileName}`);
+                // Clone the array buffer since we'll be transferring the original
+                const arrayBufferClone = arrayBuffer.slice(0);
+                extractedFiles = await extractZipFiles(arrayBufferClone);
+                
+                // Add all extracted file buffers to transferables
+                if (extractedFiles) {
+                  extractedFiles.forEach(file => {
+                    transferables.push(file.data);
+                  });
+                }
+                
+                console.log(`Worker: Extraction complete for ${fileName}, found ${extractedFiles.length} files`);
+              } catch (error) {
+                console.error(`Worker: Error extracting ${fileName}:`, error);
+                // If extraction fails, we'll still send the original file
+                extractedFiles = undefined;
+              }
+            }
+
+            // Create a message with the ArrayBuffer and extracted files if available
             const completeMessage: CompleteMessage = {
               type: 'complete',
               fileId,
               fileName,
-              data: arrayBuffer
+              data: arrayBuffer,
+              extractedFiles,
+              isExtracted: !!extractedFiles
             };
 
             console.log(`Worker: Sending complete message for ${fileName}`, {
               messageType: 'complete',
-              dataSize: arrayBuffer.byteLength
+              dataSize: arrayBuffer.byteLength,
+              extractedFiles: extractedFiles ? extractedFiles.length : 0
             });
 
-            // Post the message with the ArrayBuffer as a transferable object
-            ctx.postMessage(completeMessage, [arrayBuffer]);
+            // Add the original array buffer to transferables
+            transferables.push(arrayBuffer);
+
+            // Post the message with all ArrayBuffers as transferable objects
+            ctx.postMessage(completeMessage, transferables);
             console.log(`Worker: Message posted for ${fileName}`);
             resolve();
           } catch (error) {

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -602,44 +602,23 @@
           onComplete: async (data, releaseMemory) => {
             try {
               console.log(`Received complete message for ${data.fileName}`, {
-                dataType: typeof data.data,
-                dataSize: data.data.byteLength,
-                hasData: !!data.data,
-                isExtracted: data.isExtracted,
-                extractedFilesCount: data.extractedFiles?.length || 0
+                extractedFilesCount: data.extractedFiles.length
               });
 
-              if (data.isExtracted && data.extractedFiles && data.extractedFiles.length > 0) {
-                // If the worker has already extracted the files, process them directly
-                console.log(`Processing ${data.extractedFiles.length} extracted files from ${data.fileName}`);
-                
-                // Convert extracted files to File objects
-                const files = data.extractedFiles.map(extractedFile => {
-                  return new File(
-                    [extractedFile.data], 
-                    extractedFile.name
-                  );
-                });
-                
-                // Process the extracted files
-                await processFiles(files);
-                console.log(`Successfully processed ${files.length} extracted files from ${data.fileName}`);
-              } else {
-                // If the worker didn't extract the files (or extraction failed), process the original file
-                console.log(`Processing original file: ${data.fileName}`);
-                
-                // Create a Blob from the ArrayBuffer
-                const blob = new Blob([data.data]);
-                console.log(`Created blob of size ${blob.size} bytes`);
-
-                // Create a File object from the blob
-                const file = new File([blob], data.fileName);
-                console.log(`Created file object: ${file.name}, size: ${file.size} bytes`);
-
-                // Process the file
-                await processFiles([file]);
-                console.log(`Successfully processed file: ${file.name}`);
-              }
+              // Process the extracted files directly
+              console.log(`Processing ${data.extractedFiles.length} extracted files from ${data.fileName}`);
+              
+              // Convert extracted files to File objects
+              const files = data.extractedFiles.map(extractedFile => {
+                return new File(
+                  [extractedFile.data], 
+                  extractedFile.name
+                );
+              });
+              
+              // Process the extracted files
+              await processFiles(files);
+              console.log(`Successfully processed ${files.length} extracted files from ${data.fileName}`);
 
               // Mark as completed
               completedFiles++;

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -569,11 +569,17 @@
         // 1. The downloaded file (fileSizes[fileInfo.id])
         // 2. Processing overhead (typically 2-3x the file size for decompression)
         const fileSize = fileSizes[fileInfo.id] || 0;
+        // For zip/cbz files, we need more memory for extraction
+        const isZipFile = fileInfo.name.toLowerCase().endsWith('.zip') || 
+                         fileInfo.name.toLowerCase().endsWith('.cbz');
+        
         const memoryRequirement = Math.max(
           // Estimate memory needed: file size + processing overhead
-          // Use at least 50MB as a minimum requirement
-          fileSize * 3, // 3x file size for processing overhead
-          50 * 1024 * 1024 // Minimum 50MB
+          // For zip files, we need more memory for extraction (5x)
+          // For regular files, 3x is sufficient
+          isZipFile ? fileSize * 5 : fileSize * 3,
+          // Minimum 50MB
+          50 * 1024 * 1024
         );
 
         console.log(
@@ -598,20 +604,42 @@
               console.log(`Received complete message for ${data.fileName}`, {
                 dataType: typeof data.data,
                 dataSize: data.data.byteLength,
-                hasData: !!data.data
+                hasData: !!data.data,
+                isExtracted: data.isExtracted,
+                extractedFilesCount: data.extractedFiles?.length || 0
               });
 
-              // Create a Blob from the ArrayBuffer
-              const blob = new Blob([data.data]);
-              console.log(`Created blob of size ${blob.size} bytes`);
+              if (data.isExtracted && data.extractedFiles && data.extractedFiles.length > 0) {
+                // If the worker has already extracted the files, process them directly
+                console.log(`Processing ${data.extractedFiles.length} extracted files from ${data.fileName}`);
+                
+                // Convert extracted files to File objects
+                const files = data.extractedFiles.map(extractedFile => {
+                  return new File(
+                    [extractedFile.data], 
+                    extractedFile.name
+                  );
+                });
+                
+                // Process the extracted files
+                await processFiles(files);
+                console.log(`Successfully processed ${files.length} extracted files from ${data.fileName}`);
+              } else {
+                // If the worker didn't extract the files (or extraction failed), process the original file
+                console.log(`Processing original file: ${data.fileName}`);
+                
+                // Create a Blob from the ArrayBuffer
+                const blob = new Blob([data.data]);
+                console.log(`Created blob of size ${blob.size} bytes`);
 
-              // Create a File object from the blob
-              const file = new File([blob], data.fileName);
-              console.log(`Created file object: ${file.name}, size: ${file.size} bytes`);
+                // Create a File object from the blob
+                const file = new File([blob], data.fileName);
+                console.log(`Created file object: ${file.name}, size: ${file.size} bytes`);
 
-              // Process the file
-              await processFiles([file]);
-              console.log(`Successfully processed file: ${file.name}`);
+                // Process the file
+                await processFiles([file]);
+                console.log(`Successfully processed file: ${file.name}`);
+              }
 
               // Mark as completed
               completedFiles++;


### PR DESCRIPTION
This PR moves the decompression step from the main thread to the worker thread. This should both massively increase import speed, and also prevent a large backlog from forming in memory and potentially causing OoM errors.

## Changes

1. Updated the download-worker.ts:
   - Added ZipReader import from @zip.js/zip.js
   - Added new interfaces for ExtractedFile and updated CompleteMessage to only include extracted files
   - Added extractZipFiles function to extract files from a zip/cbz archive
   - Modified the downloadFile function to extract zip/cbz files before sending them to the main thread
   - Added transferable objects handling for all extracted file ArrayBuffers
   - Simplified the interface to only pass extracted files to the main thread
   - Removed duplicate filtering code (the importer will handle filtering)

2. Updated the cloud/+page.svelte:
   - Modified the onComplete handler to process extracted files directly
   - Simplified the code by removing the fallback to processing the original file
   - Updated memory requirement calculation to allocate more memory for zip/cbz files (5x instead of 3x)

3. Updated the worker-pool.ts:
   - Updated the logging to only include information about extracted files