### PR TITLE
Fix: Cloud page download button not working

### DIFF
--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -18,8 +18,11 @@
     signIn,
     logout,
     syncReadProgress,
-    READER_FOLDER
+    READER_FOLDER,
+    CLIENT_ID,
+    API_KEY
   } from '$lib/util';
+  import { progressTrackerStore } from '$lib/util/progress-tracker';
   import { get } from 'svelte/store';
   import { Badge, Button, Toggle } from 'flowbite-svelte';
   import { onMount } from 'svelte';


### PR DESCRIPTION
This PR fixes the download button on the cloud page that was broken in recent refactoring.

**Issue:**
- The download button no longer popped up the picker dialog
- This was caused by missing imports after Google Drive functionality was moved to a separate utility file

**Changes:**
- Added imports for `CLIENT_ID` and `API_KEY` from `$lib/util`
- Added import for `progressTrackerStore` from `$lib/util/progress-tracker`

These changes ensure the picker can initialize properly with the correct credentials.