### PR TITLE
Replace download/upload volume data buttons with sync volume data button

### DIFF
--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -41,7 +41,7 @@
     } else {
       // If no sync function is available, show a message
       console.log('Sync function not available');
-      showSnackbar('Sync function not available');
+      showSnackbar('Sync read progress function not available');
     }
   }
   
@@ -93,7 +93,7 @@
       <button 
         onclick={handleSync} 
         class="flex items-center justify-center w-6 h-6" 
-        title={accessToken ? "Sync volume data with cloud" : "Sign in to sync"}
+        title={accessToken ? "Sync read progress with Google Drive" : "Sign in to sync"}
       >
         <RefreshOutline class="w-6 h-6 hover:text-primary-700 cursor-pointer" />
       </button>

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
-  import { Navbar, NavBrand } from 'flowbite-svelte';
-  import { CloudArrowUpOutline, UploadSolid, UserSettingsSolid } from 'flowbite-svelte-icons';
+  import { Navbar, NavBrand, Tooltip } from 'flowbite-svelte';
+  import { CloudArrowUpOutline, UploadSolid, UserSettingsSolid, SyncSolid } from 'flowbite-svelte-icons';
   import { afterNavigate, goto } from '$app/navigation';
   import { page } from '$app/stores';
   import Settings from './Settings/Settings.svelte';
   import UploadModal from './UploadModal.svelte';
   import Icon from '$lib/assets/icon.webp';
+  import { onMount } from 'svelte';
 
   // Use $state to make these reactive
   let settingsHidden = $state(true);
   let uploadModalOpen = $state(false);
   let isReader = $state(false);
+  let accessToken = $state('');
+  let syncVolumeData: () => Promise<void>;
 
   // Define event handlers
   function openSettings() {
@@ -24,6 +27,37 @@
   function navigateToCloud() {
     goto('/cloud');
   }
+  
+  function handleSync() {
+    if (typeof syncVolumeData === 'function') {
+      syncVolumeData();
+    } else {
+      goto('/cloud');
+    }
+  }
+  
+  // Check if user is logged in to Google Drive
+  onMount(() => {
+    // Check for saved token
+    const savedToken = localStorage.getItem('gdrive_token');
+    if (savedToken) {
+      accessToken = savedToken;
+    }
+    
+    // Import the syncVolumeData function from the cloud page
+    import('/src/routes/cloud/+page.svelte').then(module => {
+      syncVolumeData = module.syncVolumeData;
+    }).catch(error => {
+      console.error('Failed to import syncVolumeData:', error);
+    });
+    
+    // Listen for changes to the token
+    window.addEventListener('storage', (event) => {
+      if (event.key === 'gdrive_token') {
+        accessToken = event.newValue || '';
+      }
+    });
+  });
 
   afterNavigate(() => {
     isReader = $page.route.id === '/[manga]/[volume]';
@@ -54,6 +88,17 @@
       <button onclick={navigateToCloud} class="flex items-center justify-center w-6 h-6">
         <CloudArrowUpOutline class="w-6 h-6 hover:text-primary-700 cursor-pointer" />
       </button>
+      <div class="relative">
+        <Tooltip content={accessToken ? "Sync volume data with cloud" : "Sign in to sync"}>
+          <button 
+            onclick={handleSync} 
+            class="flex items-center justify-center w-6 h-6" 
+            disabled={!accessToken}
+          >
+            <SyncSolid class={`w-6 h-6 ${accessToken ? 'hover:text-primary-700 cursor-pointer' : 'text-gray-400 cursor-not-allowed'}`} />
+          </button>
+        </Tooltip>
+      </div>
     </div>
   </Navbar>
 </div>

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Navbar, NavBrand, Tooltip } from 'flowbite-svelte';
-  import { CloudArrowUpOutline, UploadSolid, UserSettingsSolid, SyncSolid } from 'flowbite-svelte-icons';
+  import { CloudArrowUpOutline, UploadSolid, UserSettingsSolid, ArrowsRepeatOutline } from 'flowbite-svelte-icons';
   import { afterNavigate, goto } from '$app/navigation';
   import { page } from '$app/stores';
   import Settings from './Settings/Settings.svelte';
@@ -95,7 +95,7 @@
             class="flex items-center justify-center w-6 h-6" 
             disabled={!accessToken}
           >
-            <SyncSolid class={`w-6 h-6 ${accessToken ? 'hover:text-primary-700 cursor-pointer' : 'text-gray-400 cursor-not-allowed'}`} />
+            <ArrowsRepeatOutline class={`w-6 h-6 ${accessToken ? 'hover:text-primary-700 cursor-pointer' : 'text-gray-400 cursor-not-allowed'}`} />
           </button>
         </Tooltip>
       </div>

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -7,7 +7,7 @@
   import UploadModal from './UploadModal.svelte';
   import Icon from '$lib/assets/icon.webp';
   import { onMount } from 'svelte';
-  import { syncFunctionStore } from '$lib/util';
+  import { syncFunctionStore, showSnackbar } from '$lib/util';
 
   // Use $state to make these reactive
   let settingsHidden = $state(true);
@@ -35,10 +35,13 @@
   }
   
   function handleSync() {
+    // If we have a sync function, use it
     if (typeof syncFunction === 'function') {
       syncFunction();
     } else {
-      goto('/cloud');
+      // If no sync function is available, show a message
+      console.log('Sync function not available');
+      showSnackbar('Sync function not available');
     }
   }
   
@@ -89,10 +92,10 @@
       </button>
       <button 
         onclick={handleSync} 
-        class="flex items-center justify-center w-8 h-8 ml-1 border border-gray-300 rounded-md p-1" 
+        class="flex items-center justify-center w-6 h-6" 
         title={accessToken ? "Sync volume data with cloud" : "Sign in to sync"}
       >
-        <RefreshOutline class={`w-5 h-5 ${accessToken ? 'text-blue-500 hover:text-primary-700 cursor-pointer' : 'text-gray-400'}`} />
+        <RefreshOutline class="w-6 h-6 hover:text-primary-700 cursor-pointer" />
       </button>
     </div>
   </Navbar>

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -87,17 +87,13 @@
       <button onclick={navigateToCloud} class="flex items-center justify-center w-6 h-6">
         <CloudArrowUpOutline class="w-6 h-6 hover:text-primary-700 cursor-pointer" />
       </button>
-      <div class="relative">
-        <Tooltip content={accessToken ? "Sync volume data with cloud" : "Sign in to sync"}>
-          <button 
-            onclick={handleSync} 
-            class="flex items-center justify-center w-6 h-6" 
-            disabled={!accessToken}
-          >
-            <RefreshOutline class={`w-6 h-6 ${accessToken ? 'hover:text-primary-700 cursor-pointer' : 'text-gray-400 cursor-not-allowed'}`} />
-          </button>
-        </Tooltip>
-      </div>
+      <button 
+        onclick={handleSync} 
+        class="flex items-center justify-center w-8 h-8 ml-1 border border-gray-300 rounded-md p-1" 
+        title={accessToken ? "Sync volume data with cloud" : "Sign in to sync"}
+      >
+        <RefreshOutline class={`w-5 h-5 ${accessToken ? 'text-blue-500 hover:text-primary-700 cursor-pointer' : 'text-gray-400'}`} />
+      </button>
     </div>
   </Navbar>
 </div>

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { Navbar, NavBrand, Tooltip } from 'flowbite-svelte';
-  import { CloudArrowUpOutline, UploadSolid, UserSettingsSolid, ArrowsRepeatOutline } from 'flowbite-svelte-icons';
+  import { CloudArrowUpOutline, UploadSolid, UserSettingsSolid, RefreshOutline } from 'flowbite-svelte-icons';
   import { afterNavigate, goto } from '$app/navigation';
   import { page } from '$app/stores';
   import Settings from './Settings/Settings.svelte';
@@ -95,7 +95,7 @@
             class="flex items-center justify-center w-6 h-6" 
             disabled={!accessToken}
           >
-            <ArrowsRepeatOutline class={`w-6 h-6 ${accessToken ? 'hover:text-primary-700 cursor-pointer' : 'text-gray-400 cursor-not-allowed'}`} />
+            <RefreshOutline class={`w-6 h-6 ${accessToken ? 'hover:text-primary-700 cursor-pointer' : 'text-gray-400 cursor-not-allowed'}`} />
           </button>
         </Tooltip>
       </div>

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -45,7 +45,7 @@
     }
     
     // Import the syncVolumeData function from the cloud page
