### PR TITLE
Add night mode with SVG filter for red-only display

### DIFF
--- a/src/lib/components/NightModeFilter.svelte
+++ b/src/lib/components/NightModeFilter.svelte
@@ -5,9 +5,9 @@
 
   // Create elements to hold our filter
   let styleElement: HTMLStyleElement | null = null;
-  let svgElement: SVGElement | null = null;
+  let canvasElement: HTMLCanvasElement | null = null;
 
-  // Function to apply the night mode filter using SVG filter
+  // Function to apply the night mode filter using a canvas-based approach
   function applyNightModeFilter() {
     if (!browser) return;
     
@@ -17,37 +17,27 @@
       document.head.appendChild(styleElement);
     }
     
-    // Create SVG filter element if it doesn't exist
-    if (!svgElement) {
-      svgElement = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-      svgElement.setAttribute('width', '0');
-      svgElement.setAttribute('height', '0');
-      svgElement.style.position = 'absolute';
-      svgElement.style.zIndex = '-9999';
-      svgElement.innerHTML = `
-        <defs>
-          <filter id="night-mode-filter">
-            <!-- This implements the exact color matrix:
-                 [-1/3, -1/3, -1/3, 0, 255,  // red channel
-                  0, 0, 0, 0, 0,             // green channel
-                  0, 0, 0, 0, 0,             // blue channel
-                  0, 0, 0, 1, 0]             // alpha channel -->
-            <feColorMatrix type="matrix" 
-              values="-0.333 -0.333 -0.333 0 255
-                      0 0 0 0 0
-                      0 0 0 0 0
-                      0 0 0 1 0" />
-          </filter>
-        </defs>
-      `;
-      document.body.appendChild(svgElement);
-    }
-    
-    // Apply the SVG filter that exactly matches the color matrix
+    // Apply the CSS filter
     if ($settings.nightMode) {
+      // This CSS implementation is a close approximation of the Flutter color matrix
+      // It preserves black as black while converting other colors to red based on luminosity
       styleElement.textContent = `
         html {
-          filter: url(#night-mode-filter) !important;
+          filter: grayscale(100%) brightness(0.8) !important;
+        }
+        
+        /* Create a red overlay with multiply blend mode to preserve blacks */
+        html::before {
+          content: "";
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background-color: red;
+          mix-blend-mode: multiply;
+          pointer-events: none;
+          z-index: 9999;
         }
       `;
     } else {
@@ -70,11 +60,11 @@
       if (styleElement) {
         styleElement.remove();
       }
-      if (svgElement) {
-        svgElement.remove();
+      if (canvasElement) {
+        canvasElement.remove();
       }
     }
   });
 </script>
 
-<!-- This component doesn't render any visible elements, it just applies the SVG filter -->
+<!-- This component doesn't render any visible elements, it just applies the CSS filter -->

--- a/src/lib/components/NightModeFilter.svelte
+++ b/src/lib/components/NightModeFilter.svelte
@@ -5,9 +5,9 @@
 
   // Create elements to hold our filter
   let styleElement: HTMLStyleElement | null = null;
-  let canvasElement: HTMLCanvasElement | null = null;
+  let svgElement: SVGElement | null = null;
 
-  // Function to apply the night mode filter using a canvas-based approach
+  // Function to apply the night mode filter
   function applyNightModeFilter() {
     if (!browser) return;
     
@@ -17,27 +17,47 @@
       document.head.appendChild(styleElement);
     }
     
-    // Apply the CSS filter
+    // Create SVG filter element if it doesn't exist
+    if (!svgElement) {
+      svgElement = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svgElement.setAttribute('width', '0');
+      svgElement.setAttribute('height', '0');
+      svgElement.style.position = 'absolute';
+      svgElement.style.zIndex = '-9999';
+      
+      // This implements a filter that approximates the Flutter color matrix:
+      // [-1/3, -1/3, -1/3, 0, 255,  // red channel
+      //  0, 0, 0, 0, 0,             // green channel
+      //  0, 0, 0, 0, 0,             // blue channel
+      //  0, 0, 0, 1, 0]             // alpha channel
+      
+      svgElement.innerHTML = `
+        <defs>
+          <filter id="night-mode-filter">
+            <!-- Convert to grayscale first -->
+            <feColorMatrix type="matrix" 
+              values="0.2126 0.7152 0.0722 0 0
+                      0.2126 0.7152 0.0722 0 0
+                      0.2126 0.7152 0.0722 0 0
+                      0 0 0 1 0" />
+                      
+            <!-- Keep only the red channel -->
+            <feColorMatrix type="matrix"
+              values="1 0 0 0 0
+                      0 0 0 0 0
+                      0 0 0 0 0
+                      0 0 0 1 0" />
+          </filter>
+        </defs>
+      `;
+      document.body.appendChild(svgElement);
+    }
+    
+    // Apply the filter
     if ($settings.nightMode) {
-      // This CSS implementation is a close approximation of the Flutter color matrix
-      // It preserves black as black while converting other colors to red based on luminosity
       styleElement.textContent = `
         html {
-          filter: grayscale(100%) brightness(0.8) !important;
-        }
-        
-        /* Create a red overlay with multiply blend mode to preserve blacks */
-        html::before {
-          content: "";
-          position: fixed;
-          top: 0;
-          left: 0;
-          width: 100%;
-          height: 100%;
-          background-color: red;
-          mix-blend-mode: multiply;
-          pointer-events: none;
-          z-index: 9999;
+          filter: url(#night-mode-filter) !important;
         }
       `;
     } else {
@@ -60,11 +80,11 @@
       if (styleElement) {
         styleElement.remove();
       }
-      if (canvasElement) {
-        canvasElement.remove();
+      if (svgElement) {
+        svgElement.remove();
       }
     }
   });
 </script>
 
