### PR TITLE
Decompress zip/cbz files in download worker instead of main thread

### DIFF
--- a/src/lib/workers/download-worker.ts
+++ b/src/lib/workers/download-worker.ts
@@ -101,7 +101,7 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
     };
 
     return new Promise<void>((resolve, reject) => {
-      xhr.onload = () => {
+      xhr.onload = async () => {
         if (xhr.status >= 200 && xhr.status < 300) {
           try {
             // Get the ArrayBuffer response

--- a/src/lib/workers/download-worker.ts
+++ b/src/lib/workers/download-worker.ts
@@ -22,9 +22,8 @@ interface CompleteMessage {
   type: 'complete';
   fileId: string;
   fileName: string;
-  data: ArrayBuffer;
-  entries?: DecompressedEntry[];
-  isDecompressed?: boolean;
+  data: ArrayBuffer; // Empty buffer since we're sending the decompressed entries
+  entries: DecompressedEntry[];
 }
 
 interface ErrorMessage {
@@ -113,108 +112,63 @@ async function downloadFile(fileId: string, fileName: string, accessToken: strin
               status: xhr.status
             });
 
-            // Check if the file is a zip or cbz file
-            const isZipFile = fileName.toLowerCase().endsWith('.zip') || fileName.toLowerCase().endsWith('.cbz');
+            console.log(`Worker: Decompressing ${fileName}...`);
             
-            if (isZipFile) {
+            // Create a blob from the array buffer
+            const blob = new Blob([arrayBuffer]);
+            
+            // Create a zip reader
+            const zipReader = new ZipReader(new BlobReader(blob));
+            
+            // Get all entries from the zip file
+            const entries = await zipReader.getEntries();
+            
+            // Process each entry
+            const decompressedEntries: DecompressedEntry[] = [];
+            
+            for (const entry of entries) {
+              // Skip directories
+              if (entry.directory) continue;
+              
               try {
-                console.log(`Worker: Decompressing ${fileName}...`);
+                // Get the entry data as an array buffer
+                const entryData = await entry.getData(new Uint8Array) as Uint8Array;
                 
-                // Create a blob from the array buffer
-                const blob = new Blob([arrayBuffer]);
-                
-                // Create a zip reader
-                const zipReader = new ZipReader(new BlobReader(blob));
-                
-                // Get all entries from the zip file
-                const entries = await zipReader.getEntries();
-                
-                // Process each entry
-                const decompressedEntries: DecompressedEntry[] = [];
-                
-                for (const entry of entries) {
-                  // Skip directories
-                  if (entry.directory) continue;
-                  
-                  try {
-                    // Get the entry data as an array buffer
-                    const entryData = await entry.getData(new Uint8Array) as Uint8Array;
-                    
-                    // Add the entry to the decompressed entries
-                    decompressedEntries.push({
-                      filename: entry.filename,
-                      data: entryData.buffer
-                    });
-                  } catch (entryError) {
-                    console.error(`Worker: Error extracting entry ${entry.filename}:`, entryError);
-                  }
-                }
-                
-                // Close the zip reader
-                await zipReader.close();
-                
-                console.log(`Worker: Decompressed ${decompressedEntries.length} files from ${fileName}`);
-                
-                // Create a message with the decompressed entries
-                const completeMessage: CompleteMessage = {
-                  type: 'complete',
-                  fileId,
-                  fileName,
-                  data: new ArrayBuffer(0), // Empty buffer since we're sending the decompressed entries
-                  entries: decompressedEntries,
-                  isDecompressed: true
-                };
-                
-                console.log(`Worker: Sending complete message for ${fileName} with ${decompressedEntries.length} decompressed entries`);
-                
-                // Create an array of transferable objects (the entry data array buffers)
-                const transferables = decompressedEntries.map(entry => entry.data);
-                
-                console.log(`Worker: Sending ${transferables.length} transferable objects`);
-                
-                // Post the message with the transferable objects
-                ctx.postMessage(completeMessage, transferables);
-                console.log(`Worker: Message posted for ${fileName}`);
-                resolve();
-              } catch (decompressError) {
-                console.error(`Worker: Error decompressing ${fileName}:`, decompressError);
-                
-                // If decompression fails, fall back to sending the original file
-                const completeMessage: CompleteMessage = {
-                  type: 'complete',
-                  fileId,
-                  fileName,
-                  data: arrayBuffer,
-                  isDecompressed: false
-                };
-                
-                console.log(`Worker: Sending original file for ${fileName} due to decompression error`);
-                
-                // Post the message with the ArrayBuffer as a transferable object
-                ctx.postMessage(completeMessage, [arrayBuffer]);
-                console.log(`Worker: Message posted for ${fileName}`);
-                resolve();
+                // Add the entry to the decompressed entries
+                decompressedEntries.push({
+                  filename: entry.filename,
+                  data: entryData.buffer
+                });
+              } catch (entryError) {
+                console.error(`Worker: Error extracting entry ${entry.filename}:`, entryError);
               }
-            } else {
-              // Not a zip/cbz file, send the original file
-              const completeMessage: CompleteMessage = {
-                type: 'complete',
-                fileId,
-                fileName,
-                data: arrayBuffer,
-                isDecompressed: false
-              };
-              
-              console.log(`Worker: Sending complete message for ${fileName}`, {
-                messageType: 'complete',
-                dataSize: arrayBuffer.byteLength
-              });
-              
-              // Post the message with the ArrayBuffer as a transferable object
-              ctx.postMessage(completeMessage, [arrayBuffer]);
-              console.log(`Worker: Message posted for ${fileName}`);
-              resolve();
             }
+            
+            // Close the zip reader
+            await zipReader.close();
+            
+            console.log(`Worker: Decompressed ${decompressedEntries.length} files from ${fileName}`);
+            
+            // Create a message with the decompressed entries
+            const completeMessage: CompleteMessage = {
+              type: 'complete',
+              fileId,
+              fileName,
+              data: new ArrayBuffer(0), // Empty buffer since we're sending the decompressed entries
+              entries: decompressedEntries
+            };
+            
+            console.log(`Worker: Sending complete message for ${fileName} with ${decompressedEntries.length} decompressed entries`);
+            
+            // Create an array of transferable objects (the entry data array buffers)
+            const transferables = decompressedEntries.map(entry => entry.data);
+            
+            console.log(`Worker: Sending ${transferables.length} transferable objects`);
+            
+            // Post the message with the transferable objects
+            ctx.postMessage(completeMessage, transferables);
+            console.log(`Worker: Message posted for ${fileName}`);
+            resolve();
           } catch (error) {
             console.error('Worker: Error processing response:', error);
             const errorMessage: ErrorMessage = {

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -596,42 +596,21 @@
           onComplete: async (data, releaseMemory) => {
             try {
               console.log(`Received complete message for ${data.fileName}`, {
-                dataType: typeof data.data,
-                dataSize: data.data?.byteLength,
-                hasData: !!data.data,
-                isDecompressed: data.isDecompressed,
                 entriesCount: data.entries?.length
               });
 
-              if (data.isDecompressed && data.entries && data.entries.length > 0) {
-                console.log(`Processing ${data.entries.length} decompressed entries from ${data.fileName}`);
-                
-                // Create File objects for each entry
-                const files = data.entries.map(entry => {
-                  return new File([entry.data], entry.filename);
-                });
-                
-                console.log(`Created ${files.length} file objects from decompressed entries`);
-                
-                // Process all the files
-                await processFiles(files);
-                console.log(`Successfully processed ${files.length} decompressed files from ${data.fileName}`);
-              } else {
-                // Handle the original file (either not a zip/cbz or decompression failed)
-                console.log(`Processing original file: ${data.fileName}`);
-                
-                // Create a Blob from the ArrayBuffer
-                const blob = new Blob([data.data]);
-                console.log(`Created blob of size ${blob.size} bytes`);
-
-                // Create a File object from the blob
-                const file = new File([blob], data.fileName);
-                console.log(`Created file object: ${file.name}, size: ${file.size} bytes`);
-
-                // Process the file
-                await processFiles([file]);
-                console.log(`Successfully processed file: ${file.name}`);
-              }
+              console.log(`Processing ${data.entries.length} decompressed entries from ${data.fileName}`);
+              
+              // Create File objects for each entry
+              const files = data.entries.map(entry => {
+                return new File([entry.data], entry.filename);
+              });
+              
+              console.log(`Created ${files.length} file objects from decompressed entries`);
+              
+              // Process all the files
+              await processFiles(files);
+              console.log(`Successfully processed ${files.length} decompressed files from ${data.fileName}`);
 
               // Mark as completed
               completedFiles++;

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -597,21 +597,41 @@
             try {
               console.log(`Received complete message for ${data.fileName}`, {
                 dataType: typeof data.data,
-                dataSize: data.data.byteLength,
-                hasData: !!data.data
+                dataSize: data.data?.byteLength,
+                hasData: !!data.data,
+                isDecompressed: data.isDecompressed,
+                entriesCount: data.entries?.length
               });
 
-              // Create a Blob from the ArrayBuffer
-              const blob = new Blob([data.data]);
-              console.log(`Created blob of size ${blob.size} bytes`);
+              if (data.isDecompressed && data.entries && data.entries.length > 0) {
+                console.log(`Processing ${data.entries.length} decompressed entries from ${data.fileName}`);
+                
+                // Create File objects for each entry
+                const files = data.entries.map(entry => {
+                  return new File([entry.data], entry.filename);
+                });
+                
+                console.log(`Created ${files.length} file objects from decompressed entries`);
+                
+                // Process all the files
+                await processFiles(files);
+                console.log(`Successfully processed ${files.length} decompressed files from ${data.fileName}`);
+              } else {
+                // Handle the original file (either not a zip/cbz or decompression failed)
+                console.log(`Processing original file: ${data.fileName}`);
+                
+                // Create a Blob from the ArrayBuffer
+                const blob = new Blob([data.data]);
+                console.log(`Created blob of size ${blob.size} bytes`);
 
-              // Create a File object from the blob
-              const file = new File([blob], data.fileName);
-              console.log(`Created file object: ${file.name}, size: ${file.size} bytes`);
+                // Create a File object from the blob
+                const file = new File([blob], data.fileName);
+                console.log(`Created file object: ${file.name}, size: ${file.size} bytes`);
 
-              // Process the file
-              await processFiles([file]);
-              console.log(`Successfully processed file: ${file.name}`);
+                // Process the file
+                await processFiles([file]);
+                console.log(`Successfully processed file: ${file.name}`);
+              }
 
               // Mark as completed
               completedFiles++;


### PR DESCRIPTION
This PR modifies the download worker to decompress zip/cbz files directly in the worker thread instead of passing them to the main thread for decompression. This improves performance by offloading the decompression work to the worker thread and reduces the amount of data that needs to be transferred between threads.

Changes:
1. Added decompression functionality to the download worker using @zip.js/zip.js
2. Modified the worker to always decompress files (since all files from Google Drive are zip/cbz)
3. Updated the main thread to handle decompressed files
4. Removed all fallback code to simplify the implementation