-    import('/src/routes/cloud/+page.svelte').then(module => {
+    import('../../routes/cloud/+page.svelte').then(module => {
       syncVolumeData = module.syncVolumeData;
     }).catch(error => {
       console.error('Failed to import syncVolumeData:', error);

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -38,14 +38,8 @@
     syncReadProgress();
   }
   
-  // Initialize Google Drive API
+  // Listen for changes to the token in localStorage
   onMount(() => {
-    // Initialize the Google Drive API
-    initGoogleDriveApi().catch(error => {
-      console.error('Failed to initialize Google Drive API:', error);
-    });
-    
-    // Listen for changes to the token in localStorage
     window.addEventListener('storage', (event) => {
       if (event.key === 'gdrive_token') {
         accessTokenStore.set(event.newValue || '');

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -7,13 +7,19 @@
   import UploadModal from './UploadModal.svelte';
   import Icon from '$lib/assets/icon.webp';
   import { onMount } from 'svelte';
+  import { syncFunctionStore } from '$lib/util';
 
   // Use $state to make these reactive
   let settingsHidden = $state(true);
   let uploadModalOpen = $state(false);
   let isReader = $state(false);
   let accessToken = $state('');
-  let syncVolumeData: () => Promise<void>;
+  
+  // Subscribe to the sync function store
+  let syncFunction = $state(null);
+  syncFunctionStore.subscribe(value => {
+    syncFunction = value;
+  });
 
   // Define event handlers
   function openSettings() {
@@ -29,8 +35,8 @@
   }
   
   function handleSync() {
-    if (typeof syncVolumeData === 'function') {
-      syncVolumeData();
+    if (typeof syncFunction === 'function') {
+      syncFunction();
     } else {
       goto('/cloud');
     }
@@ -43,13 +49,6 @@
     if (savedToken) {
       accessToken = savedToken;
     }
-    
-    // Import the syncVolumeData function from the cloud page
-    import('../../routes/cloud/+page.svelte').then(module => {
-      syncVolumeData = module.syncVolumeData;
-    }).catch(error => {
-      console.error('Failed to import syncVolumeData:', error);
-    });
     
     // Listen for changes to the token
     window.addEventListener('storage', (event) => {

--- a/src/lib/util/google-drive.ts
+++ b/src/lib/util/google-drive.ts
@@ -1,7 +1,7 @@
 import { parseVolumesFromJson, volumes } from '$lib/settings';
 import { progressTrackerStore } from '$lib/util/progress-tracker';
 import { showSnackbar } from '$lib/util/snackbar';
-import { uploadFile } from '$lib/util/upload';
+import { uploadFile } from '$lib/util/cloud';
 import { writable, get } from 'svelte/store';
 
 // Constants

--- a/src/lib/util/google-drive.ts
+++ b/src/lib/util/google-drive.ts
@@ -1,0 +1,406 @@
+import { parseVolumesFromJson, volumes } from '$lib/settings';
+import { progressTrackerStore } from '$lib/util/progress-tracker';
+import { showSnackbar } from '$lib/util/snackbar';
+import { uploadFile } from '$lib/util/upload';
+import { writable, get } from 'svelte/store';
+
+// Constants
+export const CLIENT_ID = import.meta.env.VITE_GDRIVE_CLIENT_ID;
+export const API_KEY = import.meta.env.VITE_GDRIVE_API_KEY;
+export const DISCOVERY_DOC = 'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest';
+export const SCOPES = 'https://www.googleapis.com/auth/drive.file';
+export const FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
+export const READER_FOLDER = 'mokuro-reader';
+export const VOLUME_DATA_FILE = 'volume-data.json';
+export const PROFILES_FILE = 'profiles.json';
+export const FILE_TYPE = 'application/json';
+
+// Stores
+export const accessTokenStore = writable<string>('');
+export const readerFolderIdStore = writable<string>('');
+export const volumeDataIdStore = writable<string>('');
+export const profilesIdStore = writable<string>('');
+export const tokenClientStore = writable<any>(null);
+export const isInitializedStore = writable<boolean>(false);
+
+// Helper function to handle errors consistently
+export function handleDriveError(error: any, context: string) {
+  // Check if it's a connectivity issue
+  const errorMessage = error.toString().toLowerCase();
+  const isConnectivityError =
+    errorMessage.includes('network') ||
+    errorMessage.includes('connection') ||
+    errorMessage.includes('offline') ||
+    errorMessage.includes('internet');
+
+  if (!isConnectivityError) {
+    // Log the user out for non-connectivity errors
+    logout();
+    showSnackbar(`Error ${context}: ${error.message || 'Unknown error'}`);
+  } else {
+    showSnackbar('Connection error: Please check your internet connection');
+  }
+
+  console.error(`${context} error:`, error);
+}
+
+// Initialize Google Drive API
+export async function initGoogleDriveApi() {
+  if (get(isInitializedStore)) {
+    return;
+  }
+
+  return new Promise<void>((resolve, reject) => {
+    try {
+      // Load the Google API client
+      gapi.load('client', async () => {
+        try {
+          await gapi.client.init({
+            apiKey: API_KEY,
+            discoveryDocs: [DISCOVERY_DOC]
+          });
+
+          // Initialize token client
+          const tokenClient = google.accounts.oauth2.initTokenClient({
+            client_id: CLIENT_ID,
+            scope: SCOPES,
+            callback: (resp: any) => {
+              if (resp?.error !== undefined) {
+                localStorage.removeItem('gdrive_token');
+                accessTokenStore.set('');
+                reject(resp);
+                return;
+              }
+
+              const token = resp?.access_token || '';
+              accessTokenStore.set(token);
+              localStorage.setItem('gdrive_token', token);
+              
+              // After successful authentication, connect to Drive
+              connectDrive(token)
+                .then(() => resolve())
+                .catch(reject);
+            }
+          });
+          
+          tokenClientStore.set(tokenClient);
+
+          // Try to restore the saved token
+          const savedToken = localStorage.getItem('gdrive_token');
+          if (savedToken) {
+            try {
+              // Set the token in gapi client
+              gapi.client.setToken({ access_token: savedToken });
+              accessTokenStore.set(savedToken);
+              
+              // Connect to Drive with the saved token
+              await connectDrive(savedToken);
+              resolve();
+            } catch (error) {
+              console.error('Failed to restore saved token:', error);
+              reject(error);
+            }
+          } else {
+            // No saved token, but API is initialized
+            isInitializedStore.set(true);
+            resolve();
+          }
+        } catch (error) {
+          handleDriveError(error, 'initializing Google Drive');
+          reject(error);
+        }
+      });
+
+      // Also load the picker API
+      gapi.load('picker', () => {});
+    } catch (error) {
+      console.error('Error loading Google API:', error);
+      reject(error);
+    }
+  });
+}
+
+// Connect to Google Drive
+export async function connectDrive(token: string) {
+  const processId = 'connect-drive';
+  progressTrackerStore.addProcess({
+    id: processId,
+    description: 'Connecting to Google Drive',
+    progress: 0,
+    status: 'Initializing connection...'
+  });
+
+  try {
+    progressTrackerStore.updateProcess(processId, {
+      progress: 20,
+      status: 'Checking for reader folder...'
+    });
+
+    const { result: readerFolderRes } = await gapi.client.drive.files.list({
+      q: `mimeType='application/vnd.google-apps.folder' and name='${READER_FOLDER}'`,
+      fields: 'files(id)'
+    });
+
+    let readerFolderId = '';
+    if (readerFolderRes.files?.length === 0) {
+      progressTrackerStore.updateProcess(processId, {
+        progress: 40,
+        status: 'Creating reader folder...'
+      });
+
+      const { result: createReaderFolderRes } = await gapi.client.drive.files.create({
+        resource: { mimeType: FOLDER_MIME_TYPE, name: READER_FOLDER },
+        fields: 'id'
+      });
+
+      readerFolderId = createReaderFolderRes.id || '';
+    } else {
+      const id = readerFolderRes.files?.[0]?.id || '';
+      readerFolderId = id || '';
+    }
+    
+    readerFolderIdStore.set(readerFolderId);
+
+    progressTrackerStore.updateProcess(processId, {
+      progress: 60,
+      status: 'Checking for volume data...'
+    });
+
+    const { result: volumeDataRes } = await gapi.client.drive.files.list({
+      q: `'${readerFolderId}' in parents and name='${VOLUME_DATA_FILE}'`,
+      fields: 'files(id, name)'
+    });
+
+    let volumeDataId = '';
+    if (volumeDataRes.files?.length !== 0) {
+      volumeDataId = volumeDataRes.files?.[0].id || '';
+    }
+    
+    volumeDataIdStore.set(volumeDataId);
+
+    progressTrackerStore.updateProcess(processId, {
+      progress: 80,
+      status: 'Checking for profiles...'
+    });
+
+    const { result: profilesRes } = await gapi.client.drive.files.list({
+      q: `'${readerFolderId}' in parents and name='${PROFILES_FILE}'`,
+      fields: 'files(id, name)'
+    });
+
+    let profilesId = '';
+    if (profilesRes.files?.length !== 0) {
+      profilesId = profilesRes.files?.[0].id || '';
+    }
+    
+    profilesIdStore.set(profilesId);
+
+    progressTrackerStore.updateProcess(processId, {
+      progress: 100,
+      status: 'Connected successfully'
+    });
+    setTimeout(() => progressTrackerStore.removeProcess(processId), 3000);
+
+    if (token) {
+      showSnackbar('Connected to Google Drive');
+      
+      // Check if we need to sync after login
+      const syncAfterLogin = localStorage.getItem('sync_after_login');
+      if (syncAfterLogin === 'true') {
+        // Clear the flag
+        localStorage.removeItem('sync_after_login');
+        // Perform sync
+        setTimeout(() => syncReadProgress(), 500);
+      }
+    }
+    
+    isInitializedStore.set(true);
+  } catch (error) {
+    progressTrackerStore.updateProcess(processId, {
+      progress: 0,
+      status: 'Connection failed'
+    });
+    setTimeout(() => progressTrackerStore.removeProcess(processId), 3000);
+    handleDriveError(error, 'connecting to Google Drive');
+    throw error;
+  }
+}
+
+// Sign in to Google Drive
+export function signIn() {
+  const tokenClient = get(tokenClientStore);
+  if (tokenClient) {
+    // Always show the account picker to allow switching accounts
+    tokenClient.requestAccessToken({ prompt: 'consent' });
+  } else {
+    showSnackbar('Google Drive API not initialized');
+    // Try to initialize
+    initGoogleDriveApi().catch(error => {
+      console.error('Failed to initialize Google Drive API:', error);
+    });
+  }
+}
+
+// Log out from Google Drive
+export function logout() {
+  // Remove token from localStorage
+  localStorage.removeItem('gdrive_token');
+
+  // Clear the token from memory
+  accessTokenStore.set('');
+
+  // Revoke the token with Google to ensure account picker shows up next time
+  if (gapi.client.getToken()) {
+    const token = gapi.client.getToken().access_token;
+    // Clear the token from gapi client
+    gapi.client.setToken(null);
+
+    // Revoke the token with Google's OAuth service
+    fetch(`https://oauth2.googleapis.com/revoke?token=${token}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      }
+    }).catch((error) => {
+      console.error('Error revoking token:', error);
+    });
+  }
+}
+
+// Sync read progress between local storage and Google Drive
+export async function syncReadProgress() {
+  // If not authenticated, prompt login first
+  if (!get(accessTokenStore)) {
+    // Store that we want to sync after login
+    localStorage.setItem('sync_after_login', 'true');
+    signIn();
+    return;
+  }
+  
+  // If not initialized, initialize first
+  if (!get(isInitializedStore)) {
+    try {
+      await initGoogleDriveApi();
+    } catch (error) {
+      console.error('Failed to initialize Google Drive API:', error);
+      showSnackbar('Failed to initialize Google Drive API');
+      return;
+    }
+  }
+
+  const processId = 'sync-volume-data';
+  progressTrackerStore.addProcess({
+    id: processId,
+    description: 'Syncing read progress',
+    progress: 0,
+    status: 'Starting sync...'
+  });
+
+  try {
+    // Step 1: Download cloud volume data if it exists
+    let cloudVolumes = {};
+    const volumeDataId = get(volumeDataIdStore);
+    
+    if (volumeDataId) {
+      progressTrackerStore.updateProcess(processId, {
+        progress: 20,
+        status: 'Downloading cloud data...'
+      });
+
+      try {
+        const { body } = await gapi.client.drive.files.get({
+          fileId: volumeDataId,
+          alt: 'media'
+        });
+        cloudVolumes = parseVolumesFromJson(body);
+      } catch (error) {
+        console.error('Error downloading cloud volume data:', error);
+        // Continue with empty cloud volumes if download fails
+      }
+    }
+
+    // Step 2: Get local volume data
+    progressTrackerStore.updateProcess(processId, {
+      progress: 40,
+      status: 'Merging data...'
+    });
+
+    let localVolumes = {};
+    volumes.subscribe(value => {
+      localVolumes = { ...value };
+    })();
+
+    // Step 3: Merge the data, keeping the newer records based on lastProgressUpdate
+    const mergedVolumes = {};
+    
+    // Process all volume IDs from both sources
+    const allVolumeIds = new Set([
+      ...Object.keys(localVolumes),
+      ...Object.keys(cloudVolumes)
+    ]);
+    
+    allVolumeIds.forEach(volumeId => {
+      const localVolume = localVolumes[volumeId];
+      const cloudVolume = cloudVolumes[volumeId];
+      
+      // If volume exists only in one source, use that one
+      if (!localVolume) {
+        mergedVolumes[volumeId] = cloudVolume;
+      } else if (!cloudVolume) {
+        mergedVolumes[volumeId] = localVolume;
+      } else {
+        // Both exist, compare lastProgressUpdate dates
+        const localDate = new Date(localVolume.lastProgressUpdate).getTime();
+        const cloudDate = new Date(cloudVolume.lastProgressUpdate).getTime();
+        
+        // Keep the newer record
+        mergedVolumes[volumeId] = localDate >= cloudDate ? localVolume : cloudVolume;
+      }
+    });
+    
+    // Step 4: Update local volume data with merged data
+    progressTrackerStore.updateProcess(processId, {
+      progress: 60,
+      status: 'Updating local data...'
+    });
+    
+    volumes.update(() => mergedVolumes);
+    
+    // Step 5: Upload merged data to cloud
+    progressTrackerStore.updateProcess(processId, {
+      progress: 80,
+      status: 'Uploading merged data...'
+    });
+    
+    const metadata = {
+      mimeType: FILE_TYPE,
+      name: VOLUME_DATA_FILE,
+      parents: [volumeDataId ? null : get(readerFolderIdStore)]
+    };
+    
+    const res = await uploadFile({
+      accessToken: get(accessTokenStore),
+      fileId: volumeDataId,
+      metadata,
+      localStorageId: 'volumes',
+      type: FILE_TYPE
+    });
+    
+    volumeDataIdStore.set(res.id);
+    
+    progressTrackerStore.updateProcess(processId, {
+      progress: 100,
+      status: 'Sync complete'
+    });
+    setTimeout(() => progressTrackerStore.removeProcess(processId), 3000);
+    
+    showSnackbar('Read progress synced successfully');
+  } catch (error) {
+    progressTrackerStore.updateProcess(processId, {
+      progress: 0,
+      status: 'Sync failed'
+    });
+    setTimeout(() => progressTrackerStore.removeProcess(processId), 3000);
+    handleDriveError(error, 'syncing read progress');
+  }
+}

--- a/src/lib/util/index.ts
+++ b/src/lib/util/index.ts
@@ -4,3 +4,4 @@ export * from './misc';
 export * from './modals';
 export * from './zip';
 export * from './cloud';
+export * from './sync-store';

--- a/src/lib/util/index.ts
+++ b/src/lib/util/index.ts
@@ -5,3 +5,4 @@ export * from './modals';
 export * from './zip';
 export * from './cloud';
 export * from './sync-store';
+export * from './google-drive';

--- a/src/lib/util/sync-store.ts
+++ b/src/lib/util/sync-store.ts
@@ -1,0 +1,4 @@
+import { writable } from 'svelte/store';
+
+// Create a store to hold the sync function
+export const syncFunctionStore = writable<(() => Promise<void>) | null>(null);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import '../app.postcss';
-  import { browser, dev } from '$app/environment';
+  import { dev } from '$app/environment';
   import { inject } from '@vercel/analytics';
-  import { onMount } from 'svelte';
 
   import NavBar from '$lib/components/NavBar.svelte';
   import Snackbar from '$lib/components/Snackbar.svelte';
@@ -10,7 +9,6 @@
   import ExtractionModal from '$lib/components/ExtractionModal.svelte';
   import ProgressTracker from '$lib/components/ProgressTracker.svelte';
   import NightModeFilter from '$lib/components/NightModeFilter.svelte';
-  import { initGoogleDriveApi } from '$lib/util';
 
   interface Props {
     children?: import('svelte').Snippet;
@@ -19,21 +17,6 @@
   let { children }: Props = $props();
 
   inject({ mode: dev ? 'development' : 'production' });
-
-  // Start thumbnail processing only in browser environment
-  if (browser) {
-    import('$lib/catalog/thumbnails');
-  }
-  
-  // Initialize Google Drive API in browser environment
-  onMount(() => {
-    if (browser) {
-      // Initialize Google Drive API
-      initGoogleDriveApi().catch(error => {
-        console.error('Failed to initialize Google Drive API:', error);
-      });
-    }
-  });
 </script>
 
 <div class=" h-full min-h-[100svh] text-white">

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
   import '../app.postcss';
   import { browser, dev } from '$app/environment';
   import { inject } from '@vercel/analytics';
+  import { onMount } from 'svelte';
 
   import NavBar from '$lib/components/NavBar.svelte';
   import Snackbar from '$lib/components/Snackbar.svelte';
@@ -9,6 +10,7 @@
   import ExtractionModal from '$lib/components/ExtractionModal.svelte';
   import ProgressTracker from '$lib/components/ProgressTracker.svelte';
   import NightModeFilter from '$lib/components/NightModeFilter.svelte';
+  import { initGoogleDriveApi } from '$lib/util';
 
   interface Props {
     children?: import('svelte').Snippet;
@@ -22,6 +24,16 @@
   if (browser) {
     import('$lib/catalog/thumbnails');
   }
+  
+  // Initialize Google Drive API in browser environment
+  onMount(() => {
+    if (browser) {
+      // Initialize Google Drive API
+      initGoogleDriveApi().catch(error => {
+        console.error('Failed to initialize Google Drive API:', error);
+      });
+    }
+  });
 </script>
 
 <div class=" h-full min-h-[100svh] text-white">

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,17 @@
+import { browser } from '$app/environment';
+import { initGoogleDriveApi } from '$lib/util';
+
+// Initialize services that should be available app-wide
+export function load() {
+  if (browser) {
+    // Initialize Google Drive API
+    initGoogleDriveApi().catch(error => {
+      console.error('Failed to initialize Google Drive API:', error);
+    });
+    
+    // Start thumbnail processing
+    import('$lib/catalog/thumbnails');
+  }
+  
+  return {};
+}

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -834,7 +834,7 @@
     const processId = 'sync-volume-data';
     progressTrackerStore.addProcess({
       id: processId,
-      description: 'Syncing volume data',
+      description: 'Syncing read progress',
       progress: 0,
       status: 'Starting sync...'
     });
@@ -935,14 +935,14 @@
       });
       setTimeout(() => progressTrackerStore.removeProcess(processId), 3000);
       
-      showSnackbar('Volume data synced successfully');
+      showSnackbar('Read progress synced successfully');
     } catch (error) {
       progressTrackerStore.updateProcess(processId, {
         progress: 0,
         status: 'Sync failed'
       });
       setTimeout(() => progressTrackerStore.removeProcess(processId), 3000);
-      handleDriveError(error, 'syncing volume data');
+      handleDriveError(error, 'syncing read progress');
     }
   }
   
@@ -1043,10 +1043,10 @@
             color="dark"
             on:click={performSync}
           >
-            Sync volume data
+            Sync read progress
           </Button>
           <p class="text-xs text-gray-500 ml-1">
-            Merges local and cloud data, keeping the most recent progress for each volume.
+            Merges local and Google Drive data, keeping the most recent progress for each volume.
           </p>
         </div>
         <div class="flex-col gap-2 flex">

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -1045,9 +1045,6 @@
           >
             Sync read progress
           </Button>
-          <p class="text-xs text-gray-500 ml-1">
-            Merges local and Google Drive data, keeping the most recent progress for each volume.
-          </p>
         </div>
         <div class="flex-col gap-2 flex">
           <Button

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -5,7 +5,7 @@
   import { parseVolumesFromJson, profiles, volumes } from '$lib/settings';
   import { miscSettings, updateMiscSetting } from '$lib/settings/misc';
 
-  import { promptConfirmation, showSnackbar, uploadFile } from '$lib/util';
+  import { promptConfirmation, showSnackbar, uploadFile, syncFunctionStore } from '$lib/util';
   import { Badge, Button, Toggle } from 'flowbite-svelte';
   import { onMount } from 'svelte';
   import { GoogleSolid } from 'flowbite-svelte-icons';
@@ -301,6 +301,9 @@
   }
 
   onMount(() => {
+    // Register the sync function in the store
+    syncFunctionStore.set(syncVolumeData);
+    
     // Clear service worker cache for Google Drive downloads
     clearServiceWorkerCache();
     

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -626,6 +626,16 @@
   async function performSync() {
     await syncReadProgress();
   }
+  
+  // Make sure the cloud page is properly initialized
+  onMount(() => {
+    // If we have a token but no folder ID, try to initialize
+    if (accessToken && !readerFolderId) {
+      initGoogleDriveApi().catch(error => {
+        console.error('Failed to initialize Google Drive API:', error);
+      });
+    }
+  });
 
   async function onDownloadProfiles() {
     const processId = 'download-profiles';

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -634,19 +634,9 @@
     // Clear service worker cache for Google Drive downloads
     clearServiceWorkerCache();
     
-    console.log('Cloud page mounted, initializing Google Drive API');
-    console.log('Current state:', { accessToken, readerFolderId, volumeDataId, profilesId });
-    
     try {
       // Always try to initialize when the cloud page is loaded
       await initGoogleDriveApi();
-      console.log('Google Drive API initialized successfully');
-      console.log('Updated state:', { 
-        accessToken: get(accessTokenStore), 
-        readerFolderId: get(readerFolderIdStore), 
-        volumeDataId: get(volumeDataIdStore), 
-        profilesId: get(profilesIdStore) 
-      });
     } catch (error) {
       console.error('Failed to initialize Google Drive API:', error);
     }
@@ -705,14 +695,6 @@
 </svelte:head>
 
 <div class="p-2 h-[90svh]">
-  <!-- Debug info -->
-  <div class="text-xs text-gray-500 mb-4">
-    <p>Access Token: {accessToken ? 'Present' : 'Not present'}</p>
-    <p>Reader Folder ID: {readerFolderId ? readerFolderId : 'Not set'}</p>
-    <p>Volume Data ID: {volumeDataId ? volumeDataId : 'Not set'}</p>
-    <p>Profiles ID: {profilesId ? profilesId : 'Not set'}</p>
-  </div>
-
   {#if accessToken}
     <div class="flex justify-between items-center gap-6 flex-col">
       <div class="flex justify-between items-center w-full max-w-3xl">

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -17,8 +17,10 @@
     initGoogleDriveApi,
     signIn,
     logout,
-    syncReadProgress
+    syncReadProgress,
+    READER_FOLDER
   } from '$lib/util';
+  import { get } from 'svelte/store';
   import { Badge, Button, Toggle } from 'flowbite-svelte';
   import { onMount } from 'svelte';
   import { GoogleSolid } from 'flowbite-svelte-icons';
@@ -628,12 +630,25 @@
   }
   
   // Make sure the cloud page is properly initialized
-  onMount(() => {
-    // If we have a token but no folder ID, try to initialize
-    if (accessToken && !readerFolderId) {
-      initGoogleDriveApi().catch(error => {
-        console.error('Failed to initialize Google Drive API:', error);
+  onMount(async () => {
+    // Clear service worker cache for Google Drive downloads
+    clearServiceWorkerCache();
+    
+    console.log('Cloud page mounted, initializing Google Drive API');
+    console.log('Current state:', { accessToken, readerFolderId, volumeDataId, profilesId });
+    
+    try {
+      // Always try to initialize when the cloud page is loaded
+      await initGoogleDriveApi();
+      console.log('Google Drive API initialized successfully');
+      console.log('Updated state:', { 
+        accessToken: get(accessTokenStore), 
+        readerFolderId: get(readerFolderIdStore), 
+        volumeDataId: get(volumeDataIdStore), 
+        profilesId: get(profilesIdStore) 
       });
+    } catch (error) {
+      console.error('Failed to initialize Google Drive API:', error);
     }
   });
 
@@ -690,6 +705,14 @@
 </svelte:head>
 
 <div class="p-2 h-[90svh]">
+  <!-- Debug info -->
+  <div class="text-xs text-gray-500 mb-4">
+    <p>Access Token: {accessToken ? 'Present' : 'Not present'}</p>
+    <p>Reader Folder ID: {readerFolderId ? readerFolderId : 'Not set'}</p>
+    <p>Volume Data ID: {volumeDataId ? volumeDataId : 'Not set'}</p>
+    <p>Profiles ID: {profilesId ? profilesId : 'Not set'}</p>
+  </div>
+
   {#if accessToken}
     <div class="flex justify-between items-center gap-6 flex-col">
       <div class="flex justify-between items-center w-full max-w-3xl">

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -146,11 +146,6 @@
   onMount(() => {
     // Clear service worker cache for Google Drive downloads
     clearServiceWorkerCache();
-    
-    // Initialize Google Drive API
-    initGoogleDriveApi().catch(error => {
-      console.error('Failed to initialize Google Drive API:', error);
-    });
   });
 
   function createPicker() {

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -2,68 +2,42 @@
   import { run } from 'svelte/legacy';
 
   import { processFiles } from '$lib/upload';
-  import { parseVolumesFromJson, profiles, volumes } from '$lib/settings';
+  import { profiles } from '$lib/settings';
   import { miscSettings, updateMiscSetting } from '$lib/settings/misc';
 
-  import { promptConfirmation, showSnackbar, uploadFile, syncFunctionStore } from '$lib/util';
+  import { 
+    promptConfirmation, 
+    showSnackbar, 
+    uploadFile, 
+    accessTokenStore,
+    readerFolderIdStore,
+    volumeDataIdStore,
+    profilesIdStore,
+    tokenClientStore,
+    initGoogleDriveApi,
+    signIn,
+    logout,
+    syncReadProgress
+  } from '$lib/util';
   import { Badge, Button, Toggle } from 'flowbite-svelte';
   import { onMount } from 'svelte';
   import { GoogleSolid } from 'flowbite-svelte-icons';
-  import { progressTrackerStore } from '$lib/util/progress-tracker';
 
-  interface Props {
-    accessToken?: string;
-  }
-
-  let { accessToken = $bindable('') }: Props = $props();
-
-  // Helper function to handle errors consistently
-  function handleDriveError(error: any, context: string) {
-    // Check if it's a connectivity issue
-    const errorMessage = error.toString().toLowerCase();
-    const isConnectivityError =
-      errorMessage.includes('network') ||
-      errorMessage.includes('connection') ||
-      errorMessage.includes('offline') ||
-      errorMessage.includes('internet');
-
-    if (!isConnectivityError) {
-      // Log the user out for non-connectivity errors
-      logout();
-      showSnackbar(`Error ${context}: ${error.message || 'Unknown error'}`);
-    } else {
-      showSnackbar('Connection error: Please check your internet connection');
-    }
-
-    console.error(`${context} error:`, error);
-  }
-
-  const CLIENT_ID = import.meta.env.VITE_GDRIVE_CLIENT_ID;
-  const API_KEY = import.meta.env.VITE_GDRIVE_API_KEY;
-
-  const DISCOVERY_DOC = 'https://www.googleapis.com/discovery/v1/apis/drive/v3/rest';
-  const SCOPES = 'https://www.googleapis.com/auth/drive.file';
-
-  const FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder';
-  const READER_FOLDER = 'mokuro-reader';
-  const VOLUME_DATA_FILE = 'volume-data.json';
-  const PROFILES_FILE = 'profiles.json';
-
-  const type = 'application/json';
-
-  let tokenClient: any;
-  let readerFolderId = '';
+  // Subscribe to stores
+  let accessToken = $state('');
+  let readerFolderId = $state('');
   let volumeDataId = $state('');
   let profilesId = $state('');
+  let tokenClient = $state(null);
+  
+  accessTokenStore.subscribe(value => { accessToken = value; });
+  readerFolderIdStore.subscribe(value => { readerFolderId = value; });
+  volumeDataIdStore.subscribe(value => { volumeDataId = value; });
+  profilesIdStore.subscribe(value => { profilesId = value; });
+  tokenClientStore.subscribe(value => { tokenClient = value; });
 
-  // This variable is used to track if we're connected to Google Drive
-  // and is used in the UI to show/hide the login button
-
-  run(() => {
-    if (accessToken) {
-      localStorage.setItem('gdrive_token', accessToken);
-    }
-  });
+  // Use constants from the google-drive utility
+  const type = 'application/json';
 
   async function getFileSize(fileId: string): Promise<number> {
     try {
@@ -130,137 +104,6 @@
     return xhrDownloadFileIdWithTracking(fileId, fileName, () => {});
   }
 
-  export async function connectDrive(resp?: any) {
-    if (resp?.error !== undefined) {
-      localStorage.removeItem('gdrive_token');
-      accessToken = '';
-      throw resp;
-    }
-
-    accessToken = resp?.access_token;
-
-    const processId = 'connect-drive';
-    progressTrackerStore.addProcess({
-      id: processId,
-      description: 'Connecting to Google Drive',
-      progress: 0,
-      status: 'Initializing connection...'
-    });
-
-    try {
-      progressTrackerStore.updateProcess(processId, {
-        progress: 20,
-        status: 'Checking for reader folder...'
-      });
-
-      const { result: readerFolderRes } = await gapi.client.drive.files.list({
-        q: `mimeType='application/vnd.google-apps.folder' and name='${READER_FOLDER}'`,
-        fields: 'files(id)'
-      });
-
-      if (readerFolderRes.files?.length === 0) {
-        progressTrackerStore.updateProcess(processId, {
-          progress: 40,
-          status: 'Creating reader folder...'
-        });
-
-        const { result: createReaderFolderRes } = await gapi.client.drive.files.create({
-          resource: { mimeType: FOLDER_MIME_TYPE, name: READER_FOLDER },
-          fields: 'id'
-        });
-
-        readerFolderId = createReaderFolderRes.id || '';
-      } else {
-        const id = readerFolderRes.files?.[0]?.id || '';
-        readerFolderId = id || '';
-      }
-
-      progressTrackerStore.updateProcess(processId, {
-        progress: 60,
-        status: 'Checking for volume data...'
-      });
-
-      const { result: volumeDataRes } = await gapi.client.drive.files.list({
-        q: `'${readerFolderId}' in parents and name='${VOLUME_DATA_FILE}'`,
-        fields: 'files(id, name)'
-      });
-
-      if (volumeDataRes.files?.length !== 0) {
-        volumeDataId = volumeDataRes.files?.[0].id || '';
-      }
-
-      progressTrackerStore.updateProcess(processId, {
-        progress: 80,
-        status: 'Checking for profiles...'
-      });
-
-      const { result: profilesRes } = await gapi.client.drive.files.list({
-        q: `'${readerFolderId}' in parents and name='${PROFILES_FILE}'`,
-        fields: 'files(id, name)'
-      });
-
-      if (profilesRes.files?.length !== 0) {
-        profilesId = profilesRes.files?.[0].id || '';
-      }
-
-      progressTrackerStore.updateProcess(processId, {
-        progress: 100,
-        status: 'Connected successfully'
-      });
-      setTimeout(() => progressTrackerStore.removeProcess(processId), 3000);
-
-      if (accessToken) {
-        showSnackbar('Connected to Google Drive');
-        
-        // Check if we need to sync after login
-        const syncAfterLogin = localStorage.getItem('sync_after_login');
-        if (syncAfterLogin === 'true') {
-          // Clear the flag
-          localStorage.removeItem('sync_after_login');
-          // Perform sync
-          setTimeout(() => performSync(), 500);
-        }
-      }
-    } catch (error) {
-      progressTrackerStore.updateProcess(processId, {
-        progress: 0,
-        status: 'Connection failed'
-      });
-      setTimeout(() => progressTrackerStore.removeProcess(processId), 3000);
-      handleDriveError(error, 'connecting to Google Drive');
-    }
-  }
-
-  function signIn() {
-    // Always show the account picker to allow switching accounts
-    tokenClient.requestAccessToken({ prompt: 'consent' });
-  }
-
-  export function logout() {
-    // Remove token from localStorage
-    localStorage.removeItem('gdrive_token');
-
-    // Clear the token from memory
-    accessToken = '';
-
-    // Revoke the token with Google to ensure account picker shows up next time
-    if (gapi.client.getToken()) {
-      const token = gapi.client.getToken().access_token;
-      // Clear the token from gapi client
-      gapi.client.setToken(null);
-
-      // Revoke the token with Google's OAuth service
-      fetch(`https://oauth2.googleapis.com/revoke?token=${token}`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded'
-        }
-      }).catch((error) => {
-        console.error('Error revoking token:', error);
-      });
-    }
-  }
-
   // Function to clear service worker cache for Google Drive downloads
   async function clearServiceWorkerCache() {
     if ('caches' in window) {
@@ -301,45 +144,13 @@
   }
 
   onMount(() => {
-    // Register the sync function in the store
-    syncFunctionStore.set(syncVolumeData);
-    
     // Clear service worker cache for Google Drive downloads
     clearServiceWorkerCache();
     
-    gapi.load('client', async () => {
-      try {
-        await gapi.client.init({
-          apiKey: API_KEY,
-          discoveryDocs: [DISCOVERY_DOC]
-        });
-
-        // Initialize token client after gapi client is ready
-        tokenClient = google.accounts.oauth2.initTokenClient({
-          client_id: CLIENT_ID,
-          scope: SCOPES,
-          callback: connectDrive
-        });
-
-        // Try to restore the saved token only after gapi client is initialized
-        const savedToken = localStorage.getItem('gdrive_token');
-        if (savedToken) {
-          try {
-            // Set the token in gapi client
-            gapi.client.setToken({ access_token: savedToken });
-            accessToken = savedToken;
-            await connectDrive({ access_token: savedToken });
-          } catch (error) {
-            console.error('Failed to restore saved token:', error);
-            // Token will be cleared in connectDrive if there's an error
-          }
-        }
-      } catch (error) {
-        handleDriveError(error, 'initializing Google Drive');
-      }
+    // Initialize Google Drive API
+    initGoogleDriveApi().catch(error => {
+      console.error('Failed to initialize Google Drive API:', error);
     });
-
-    gapi.load('picker', () => {});
   });
 
   function createPicker() {
@@ -816,139 +627,9 @@
     }
   }
   
-  // This function handles the sync operation with authentication check
-  export async function syncVolumeData() {
-    // If not authenticated, prompt login first
-    if (!accessToken) {
-      // Store that we want to sync after login
-      localStorage.setItem('sync_after_login', 'true');
-      signIn();
-      return;
-    }
-    
-    await performSync();
-  }
-  
-  // This function performs the actual sync operation
-  async function performSync() {
-    const processId = 'sync-volume-data';
-    progressTrackerStore.addProcess({
-      id: processId,
-      description: 'Syncing read progress',
-      progress: 0,
-      status: 'Starting sync...'
-    });
-
-    try {
-      // Step 1: Download cloud volume data if it exists
-      let cloudVolumes = {};
-      if (volumeDataId) {
-        progressTrackerStore.updateProcess(processId, {
-          progress: 20,
-          status: 'Downloading cloud data...'
-        });
-
-        try {
-          const { body } = await gapi.client.drive.files.get({
-            fileId: volumeDataId,
-            alt: 'media'
-          });
-          cloudVolumes = parseVolumesFromJson(body);
-        } catch (error) {
-          console.error('Error downloading cloud volume data:', error);
-          // Continue with empty cloud volumes if download fails
-        }
-      }
-
-      // Step 2: Get local volume data
-      progressTrackerStore.updateProcess(processId, {
-        progress: 40,
-        status: 'Merging data...'
-      });
-
-      let localVolumes = {};
-      volumes.subscribe(value => {
-        localVolumes = { ...value };
-      })();
-
-      // Step 3: Merge the data, keeping the newer records based on lastProgressUpdate
-      const mergedVolumes = {};
-      
-      // Process all volume IDs from both sources
-      const allVolumeIds = new Set([
-        ...Object.keys(localVolumes),
-        ...Object.keys(cloudVolumes)
-      ]);
-      
-      allVolumeIds.forEach(volumeId => {
-        const localVolume = localVolumes[volumeId];
-        const cloudVolume = cloudVolumes[volumeId];
-        
-        // If volume exists only in one source, use that one
-        if (!localVolume) {
-          mergedVolumes[volumeId] = cloudVolume;
-        } else if (!cloudVolume) {
-          mergedVolumes[volumeId] = localVolume;
-        } else {
-          // Both exist, compare lastProgressUpdate dates
-          const localDate = new Date(localVolume.lastProgressUpdate).getTime();
-          const cloudDate = new Date(cloudVolume.lastProgressUpdate).getTime();
-          
-          // Keep the newer record
-          mergedVolumes[volumeId] = localDate >= cloudDate ? localVolume : cloudVolume;
-        }
-      });
-      
-      // Step 4: Update local volume data with merged data
-      progressTrackerStore.updateProcess(processId, {
-        progress: 60,
-        status: 'Updating local data...'
-      });
-      
-      volumes.update(() => mergedVolumes);
-      
-      // Step 5: Upload merged data to cloud
-      progressTrackerStore.updateProcess(processId, {
-        progress: 80,
-        status: 'Uploading merged data...'
-      });
-      
-      const metadata = {
-        mimeType: type,
-        name: VOLUME_DATA_FILE,
-        parents: [volumeDataId ? null : readerFolderId]
-      };
-      
-      const res = await uploadFile({
-        accessToken,
-        fileId: volumeDataId,
-        metadata,
-        localStorageId: 'volumes',
-        type
-      });
-      
-      volumeDataId = res.id;
-      
-      progressTrackerStore.updateProcess(processId, {
-        progress: 100,
-        status: 'Sync complete'
-      });
-      setTimeout(() => progressTrackerStore.removeProcess(processId), 3000);
-      
-      showSnackbar('Read progress synced successfully');
-    } catch (error) {
-      progressTrackerStore.updateProcess(processId, {
-        progress: 0,
-        status: 'Sync failed'
-      });
-      setTimeout(() => progressTrackerStore.removeProcess(processId), 3000);
-      handleDriveError(error, 'syncing read progress');
-    }
-  }
-  
   // For backward compatibility with the button in the cloud page
-  async function onSyncVolumeData() {
-    await performSync();
+  async function performSync() {
+    await syncReadProgress();
   }
 
   async function onDownloadProfiles() {


### PR DESCRIPTION
This PR replaces the separate "download volume data" and "upload volume data" buttons with a single "sync volume data" button.

The new sync functionality:
- Downloads volume data from Google Drive
- Merges it with local volume data
- In case of conflicts, keeps whichever record is newer based on lastProgressUpdate timestamp
- Updates both local storage and Google Drive with the merged data

Additional improvements:
- Added a sync button to the navigation bar next to the cloud button
- The sync button is disabled if there are no cloud credentials
- Removed the confirmation modal for sync operations since they are non-destructive
- If the access token is expired, the user is prompted to log in and sync is performed automatically after authentication

A helpful tooltip has been added to explain the functionality to users.