-<!-- This component doesn't render any visible elements, it just applies the CSS filter -->
+<!-- This component doesn't render any visible elements, it just applies the filter -->

--- a/src/lib/components/NightModeFilter.svelte
+++ b/src/lib/components/NightModeFilter.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+  import { settings } from '$lib/settings';
+  import { browser } from '$app/environment';
+  import { onMount, onDestroy } from 'svelte';
+
+  // Create a style element to hold our CSS filter
+  let styleElement: HTMLStyleElement | null = null;
+
+  // Function to apply the night mode filter
+  function applyNightModeFilter() {
+    if (!browser) return;
+    
+    // Create style element if it doesn't exist
+    if (!styleElement) {
+      styleElement = document.createElement('style');
+      document.head.appendChild(styleElement);
+    }
+    
+    // Apply the CSS filter that converts colors to red based on luminosity
+    if ($settings.nightMode) {
+      styleElement.textContent = `
+        html {
+          filter: grayscale(100%) sepia(100%) hue-rotate(0deg) saturate(60%) brightness(0.8) !important;
+        }
+      `;
+    } else {
+      styleElement.textContent = '';
+    }
+  }
+
+  // Watch for changes to the night mode setting
+  $: if (browser && $settings) {
+    applyNightModeFilter();
+  }
+
+  // Set up and clean up
+  onMount(() => {
+    applyNightModeFilter();
+  });
+
+  onDestroy(() => {
+    if (browser && styleElement) {
+      styleElement.remove();
+    }
+  });
+</script>
+
+<!-- This component doesn't render any visible elements, it just applies the CSS filter -->

--- a/src/lib/components/NightModeFilter.svelte
+++ b/src/lib/components/NightModeFilter.svelte
@@ -5,6 +5,7 @@
 
   // Create a style element to hold our CSS filter
   let styleElement: HTMLStyleElement | null = null;
+  let canvasElement: HTMLCanvasElement | null = null;
 
   // Function to apply the night mode filter
   function applyNightModeFilter() {
@@ -16,11 +17,30 @@
       document.head.appendChild(styleElement);
     }
     
-    // Apply the CSS filter that converts colors to red based on luminosity
+    // Apply the stronger red filter using a color matrix transformation
     if ($settings.nightMode) {
+      // This uses a CSS filter that approximates the color matrix:
+      // [-1/3, -1/3, -1/3, 0, 255,  // red channel
+      //  0, 0, 0, 0, 0,             // green channel
+      //  0, 0, 0, 0, 0,             // blue channel
+      //  0, 0, 0, 1, 0]             // alpha channel
       styleElement.textContent = `
         html {
-          filter: grayscale(100%) sepia(100%) hue-rotate(0deg) saturate(60%) brightness(0.8) !important;
+          filter: brightness(0.7) contrast(1.2) grayscale(1) sepia(1) hue-rotate(0deg) saturate(3) !important;
+        }
+        
+        /* Create a red overlay with screen blend mode */
+        html::before {
+          content: "";
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background-color: rgba(255, 0, 0, 0.3);
+          mix-blend-mode: screen;
+          pointer-events: none;
+          z-index: 9999;
         }
       `;
     } else {
@@ -28,19 +48,50 @@
     }
   }
 
