### PR TITLE
Implement refresh token handling for Google Drive authentication

### DIFF
--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -201,7 +201,9 @@
   }
 
   export async function connectDrive(resp?: any) {
+    console.log('connectDrive called with response:', resp ? 'Response object received' : 'No response');
     if (resp?.error !== undefined) {
+      console.error('Error in connectDrive:', resp.error);
       localStorage.removeItem('gdrive_refresh_token');
       accessToken = '';
       throw resp;
@@ -209,11 +211,15 @@
 
     // Set the access token in memory
     accessToken = resp?.access_token;
+    console.log('Access token set in memory:', accessToken ? 'Yes' : 'No');
     
     // Store the refresh token in localStorage if provided
     if (resp?.refresh_token) {
+      console.log('Refresh token received, storing in localStorage');
       localStorage.setItem('gdrive_refresh_token', resp.refresh_token);
-      console.log('Refresh token stored');
+      console.log('Refresh token stored successfully');
+    } else {
+      console.log('No refresh token in response');
     }
 
     const processId = 'connect-drive';
@@ -304,6 +310,7 @@
   }
 
   function signIn() {
+    console.log('Sign in clicked, requesting access token with offline access');
     // Always show the account picker to allow switching accounts
     // Request offline access to get a refresh token
     tokenClient.requestAccessToken({ 
@@ -416,16 +423,35 @@
   // Function to initialize Google API client and token client
   async function initializeGoogleAPI() {
     try {
+      // Check if gapi is available
+      if (!window.gapi) {
+        console.error('Google API client library not loaded');
+        return false;
+      }
+      
+      // Check if google.accounts.oauth2 is available
+      if (!window.google?.accounts?.oauth2) {
+        console.error('Google Identity Services library not loaded');
+        return false;
+      }
+      
+      console.log('Loading Google API client');
       await new Promise<void>((resolve) => {
-        gapi.load('client', () => resolve());
+        gapi.load('client', () => {
+          console.log('Google API client loaded');
+          resolve();
+        });
       });
       
+      console.log('Initializing Google API client with API key and discovery docs');
       await gapi.client.init({
         apiKey: API_KEY,
         discoveryDocs: [DISCOVERY_DOC]
       });
+      console.log('Google API client initialized successfully');
 
       // Initialize token client after gapi client is ready
+      console.log('Initializing token client');
       tokenClient = google.accounts.oauth2.initTokenClient({
         client_id: CLIENT_ID,
         scope: SCOPES,
@@ -433,6 +459,7 @@
         // Request offline access to get a refresh token
         access_type: 'offline'
       });
+      console.log('Token client initialized successfully');
       
       return true;
     } catch (error) {
@@ -444,9 +471,14 @@
   
   // Function to refresh token using the saved refresh token
   async function refreshTokenWithSavedRefreshToken(): Promise<boolean> {
+    console.log('Attempting to refresh token with saved refresh token');
+    
+    // Check if we have a saved refresh token
     const savedRefreshToken = localStorage.getItem('gdrive_refresh_token');
+    console.log('Saved refresh token found:', savedRefreshToken ? 'Yes' : 'No');
+    
     if (!savedRefreshToken) {
-      console.log('No saved refresh token found');
+      console.log('No saved refresh token found, cannot refresh token');
       return false;
     }
     
@@ -455,33 +487,44 @@
       
       // Create a promise that will resolve when the token is refreshed
       return await new Promise<boolean>((resolve) => {
+        console.log('Setting up token refresh promise');
+        
         // Store the original callback
         const originalCallback = tokenClient.callback;
+        console.log('Original callback stored:', originalCallback ? 'Yes' : 'No');
         
         // Override the callback temporarily
         tokenClient.callback = (resp) => {
+          console.log('Token refresh callback received response:', resp ? 'Yes' : 'No');
+          
           // Restore the original callback
           tokenClient.callback = originalCallback;
+          console.log('Original callback restored');
           
           if (resp?.error) {
-            console.error('Token refresh failed:', resp.error);
+            console.error('Token refresh failed with error:', resp.error);
             // If there's an error with the refresh token, we'll need to re-authenticate
             localStorage.removeItem('gdrive_refresh_token');
             resolve(false);
           } else {
             // Set the access token directly so the UI updates immediately
             accessToken = resp.access_token;
-            console.log('Successfully refreshed token on page load, accessToken set');
+            console.log('Successfully refreshed token, accessToken set:', accessToken ? 'Yes' : 'No');
             
             // Call the original callback to handle the rest of the connection process
-            if (originalCallback) originalCallback(resp);
+            if (originalCallback) {
+              console.log('Calling original callback with response');
+              originalCallback(resp);
+            }
             resolve(true);
           }
         };
         
         // Request a new access token using the refresh token without prompting the user
         try {
+          console.log('Requesting access token without prompt');
           tokenClient.requestAccessToken({ prompt: '' });
+          console.log('Access token request sent');
         } catch (error) {
           console.error('Error requesting access token:', error);
           localStorage.removeItem('gdrive_refresh_token');
@@ -498,25 +541,38 @@
 
   onMount(async () => {
     console.log('Cloud component mounted');
+    console.log('Initial accessToken state:', accessToken ? 'set' : 'not set');
+    console.log('Refresh token in localStorage:', localStorage.getItem('gdrive_refresh_token') ? 'Yes' : 'No');
     
     // Clear service worker cache for Google Drive downloads
-    clearServiceWorkerCache();
+    await clearServiceWorkerCache();
+    console.log('Service worker cache cleared');
     
     // Initialize Google API client
+    console.log('Initializing Google API client');
     const initialized = await initializeGoogleAPI();
+    console.log('Google API client initialized:', initialized ? 'Yes' : 'No');
+    
     if (!initialized) {
       console.error('Failed to initialize Google API');
       return;
     }
     
     // Load the picker API
+    console.log('Loading picker API');
     await new Promise<void>((resolve) => {
-      gapi.load('picker', () => resolve());
+      gapi.load('picker', () => {
+        console.log('Picker API loaded');
+        resolve();
+      });
     });
     
     // Try to refresh token with saved refresh token
+    console.log('Attempting to refresh token');
     const refreshed = await refreshTokenWithSavedRefreshToken();
-    console.log('Token refresh result:', refreshed, 'accessToken:', accessToken ? 'set' : 'not set');
+    console.log('Token refresh completed with result:', refreshed);
+    console.log('Final accessToken state:', accessToken ? 'set' : 'not set');
+    console.log('Refresh token in localStorage after refresh attempt:', localStorage.getItem('gdrive_refresh_token') ? 'Yes' : 'No');
   });
 
   function createPicker() {

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -204,7 +204,6 @@
     console.log('connectDrive called with response:', resp ? 'Response object received' : 'No response');
     if (resp?.error !== undefined) {
       console.error('Error in connectDrive:', resp.error);
-      localStorage.removeItem('gdrive_refresh_token');
       accessToken = '';
       throw resp;
     }
@@ -219,30 +218,8 @@
       localStorage.setItem('gdrive_refresh_token', resp.refresh_token);
       console.log('Refresh token stored successfully');
     } else {
-      console.log('No refresh token in response, this may cause login persistence issues');
+      console.log('No refresh token in response');
       console.log('Current scopes:', resp?.scope);
-      
-      // Check if we already have a refresh token
-      const existingRefreshToken = localStorage.getItem('gdrive_refresh_token');
-      if (!existingRefreshToken) {
-        console.log('No existing refresh token found. This will require re-authentication on page refresh.');
-        console.log('This typically happens when prompt is not set to "consent" or access_type is not "offline"');
-        
-        // Force a new sign-in to get a refresh token
-        console.log('Forcing a new sign-in to get a refresh token');
-        setTimeout(() => {
-          signIn();
-        }, 100);
-        return;
-      } else {
-        console.log('Using existing refresh token from localStorage');
-      }
-    }
-    
-    // Store the access token in localStorage as well for immediate use after page refresh
-    if (accessToken) {
-      localStorage.setItem('gdrive_access_token', accessToken);
-      console.log('Access token stored in localStorage');
     }
 
     const processId = 'connect-drive';
@@ -339,28 +316,25 @@
     // or when prompt='consent' is specified. We need to force the consent screen
     // to appear every time to ensure we get a refresh token.
     
-    // Clear any existing tokens to ensure we get a fresh refresh token
-    localStorage.removeItem('gdrive_refresh_token');
+    // Clear the access token from memory
     accessToken = '';
     
     // Always show the account picker to allow switching accounts
     // Request offline access to get a refresh token
     tokenClient.requestAccessToken({ 
       // Force the consent screen to appear every time
-      prompt: 'consent',
+      prompt: 'consent select_account',
       // Request offline access to get a refresh token
       access_type: 'offline'
     });
   }
 
   export function logout() {
-    // Get tokens before clearing
+    // Get refresh token before clearing
     const refreshToken = localStorage.getItem('gdrive_refresh_token');
-    const storedAccessToken = localStorage.getItem('gdrive_access_token');
     
-    // Remove tokens from localStorage
+    // Remove refresh token from localStorage
     localStorage.removeItem('gdrive_refresh_token');
-    localStorage.removeItem('gdrive_access_token');
 
     // Clear the access token from memory
     accessToken = '';
@@ -392,16 +366,6 @@
           console.error('Error revoking refresh token:', error);
         });
       }
-    } else if (storedAccessToken) {
-      // If we have a stored access token but not in gapi client, revoke it too
-      fetch(`https://oauth2.googleapis.com/revoke?token=${storedAccessToken}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded'
-        }
-      }).catch((error) => {
-        console.error('Error revoking stored access token:', error);
-      });
     }
     
     console.log('Logged out and cleared all tokens');
@@ -505,10 +469,7 @@
         scope: SCOPES,
         callback: connectDrive,
         // Request offline access to get a refresh token
-        access_type: 'offline',
-        // This is critical: prompt must be set to 'consent' to ensure we get a refresh token
-        // every time, even if the user has already granted permission
-        prompt: 'consent'
+        access_type: 'offline'
       });
       console.log('Token client initialized successfully');
       
@@ -576,10 +537,9 @@
           console.log('Requesting access token without prompt');
           // The key issue: we need to use the refresh token to get a new access token
           // but Google's OAuth2 client doesn't directly expose a refresh token API
-          // Instead, we use requestAccessToken with prompt: '' to use the stored refresh token
+          // Instead, we use requestAccessToken with prompt: 'none' to use the stored refresh token
           tokenClient.requestAccessToken({ 
-            prompt: '', 
-            access_type: 'offline'
+            prompt: 'none'
           });
           console.log('Access token request sent');
         } catch (error) {
@@ -600,11 +560,9 @@
     console.log('Cloud component mounted');
     console.log('Initial accessToken state:', accessToken ? 'set' : 'not set');
     
-    // Check for stored tokens in localStorage
+    // Check for refresh token in localStorage
     const savedRefreshToken = localStorage.getItem('gdrive_refresh_token');
-    const savedAccessToken = localStorage.getItem('gdrive_access_token');
     console.log('Refresh token in localStorage:', savedRefreshToken ? 'Yes' : 'No');
-    console.log('Access token in localStorage:', savedAccessToken ? 'Yes' : 'No');
     
     // Clear service worker cache for Google Drive downloads
     await clearServiceWorkerCache();
@@ -629,21 +587,15 @@
       });
     });
     
-    // First try to use the saved access token if available
-    if (savedAccessToken && !accessToken) {
-      console.log('Using saved access token from localStorage');
-      accessToken = savedAccessToken;
-    }
-    
-    // If we still don't have an access token but have a refresh token, try to refresh
-    if (!accessToken && savedRefreshToken) {
+    // If we have a refresh token, try to refresh the access token
+    if (savedRefreshToken) {
       console.log('Found saved refresh token, attempting to refresh access token');
       const refreshed = await refreshTokenWithSavedRefreshToken();
       console.log('Token refresh completed with result:', refreshed);
       console.log('Final accessToken state:', accessToken ? 'set' : 'not set');
       console.log('Refresh token in localStorage after refresh attempt:', localStorage.getItem('gdrive_refresh_token') ? 'Yes' : 'No');
-    } else if (!accessToken) {
-      console.log('No valid tokens found in localStorage, user will need to sign in');
+    } else {
+      console.log('No refresh token found in localStorage, user will need to sign in');
     }
   });
 

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -374,9 +374,13 @@
           tokenClient.callback = originalCallback;
           
           if (resp?.error) {
+            console.error('Token refresh failed:', resp.error);
             reject(new Error(`Token refresh failed: ${resp.error}`));
           } else {
-            // Call the original callback to update the token
+            // Set the access token directly so the UI updates immediately
+            accessToken = resp.access_token;
+            
+            // Call the original callback to handle the rest of the connection process
             if (originalCallback) originalCallback(resp);
             resolve();
           }
@@ -464,9 +468,43 @@
         if (savedRefreshToken) {
           try {
             console.log('Found saved refresh token, requesting new access token');
-            // Request a new access token using the refresh token
-            // This will call the connectDrive callback with a new access token
-            tokenClient.requestAccessToken({ prompt: '' });
+            
+            // Create a promise that will resolve when the token is refreshed
+            const tokenRefreshPromise = new Promise<void>((resolve, reject) => {
+              // Store the original callback
+              const originalCallback = tokenClient.callback;
+              
+              // Override the callback temporarily
+              tokenClient.callback = (resp) => {
+                // Restore the original callback
+                tokenClient.callback = originalCallback;
+                
+                if (resp?.error) {
+                  console.error('Token refresh failed:', resp.error);
+                  reject(new Error(`Token refresh failed: ${resp.error}`));
+                } else {
+                  // Set the access token directly so the UI updates immediately
+                  accessToken = resp.access_token;
+                  
+                  // Call the original callback to handle the rest of the connection process
+                  if (originalCallback) originalCallback(resp);
+                  resolve();
+                }
+              };
+              
+              // Request a new access token using the refresh token without prompting the user
+              tokenClient.requestAccessToken({ prompt: '' });
+            });
+            
+            try {
+              // Wait for the token refresh to complete
+              await tokenRefreshPromise;
+              console.log('Successfully refreshed token on page load');
+            } catch (refreshError) {
+              console.error('Failed to refresh token on page load:', refreshError);
+              // If there's an error with the refresh token, we'll need to re-authenticate
+              localStorage.removeItem('gdrive_refresh_token');
+            }
           } catch (error) {
             console.error('Failed to use refresh token:', error);
             // If there's an error with the refresh token, we'll need to re-authenticate

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -219,7 +219,17 @@
       localStorage.setItem('gdrive_refresh_token', resp.refresh_token);
       console.log('Refresh token stored successfully');
     } else {
-      console.log('No refresh token in response');
+      console.log('No refresh token in response, this may cause login persistence issues');
+      console.log('Current scopes:', resp?.scope);
+      
+      // Check if we already have a refresh token
+      const existingRefreshToken = localStorage.getItem('gdrive_refresh_token');
+      if (!existingRefreshToken) {
+        console.log('No existing refresh token found. This will require re-authentication on page refresh.');
+        console.log('This typically happens when prompt is not set to "consent" or access_type is not "offline"');
+      } else {
+        console.log('Using existing refresh token from localStorage');
+      }
     }
 
     const processId = 'connect-drive';
@@ -311,10 +321,17 @@
 
   function signIn() {
     console.log('Sign in clicked, requesting access token with offline access');
+    
+    // The key issue: Google only returns a refresh token on the first authorization
+    // or when prompt='consent' is specified. We need to force the consent screen
+    // to appear every time to ensure we get a refresh token.
+    
     // Always show the account picker to allow switching accounts
     // Request offline access to get a refresh token
     tokenClient.requestAccessToken({ 
+      // Force the consent screen to appear every time
       prompt: 'consent',
+      // Request offline access to get a refresh token
       access_type: 'offline'
     });
   }
@@ -457,7 +474,10 @@
         scope: SCOPES,
         callback: connectDrive,
         // Request offline access to get a refresh token
-        access_type: 'offline'
+        access_type: 'offline',
+        // This is critical: prompt must be set to 'consent' to ensure we get a refresh token
+        // every time, even if the user has already granted permission
+        prompt: 'consent'
       });
       console.log('Token client initialized successfully');
       
@@ -523,7 +543,13 @@
         // Request a new access token using the refresh token without prompting the user
         try {
           console.log('Requesting access token without prompt');
-          tokenClient.requestAccessToken({ prompt: '' });
+          // The key issue: we need to use the refresh token to get a new access token
+          // but Google's OAuth2 client doesn't directly expose a refresh token API
+          // Instead, we use requestAccessToken with prompt: '' to use the stored refresh token
+          tokenClient.requestAccessToken({ 
+            prompt: '', 
+            access_type: 'offline'
+          });
           console.log('Access token request sent');
         } catch (error) {
           console.error('Error requesting access token:', error);
@@ -542,7 +568,10 @@
   onMount(async () => {
     console.log('Cloud component mounted');
     console.log('Initial accessToken state:', accessToken ? 'set' : 'not set');
-    console.log('Refresh token in localStorage:', localStorage.getItem('gdrive_refresh_token') ? 'Yes' : 'No');
+    
+    // Check for refresh token in localStorage
+    const savedRefreshToken = localStorage.getItem('gdrive_refresh_token');
+    console.log('Refresh token in localStorage:', savedRefreshToken ? 'Yes' : 'No');
     
     // Clear service worker cache for Google Drive downloads
     await clearServiceWorkerCache();
@@ -567,12 +596,16 @@
       });
     });
     
-    // Try to refresh token with saved refresh token
-    console.log('Attempting to refresh token');
-    const refreshed = await refreshTokenWithSavedRefreshToken();
-    console.log('Token refresh completed with result:', refreshed);
-    console.log('Final accessToken state:', accessToken ? 'set' : 'not set');
-    console.log('Refresh token in localStorage after refresh attempt:', localStorage.getItem('gdrive_refresh_token') ? 'Yes' : 'No');
+    // Only try to refresh token if we have a saved refresh token
+    if (savedRefreshToken) {
+      console.log('Found saved refresh token, attempting to refresh access token');
+      const refreshed = await refreshTokenWithSavedRefreshToken();
+      console.log('Token refresh completed with result:', refreshed);
+      console.log('Final accessToken state:', accessToken ? 'set' : 'not set');
+      console.log('Refresh token in localStorage after refresh attempt:', localStorage.getItem('gdrive_refresh_token') ? 'Yes' : 'No');
+    } else {
+      console.log('No refresh token found in localStorage, user will need to sign in');
+    }
   });
 
   function createPicker() {

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -355,43 +355,13 @@
   // Helper function to refresh token and retry an operation
   async function refreshTokenAndRetry<T>(operation: () => Promise<T>): Promise<T> {
     try {
-      // Request a new token using the refresh token
-      const refreshToken = localStorage.getItem('gdrive_refresh_token');
-      if (!refreshToken) {
-        throw new Error('No refresh token available');
-      }
-
       console.log('Refreshing token and retrying operation');
       
-      // Create a promise that will resolve when the token is refreshed
-      const tokenRefreshPromise = new Promise<void>((resolve, reject) => {
-        // Store the original callback
-        const originalCallback = tokenClient.callback;
-        
-        // Override the callback temporarily
-        tokenClient.callback = (resp) => {
-          // Restore the original callback
-          tokenClient.callback = originalCallback;
-          
-          if (resp?.error) {
-            console.error('Token refresh failed:', resp.error);
-            reject(new Error(`Token refresh failed: ${resp.error}`));
-          } else {
-            // Set the access token directly so the UI updates immediately
-            accessToken = resp.access_token;
-            
-            // Call the original callback to handle the rest of the connection process
-            if (originalCallback) originalCallback(resp);
-            resolve();
-          }
-        };
-        
-        // Request a new access token without prompting the user
-        tokenClient.requestAccessToken({ prompt: '' });
-      });
-      
-      // Wait for the token to be refreshed
-      await tokenRefreshPromise;
+      // Use our helper function to refresh the token
+      const refreshed = await refreshTokenWithSavedRefreshToken();
+      if (!refreshed) {
+        throw new Error('Failed to refresh token');
+      }
       
       // Wait a moment for the token to be applied
       await new Promise(resolve => setTimeout(resolve, 500));
@@ -443,80 +413,110 @@
     }
   }
 
-  onMount(() => {
+  // Function to initialize Google API client and token client
+  async function initializeGoogleAPI() {
+    try {
+      await new Promise<void>((resolve) => {
+        gapi.load('client', () => resolve());
+      });
+      
+      await gapi.client.init({
+        apiKey: API_KEY,
+        discoveryDocs: [DISCOVERY_DOC]
+      });
+
+      // Initialize token client after gapi client is ready
+      tokenClient = google.accounts.oauth2.initTokenClient({
+        client_id: CLIENT_ID,
+        scope: SCOPES,
+        callback: connectDrive,
+        // Request offline access to get a refresh token
+        access_type: 'offline'
+      });
+      
+      return true;
+    } catch (error) {
+      console.error('Failed to initialize Google API:', error);
+      await handleDriveError(error, 'initializing Google Drive');
+      return false;
+    }
+  }
+  
+  // Function to refresh token using the saved refresh token
+  async function refreshTokenWithSavedRefreshToken(): Promise<boolean> {
+    const savedRefreshToken = localStorage.getItem('gdrive_refresh_token');
+    if (!savedRefreshToken) {
+      console.log('No saved refresh token found');
+      return false;
+    }
+    
+    try {
+      console.log('Found saved refresh token, requesting new access token');
+      
+      // Create a promise that will resolve when the token is refreshed
+      return await new Promise<boolean>((resolve) => {
+        // Store the original callback
+        const originalCallback = tokenClient.callback;
+        
+        // Override the callback temporarily
+        tokenClient.callback = (resp) => {
+          // Restore the original callback
+          tokenClient.callback = originalCallback;
+          
+          if (resp?.error) {
+            console.error('Token refresh failed:', resp.error);
+            // If there's an error with the refresh token, we'll need to re-authenticate
+            localStorage.removeItem('gdrive_refresh_token');
+            resolve(false);
+          } else {
+            // Set the access token directly so the UI updates immediately
+            accessToken = resp.access_token;
+            console.log('Successfully refreshed token on page load, accessToken set');
+            
+            // Call the original callback to handle the rest of the connection process
+            if (originalCallback) originalCallback(resp);
+            resolve(true);
+          }
+        };
+        
+        // Request a new access token using the refresh token without prompting the user
+        try {
+          tokenClient.requestAccessToken({ prompt: '' });
+        } catch (error) {
+          console.error('Error requesting access token:', error);
+          localStorage.removeItem('gdrive_refresh_token');
+          resolve(false);
+        }
+      });
+    } catch (error) {
+      console.error('Failed to use refresh token:', error);
+      // If there's an error with the refresh token, we'll need to re-authenticate
+      localStorage.removeItem('gdrive_refresh_token');
+      return false;
+    }
+  }
+
+  onMount(async () => {
+    console.log('Cloud component mounted');
+    
     // Clear service worker cache for Google Drive downloads
     clearServiceWorkerCache();
     
-    gapi.load('client', async () => {
-      try {
-        await gapi.client.init({
-          apiKey: API_KEY,
-          discoveryDocs: [DISCOVERY_DOC]
-        });
-
-        // Initialize token client after gapi client is ready
-        tokenClient = google.accounts.oauth2.initTokenClient({
-          client_id: CLIENT_ID,
-          scope: SCOPES,
-          callback: connectDrive,
-          // Request offline access to get a refresh token
-          access_type: 'offline'
-        });
-
-        // Try to restore using the refresh token
-        const savedRefreshToken = localStorage.getItem('gdrive_refresh_token');
-        if (savedRefreshToken) {
-          try {
-            console.log('Found saved refresh token, requesting new access token');
-            
-            // Create a promise that will resolve when the token is refreshed
-            const tokenRefreshPromise = new Promise<void>((resolve, reject) => {
-              // Store the original callback
-              const originalCallback = tokenClient.callback;
-              
-              // Override the callback temporarily
-              tokenClient.callback = (resp) => {
-                // Restore the original callback
-                tokenClient.callback = originalCallback;
-                
-                if (resp?.error) {
-                  console.error('Token refresh failed:', resp.error);
-                  reject(new Error(`Token refresh failed: ${resp.error}`));
-                } else {
-                  // Set the access token directly so the UI updates immediately
-                  accessToken = resp.access_token;
-                  
-                  // Call the original callback to handle the rest of the connection process
-                  if (originalCallback) originalCallback(resp);
-                  resolve();
-                }
-              };
-              
-              // Request a new access token using the refresh token without prompting the user
-              tokenClient.requestAccessToken({ prompt: '' });
-            });
-            
-            try {
-              // Wait for the token refresh to complete
-              await tokenRefreshPromise;
-              console.log('Successfully refreshed token on page load');
-            } catch (refreshError) {
-              console.error('Failed to refresh token on page load:', refreshError);
-              // If there's an error with the refresh token, we'll need to re-authenticate
-              localStorage.removeItem('gdrive_refresh_token');
-            }
-          } catch (error) {
-            console.error('Failed to use refresh token:', error);
-            // If there's an error with the refresh token, we'll need to re-authenticate
-            localStorage.removeItem('gdrive_refresh_token');
-          }
-        }
-      } catch (error) {
-        await handleDriveError(error, 'initializing Google Drive');
-      }
+    // Initialize Google API client
+    const initialized = await initializeGoogleAPI();
+    if (!initialized) {
+      console.error('Failed to initialize Google API');
+      return;
+    }
+    
+    // Load the picker API
+    await new Promise<void>((resolve) => {
+      gapi.load('picker', () => resolve());
     });
-
-    gapi.load('picker', () => {});
+    
+    // Try to refresh token with saved refresh token
+    const refreshed = await refreshTokenWithSavedRefreshToken();
+    console.log('Token refresh result:', refreshed, 'accessToken:', accessToken ? 'set' : 'not set');
   });
 
   function createPicker() {
@@ -1179,6 +1179,11 @@
       <p class="text-center text-sm text-gray-500">
         You can select multiple ZIP/CBZ files or entire folders at once.
       </p>
+      {#if import.meta.env.DEV}
+        <div class="text-xs text-gray-400 bg-gray-800 p-2 rounded">
+          Debug info: Access token is set. Token length: {accessToken.length}
+        </div>
+      {/if}
       <div class="flex flex-col gap-4 w-full max-w-3xl">
         <Button color="blue" on:click={createPicker}>Download Manga</Button>
         
@@ -1236,7 +1241,13 @@
       </div>
     </div>
   {:else}
-    <div class="flex justify-center pt-0 sm:pt-32">
+    <div class="flex flex-col items-center gap-4 pt-0 sm:pt-32">
+      {#if import.meta.env.DEV}
+        <div class="text-xs text-gray-400 bg-gray-800 p-2 rounded mb-4 max-w-3xl">
+          Debug info: Access token is not set. 
+          Refresh token in localStorage: {localStorage.getItem('gdrive_refresh_token') ? 'Yes' : 'No'}
+        </div>
+      {/if}
       <button
         class="w-full border rounded-lg border-slate-600 p-10 border-opacity-50 hover:bg-slate-800 max-w-3xl"
         onclick={signIn}

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -227,9 +227,22 @@
       if (!existingRefreshToken) {
         console.log('No existing refresh token found. This will require re-authentication on page refresh.');
         console.log('This typically happens when prompt is not set to "consent" or access_type is not "offline"');
+        
+        // Force a new sign-in to get a refresh token
+        console.log('Forcing a new sign-in to get a refresh token');
+        setTimeout(() => {
+          signIn();
+        }, 100);
+        return;
       } else {
         console.log('Using existing refresh token from localStorage');
       }
+    }
+    
+    // Store the access token in localStorage as well for immediate use after page refresh
+    if (accessToken) {
+      localStorage.setItem('gdrive_access_token', accessToken);
+      console.log('Access token stored in localStorage');
     }
 
     const processId = 'connect-drive';
@@ -326,6 +339,10 @@
     // or when prompt='consent' is specified. We need to force the consent screen
     // to appear every time to ensure we get a refresh token.
     
+    // Clear any existing tokens to ensure we get a fresh refresh token
+    localStorage.removeItem('gdrive_refresh_token');
+    accessToken = '';
+    
     // Always show the account picker to allow switching accounts
     // Request offline access to get a refresh token
     tokenClient.requestAccessToken({ 
@@ -337,11 +354,13 @@
   }
 
   export function logout() {
-    // Get refresh token before clearing
+    // Get tokens before clearing
     const refreshToken = localStorage.getItem('gdrive_refresh_token');
+    const storedAccessToken = localStorage.getItem('gdrive_access_token');
     
-    // Remove refresh token from localStorage
+    // Remove tokens from localStorage
     localStorage.removeItem('gdrive_refresh_token');
+    localStorage.removeItem('gdrive_access_token');
 
     // Clear the access token from memory
     accessToken = '';
@@ -373,7 +392,19 @@
           console.error('Error revoking refresh token:', error);
         });
       }
+    } else if (storedAccessToken) {
+      // If we have a stored access token but not in gapi client, revoke it too
+      fetch(`https://oauth2.googleapis.com/revoke?token=${storedAccessToken}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        }
+      }).catch((error) => {
+        console.error('Error revoking stored access token:', error);
+      });
     }
+    
+    console.log('Logged out and cleared all tokens');
   }
 
   // Helper function to refresh token and retry an operation
@@ -569,9 +600,11 @@
     console.log('Cloud component mounted');
     console.log('Initial accessToken state:', accessToken ? 'set' : 'not set');
     
-    // Check for refresh token in localStorage
+    // Check for stored tokens in localStorage
     const savedRefreshToken = localStorage.getItem('gdrive_refresh_token');
+    const savedAccessToken = localStorage.getItem('gdrive_access_token');
     console.log('Refresh token in localStorage:', savedRefreshToken ? 'Yes' : 'No');
+    console.log('Access token in localStorage:', savedAccessToken ? 'Yes' : 'No');
     
     // Clear service worker cache for Google Drive downloads
     await clearServiceWorkerCache();
@@ -596,15 +629,21 @@
       });
     });
     
