### PR TITLE
Fix text selection drag issue in reader

### DIFF
--- a/src/lib/components/Reader/TextBoxes.svelte
+++ b/src/lib/components/Reader/TextBoxes.svelte
@@ -115,6 +115,10 @@
     white-space: nowrap;
     border: 1px solid rgba(0, 0, 0, 0);
     z-index: 11;
+    user-select: text;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
   }
 
   .textBox:focus,
@@ -132,6 +136,10 @@
     background-color: rgb(255, 255, 255);
     font-weight: var(--bold);
     z-index: 11;
+    user-select: text;
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
   }
 
   .textBox:focus p,

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -21,9 +21,9 @@ export function initPanzoom(node: HTMLElement) {
       // Check if the target is a text box or a child of a text box
       const isTextBox = target.classList.contains('textBox') || 
                         target.closest('.textBox') !== null;
-      // Return false to prevent panning when clicking on text boxes
+      // Return true to prevent panning when clicking on text boxes
       // This allows text selection within text boxes
-      return !isTextBox;
+      return isTextBox;
     },
     beforeWheel: (e) => e.altKey,
     onTouch: (e) => e.touches.length > 1,

--- a/src/lib/panzoom/util.ts
+++ b/src/lib/panzoom/util.ts
@@ -17,8 +17,13 @@ export function initPanzoom(node: HTMLElement) {
     zoomDoubleClickSpeed: 1,
     enableTextSelection: true,
     beforeMouseDown: (e) => {
-      const nodeName = (e.target as HTMLElement).nodeName;
-      return nodeName === 'P';
+      const target = e.target as HTMLElement;
+      // Check if the target is a text box or a child of a text box
+      const isTextBox = target.classList.contains('textBox') || 
+                        target.closest('.textBox') !== null;
+      // Return false to prevent panning when clicking on text boxes
+      // This allows text selection within text boxes
+      return !isTextBox;
     },
     beforeWheel: (e) => e.altKey,
     onTouch: (e) => e.touches.length > 1,


### PR DESCRIPTION
This PR fixes an issue where clicking and dragging to select text in the OCR popup text boxes causes the image to move. The image should only move when clicking and dragging outside of the OCR popup text boxes.