+  // For more advanced color matrix transformations, we could use a canvas-based approach
+  function setupCanvasFilter() {
+    if (!browser || !$settings.nightMode) return;
+    
+    // This is an alternative approach using canvas that could be implemented
+    // for more precise color matrix transformations if needed
+    /*
+    if (!canvasElement) {
+      canvasElement = document.createElement('canvas');
+      canvasElement.style.position = 'fixed';
+      canvasElement.style.top = '0';
+      canvasElement.style.left = '0';
+      canvasElement.style.width = '100%';
+      canvasElement.style.height = '100%';
+      canvasElement.style.pointerEvents = 'none';
+      canvasElement.style.zIndex = '9999';
+      document.body.appendChild(canvasElement);
+      
+      // Apply color matrix transformation here
+      // This would require capturing the screen content and applying the matrix
+    }
+    */
+  }
+
   // Watch for changes to the night mode setting
   $: if (browser && $settings) {
     applyNightModeFilter();
+    setupCanvasFilter();
   }
 
   // Set up and clean up
   onMount(() => {
     applyNightModeFilter();
+    setupCanvasFilter();
   });
 
   onDestroy(() => {
-    if (browser && styleElement) {
-      styleElement.remove();
+    if (browser) {
+      if (styleElement) {
+        styleElement.remove();
+      }
+      if (canvasElement) {
+        canvasElement.remove();
+      }
     }
   });
 </script>

--- a/src/lib/components/Settings/Reader/ReaderToggles.svelte
+++ b/src/lib/components/Settings/Reader/ReaderToggles.svelte
@@ -18,7 +18,8 @@
     { key: 'mobile', text: 'Mobile', value: $settings.mobile },
     { key: 'showTimer', text: 'Show timer', value: $settings.showTimer },
     { key: 'quickActions', text: 'Show quick actions', value: $settings.quickActions },
-    { key: 'invertColors', text: 'Invert colors of the images', value: $settings.invertColors }
+    { key: 'invertColors', text: 'Invert colors of the images', value: $settings.invertColors },
+    { key: 'nightMode', text: 'Night mode (red filter)', value: $settings.nightMode }
   ] as { key: SettingsKey; text: string; value: any }[]);
 </script>
 

--- a/src/lib/components/Settings/Reader/ReaderToggles.svelte
+++ b/src/lib/components/Settings/Reader/ReaderToggles.svelte
@@ -19,7 +19,7 @@
     { key: 'showTimer', text: 'Show timer', value: $settings.showTimer },
     { key: 'quickActions', text: 'Show quick actions', value: $settings.quickActions },
     { key: 'invertColors', text: 'Invert colors of the images', value: $settings.invertColors },
-    { key: 'nightMode', text: 'Night mode (red filter)', value: $settings.nightMode }
+    { key: 'nightMode', text: 'Night mode (strong red filter)', value: $settings.nightMode }
   ] as { key: SettingsKey; text: string; value: any }[]);
 </script>
 

--- a/src/lib/settings/settings.ts
+++ b/src/lib/settings/settings.ts
@@ -58,6 +58,7 @@ export type Settings = {
   fontSize: FontSize;
   zoomDefault: ZoomModes;
   invertColors: boolean;
+  nightMode: boolean;
   volumeDefaults: VolumeDefaults;
   ankiConnectSettings: AnkiConnectSettings;
 };
@@ -86,6 +87,7 @@ const defaultSettings: Settings = {
   fontSize: 'auto',
   zoomDefault: 'zoomFitToScreen',
   invertColors: false,
+  nightMode: false,
   volumeDefaults: {
     singlePageView: false,
     rightToLeft: true,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
   import ConfirmationPopup from '$lib/components/ConfirmationPopup.svelte';
   import ExtractionModal from '$lib/components/ExtractionModal.svelte';
   import ProgressTracker from '$lib/components/ProgressTracker.svelte';
+  import NightModeFilter from '$lib/components/NightModeFilter.svelte';
 
   interface Props {
     children?: import('svelte').Snippet;
@@ -30,4 +31,5 @@
   <ConfirmationPopup />
   <ExtractionModal />
   <ProgressTracker />
+  <NightModeFilter />
 </div>


### PR DESCRIPTION
This PR adds a night mode option that converts all colors to red based on luminosity while preserving black. The implementation uses an SVG filter applied to the HTML element to achieve an effect similar to the following Flutter color matrix:

```
ColorFilter.matrix([
  -1/3, -1/3, -1/3, 0, 255, // red channel
  0, 0, 0, 0, 0,            // green channel
  0, 0, 0, 0, 0,            // blue channel
  0, 0, 0, 1, 0             // alpha channel
])
```

The key features of this implementation:
- Uses an SVG filter with feColorMatrix to properly transform colors
- First converts to grayscale to get luminosity values
- Then keeps only the red channel
- Black remains black (not bright red)
- The filter is applied at the HTML level to ensure it affects all content, including any extensions

**Changes:**
- Added a new `nightMode` setting to the settings store
- Added a toggle for night mode in the Reader settings
- Created a `NightModeFilter` component that applies an SVG filter to convert colors to red based on luminosity
- Added the filter component to the main layout to ensure it affects the entire application