-    // Only try to refresh token if we have a saved refresh token
-    if (savedRefreshToken) {
+    // First try to use the saved access token if available
+    if (savedAccessToken && !accessToken) {
+      console.log('Using saved access token from localStorage');
+      accessToken = savedAccessToken;
+    }
+    
+    // If we still don't have an access token but have a refresh token, try to refresh
+    if (!accessToken && savedRefreshToken) {
       console.log('Found saved refresh token, attempting to refresh access token');
       const refreshed = await refreshTokenWithSavedRefreshToken();
       console.log('Token refresh completed with result:', refreshed);
       console.log('Final accessToken state:', accessToken ? 'set' : 'not set');
       console.log('Refresh token in localStorage after refresh attempt:', localStorage.getItem('gdrive_refresh_token') ? 'Yes' : 'No');
-    } else {
-      console.log('No refresh token found in localStorage, user will need to sign in');
+    } else if (!accessToken) {
+      console.log('No valid tokens found in localStorage, user will need to sign in');
     }
   });
 


### PR DESCRIPTION
This PR implements a more robust Google Drive authentication system using refresh tokens.

## Changes:
- Store only refresh token in localStorage instead of access token for better security
- Silently refresh access token when API reports token expiration
- Automatically retry failed operations after token refresh
- Add helper function for token refresh and retry operations
- Improve error handling for authentication issues

## Benefits:
- Users won't need to log in as frequently
- Long-running operations won't fail due to token expiration
- More secure token handling (access tokens not stored in localStorage)
- Better error handling and recovery from authentication issues