### PR TITLE
Add Google Drive backup functionality for manga volumes

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,14 +1,14 @@
 {
   "permissions": {
     "allow": [
-      "WebFetch(domain:developers.google.com)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(git checkout:*)",
+      "Bash(git log:*)",
+      "Bash(git add:*)",
       "Bash(git commit:*)",
-      "Bash(npm run build:*)",
-      "Bash(npm run dev:*)",
-      "Bash(git pull:*)",
-      "Bash(git stash:*)",
-      "Bash(git cherry-pick:*)",
-      "Bash(gh pr create:*)"
+      "Bash(git push:*)",
+      "Bash(git restore:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/lib/components/BackupButton.svelte
+++ b/src/lib/components/BackupButton.svelte
@@ -36,7 +36,7 @@
 
   // Check if this volume exists in Drive
   let expectedPath = $derived(`${volume.series_title}/${volume.volume_title}.cbz`);
-  let isBackedUp = $derived(() => {
+  let isBackedUp = $derived.by(() => {
     const exists = driveCache.has(expectedPath);
     console.log(`Checking backup status for: ${expectedPath}, exists: ${exists}`);
     console.log('Cache keys:', Array.from(driveCache.keys()));

--- a/src/lib/components/BackupButton.svelte
+++ b/src/lib/components/BackupButton.svelte
@@ -51,6 +51,11 @@
       return;
     }
 
+    if (isBackedUp) {
+      showSnackbar('Volume already backed up', 'info');
+      return;
+    }
+
     isBackingUp = true;
     try {
       await backupVolumeToDrive(volume, (step) => {
@@ -71,9 +76,9 @@
   color={isBackedUp ? 'green' : 'light'}
   size="xs"
   class={className}
-  disabled={isBackingUp || !isAuthenticated}
+  disabled={isBackingUp || !isAuthenticated || isBackedUp}
   on:click={handleBackup}
-  title={isBackedUp ? 'Already backed up to Drive. Click to re-backup.' : 'Backup to Google Drive'}
+  title={isBackedUp ? 'Already backed up to Drive' : 'Backup to Google Drive'}
 >
   {#if isBackingUp}
     <Spinner size="4" class="me-2" />

--- a/src/lib/components/BackupButton.svelte
+++ b/src/lib/components/BackupButton.svelte
@@ -25,7 +25,9 @@
 
   let isAuthenticated = $derived(token !== '');
 
-  async function handleBackup() {
+  async function handleBackup(e: MouseEvent) {
+    e.stopPropagation();
+
     if (!isAuthenticated) {
       showSnackbar('Please sign in to Google Drive first', 'error');
       return;

--- a/src/lib/components/BackupButton.svelte
+++ b/src/lib/components/BackupButton.svelte
@@ -35,9 +35,13 @@
   });
 
   // Check if this volume exists in Drive
-  let isBackedUp = $derived(
-    driveCache.has(`${volume.series_title}/${volume.volume_title}.cbz`)
-  );
+  let expectedPath = $derived(`${volume.series_title}/${volume.volume_title}.cbz`);
+  let isBackedUp = $derived(() => {
+    const exists = driveCache.has(expectedPath);
+    console.log(`Checking backup status for: ${expectedPath}, exists: ${exists}`);
+    console.log('Cache keys:', Array.from(driveCache.keys()));
+    return exists;
+  });
 
   async function handleBackup(e: MouseEvent) {
     e.stopPropagation();

--- a/src/lib/components/BackupButton.svelte
+++ b/src/lib/components/BackupButton.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+  import { Button, Spinner } from 'flowbite-svelte';
+  import { CloudArrowUpOutline } from 'flowbite-svelte-icons';
+  import { backupVolumeToDrive } from '$lib/util';
+  import { showSnackbar } from '$lib/util';
+  import { tokenManager } from '$lib/util/google-drive';
+  import type { VolumeMetadata } from '$lib/types';
+
+  interface Props {
+    volume: VolumeMetadata;
+    class?: string;
+  }
+
+  let { volume, class: className }: Props = $props();
+
+  let isBackingUp = $state(false);
+  let currentStep = $state('');
+  let isAuthenticated = $derived($tokenManager.token !== '');
+
+  async function handleBackup() {
+    if (!isAuthenticated) {
+      showSnackbar('Please sign in to Google Drive first', 'error');
+      return;
+    }
+
+    isBackingUp = true;
+    try {
+      await backupVolumeToDrive(volume, (step) => {
+        currentStep = step;
+      });
+      showSnackbar('Backup completed successfully', 'success');
+    } catch (error) {
+      console.error('Backup failed:', error);
+      showSnackbar(`Backup failed: ${error instanceof Error ? error.message : 'Unknown error'}`, 'error');
+    } finally {
+      isBackingUp = false;
+      currentStep = '';
+    }
+  }
+</script>
+
+<Button
+  color="light"
+  size="xs"
+  class={className}
+  disabled={isBackingUp || !isAuthenticated}
+  on:click={handleBackup}
+>
+  {#if isBackingUp}
+    <Spinner size="4" class="me-2" />
+    {currentStep || 'Backing up...'}
+  {:else}
+    <CloudArrowUpOutline class="w-4 h-4 me-2" />
+    Backup to Drive
+  {/if}
+</Button>

--- a/src/lib/components/BackupButton.svelte
+++ b/src/lib/components/BackupButton.svelte
@@ -102,27 +102,17 @@
 </script>
 
 {#if isBackedUp}
-  <div class="flex gap-1">
-    <Button
-      color="green"
-      size="xs"
-      class={className}
-      disabled={true}
-      title="Already backed up to Drive"
-    >
-      <CheckCircleSolid class="w-4 h-4 me-2" />
-      Backed up
-    </Button>
-    <Button
-      color="red"
-      size="xs"
-      on:click={handleDelete}
-      disabled={!isAuthenticated}
-      title="Delete from Drive (move to trash)"
-    >
-      <TrashBinSolid class="w-4 h-4" />
-    </Button>
-  </div>
+  <Button
+    color="red"
+    size="xs"
+    class={className}
+    on:click={handleDelete}
+    disabled={!isAuthenticated}
+    title="Delete from Drive (move to trash)"
+  >
+    <TrashBinSolid class="w-4 h-4 me-2" />
+    Delete from Drive
+  </Button>
 {:else}
   <Button
     color="light"

--- a/src/lib/components/BackupButton.svelte
+++ b/src/lib/components/BackupButton.svelte
@@ -15,7 +15,15 @@
 
   let isBackingUp = $state(false);
   let currentStep = $state('');
-  let isAuthenticated = $derived($tokenManager.token !== '');
+
+  let token = $state('');
+  $effect(() => {
+    return tokenManager.token.subscribe(value => {
+      token = value;
+    });
+  });
+
+  let isAuthenticated = $derived(token !== '');
 
   async function handleBackup() {
     if (!isAuthenticated) {

--- a/src/lib/components/BackupButton.svelte
+++ b/src/lib/components/BackupButton.svelte
@@ -34,11 +34,11 @@
     });
   });
 
-  // Check if this volume exists in Drive
-  let expectedPath = $derived(`${volume.series_title}/${volume.volume_title}.cbz`);
+  // Check if this volume exists in Drive (by filename)
+  let expectedFilename = $derived(`${volume.volume_title}.cbz`);
   let isBackedUp = $derived.by(() => {
-    const exists = driveCache.has(expectedPath);
-    console.log(`Checking backup status for: ${expectedPath}, exists: ${exists}`);
+    const exists = driveCache.has(expectedFilename);
+    console.log(`Checking backup status for: ${expectedFilename}, exists: ${exists}`);
     console.log('Cache keys:', Array.from(driveCache.keys()));
     return exists;
   });

--- a/src/lib/components/BackupButton.svelte
+++ b/src/lib/components/BackupButton.svelte
@@ -34,11 +34,11 @@
     });
   });
 
-  // Check if this volume exists in Drive (by filename)
-  let expectedFilename = $derived(`${volume.volume_title}.cbz`);
+  // Check if this volume exists in Drive (by parent/filename path)
+  let expectedPath = $derived(`${volume.series_title}/${volume.volume_title}.cbz`);
   let isBackedUp = $derived.by(() => {
-    const exists = driveCache.has(expectedFilename);
-    console.log(`Checking backup status for: ${expectedFilename}, exists: ${exists}`);
+    const exists = driveCache.has(expectedPath);
+    console.log(`Checking backup status for: ${expectedPath}, exists: ${exists}`);
     console.log('Cache keys:', Array.from(driveCache.keys()));
     return exists;
   });

--- a/src/lib/components/VolumeItem.svelte
+++ b/src/lib/components/VolumeItem.svelte
@@ -7,6 +7,7 @@
   import { CheckCircleSolid, TrashBinSolid } from 'flowbite-svelte-icons';
   import { goto } from '$app/navigation';
   import { db } from '$lib/catalog/db';
+  import BackupButton from './BackupButton.svelte';
 
   interface Props {
     volume: VolumeMetadata;
@@ -85,7 +86,8 @@
           <p class="font-semibold" class:text-white={!isComplete}>{volName}</p>
           <p>{progressDisplay}</p>
         </div>
-        <div class="flex gap-2">
+        <div class="flex gap-2 items-center">
+          <BackupButton {volume} class="mr-2" />
           <button onclick={onDeleteClicked} class="flex items-center justify-center">
             <TrashBinSolid class="text-red-400 hover:text-red-500 z-10 poin" />
           </button>

--- a/src/lib/util/backup.ts
+++ b/src/lib/util/backup.ts
@@ -1,5 +1,6 @@
 import type { VolumeMetadata } from '$lib/types';
 import { driveApiClient } from './google-drive/api-client';
+import { driveFilesCache } from './google-drive/drive-files-cache';
 import { createArchiveBlob } from './zip';
 
 /**
@@ -143,6 +144,15 @@ export async function backupVolumeToDrive(
       console.warn('Failed to delete old file:', error);
     }
   }
+
+  // Update the cache with the newly uploaded file
+  driveFilesCache.addDriveFile(volume.series_title, volume.volume_title, {
+    fileId,
+    name: fileName,
+    modifiedTime: new Date().toISOString(),
+    size: cbzBlob.size,
+    path: `${volume.series_title}/${fileName}`
+  });
 
   return fileId;
 }

--- a/src/lib/util/backup.ts
+++ b/src/lib/util/backup.ts
@@ -1,0 +1,148 @@
+import type { VolumeMetadata } from '$lib/types';
+import { driveApiClient } from './google-drive/api-client';
+import { createArchiveBlob } from './zip';
+
+/**
+ * Uploads a CBZ blob to Google Drive
+ * @param blob The CBZ blob to upload
+ * @param filename The name for the file
+ * @param parentFolderId Optional parent folder ID
+ * @returns Promise resolving to the uploaded file ID
+ */
+export async function uploadCbzToDrive(
+  blob: Blob,
+  filename: string,
+  parentFolderId?: string
+): Promise<string> {
+  // Convert blob to base64
+  const reader = new FileReader();
+  const base64Promise = new Promise<string>((resolve, reject) => {
+    reader.onload = () => {
+      const result = reader.result as string;
+      // Remove data URL prefix to get just the base64 string
+      const base64 = result.split(',')[1];
+      resolve(base64);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+
+  const base64Content = await base64Promise;
+
+  // Upload using multipart upload
+  const boundary = '-------314159265358979323846';
+  const delimiter = '\r\n--' + boundary + '\r\n';
+  const closeDelimiter = '\r\n--' + boundary + '--';
+
+  const metadata = {
+    name: filename,
+    mimeType: 'application/x-cbz',
+    ...(parentFolderId && { parents: [parentFolderId] })
+  };
+
+  const multipartRequestBody =
+    delimiter +
+    'Content-Type: application/json; charset=UTF-8\r\n\r\n' +
+    JSON.stringify(metadata) +
+    delimiter +
+    'Content-Type: application/x-cbz\r\n' +
+    'Content-Transfer-Encoding: base64\r\n\r\n' +
+    base64Content +
+    closeDelimiter;
+
+  const response = await gapi.client.request({
+    path: '/upload/drive/v3/files',
+    method: 'POST',
+    params: { uploadType: 'multipart' },
+    headers: {
+      'Content-Type': 'multipart/related; boundary="' + boundary + '"'
+    },
+    body: multipartRequestBody
+  });
+
+  return response.result.id;
+}
+
+/**
+ * Finds or creates a folder in Google Drive
+ * @param folderName The name of the folder
+ * @param parentFolderId Optional parent folder ID
+ * @returns Promise resolving to the folder ID
+ */
+export async function getOrCreateFolder(
+  folderName: string,
+  parentFolderId?: string
+): Promise<string> {
+  // Search for existing folder
+  const query = parentFolderId
+    ? `name='${folderName}' and '${parentFolderId}' in parents and mimeType='application/vnd.google-apps.folder' and trashed=false`
+    : `name='${folderName}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
+
+  const files = await driveApiClient.listFiles(query, 'files(id, name)');
+
+  if (files.length > 0) {
+    return files[0].id;
+  }
+
+  // Create folder if it doesn't exist
+  return await driveApiClient.createFolder(folderName, parentFolderId);
+}
+
+/**
+ * Checks if a file exists in Google Drive
+ * @param fileName The name of the file
+ * @param parentFolderId Optional parent folder ID
+ * @returns Promise resolving to the file ID if it exists, or null
+ */
+export async function findFile(
+  fileName: string,
+  parentFolderId?: string
+): Promise<string | null> {
+  const query = parentFolderId
+    ? `name='${fileName}' and '${parentFolderId}' in parents and trashed=false`
+    : `name='${fileName}' and trashed=false`;
+
+  const files = await driveApiClient.listFiles(query, 'files(id, name)');
+
+  return files.length > 0 ? files[0].id : null;
+}
+
+/**
+ * Backs up a volume to Google Drive
+ * @param volume The volume to backup
+ * @param onProgress Optional progress callback (current, total)
+ * @returns Promise resolving to the uploaded file ID
+ */
+export async function backupVolumeToDrive(
+  volume: VolumeMetadata,
+  onProgress?: (step: string) => void
+): Promise<string> {
+  // Create the series folder
+  onProgress?.('Creating folder...');
+  const rootFolderId = await getOrCreateFolder('mokuro-reader');
+  const seriesFolderId = await getOrCreateFolder(volume.series_title, rootFolderId);
+
+  // Check if file already exists
+  const fileName = `${volume.volume_title}.cbz`;
+  onProgress?.('Checking for existing file...');
+  const existingFileId = await findFile(fileName, seriesFolderId);
+
+  // Create CBZ using the shared function
+  onProgress?.('Creating archive...');
+  const cbzBlob = await createArchiveBlob([volume]);
+
+  // Upload
+  onProgress?.('Uploading to Google Drive...');
+  const fileId = await uploadCbzToDrive(cbzBlob, fileName, seriesFolderId);
+
+  // Delete old file if it existed and is different from the new one
+  if (existingFileId && existingFileId !== fileId) {
+    try {
+      await gapi.client.drive.files.delete({ fileId: existingFileId });
+    } catch (error) {
+      console.warn('Failed to delete old file:', error);
+    }
+  }
+
+  return fileId;
+}

--- a/src/lib/util/backup.ts
+++ b/src/lib/util/backup.ts
@@ -151,7 +151,7 @@ export async function backupVolumeToDrive(
     name: fileName,
     modifiedTime: new Date().toISOString(),
     size: cbzBlob.size,
-    path: `${volume.series_title}/${fileName}`
+    path: fileName // Just filename for simple lookup
   });
 
   return fileId;

--- a/src/lib/util/backup.ts
+++ b/src/lib/util/backup.ts
@@ -151,7 +151,7 @@ export async function backupVolumeToDrive(
     name: fileName,
     modifiedTime: new Date().toISOString(),
     size: cbzBlob.size,
-    path: fileName // Just filename for simple lookup
+    path: `${volume.series_title}/${fileName}`
   });
 
   return fileId;

--- a/src/lib/util/google-drive/api-client.ts
+++ b/src/lib/util/google-drive/api-client.ts
@@ -146,6 +146,21 @@ class DriveApiClient {
     });
   }
 
+  async trashFile(fileId: string): Promise<void> {
+    return this.handleApiCall(async () => {
+      await gapi.client.drive.files.update({
+        fileId,
+        resource: { trashed: true }
+      });
+    });
+  }
+
+  async trashFiles(fileIds: string[]): Promise<void> {
+    // Batch delete by trashing each file
+    const promises = fileIds.map(fileId => this.trashFile(fileId));
+    await Promise.all(promises);
+  }
+
   private getCurrentToken(): string {
     let token = '';
     tokenManager.token.subscribe(value => { token = value; })();

--- a/src/lib/util/google-drive/api-client.ts
+++ b/src/lib/util/google-drive/api-client.ts
@@ -40,6 +40,9 @@ class DriveApiClient {
     try {
       return await apiCall();
     } catch (error: any) {
+      console.error('Drive API error caught:', error);
+      console.error('Error details - status:', error.status, 'message:', error.message);
+
       const isNetworkError = error.message?.toLowerCase().includes('network') ||
         error.message?.toLowerCase().includes('offline') ||
         error.status === 0;

--- a/src/lib/util/google-drive/backup-cache.ts
+++ b/src/lib/util/google-drive/backup-cache.ts
@@ -1,0 +1,163 @@
+import { writable } from 'svelte/store';
+import { driveApiClient } from './api-client';
+import { GOOGLE_DRIVE_CONFIG } from './constants';
+
+export interface BackupFileMetadata {
+  fileId: string;
+  name: string;
+  modifiedTime: string;
+  path: string; // Constructed path like "series/volume.cbz"
+}
+
+class BackupCacheManager {
+  private cache = writable<Map<string, BackupFileMetadata>>(new Map());
+  private isFetching = false;
+  private lastFetchTime: number | null = null;
+
+  get store() {
+    return this.cache;
+  }
+
+  /**
+   * Fetch metadata for ALL .cbz files in the mokuro-reader folder
+   * and cache them in memory for the session
+   */
+  async fetchAllBackups(): Promise<void> {
+    if (this.isFetching) {
+      console.log('Backup cache fetch already in progress');
+      return;
+    }
+
+    this.isFetching = true;
+    try {
+      console.log('Fetching all backup metadata from Google Drive...');
+
+      // Find the mokuro-reader folder
+      const folderResponse = await driveApiClient.listFiles(
+        `name='${GOOGLE_DRIVE_CONFIG.APP_FOLDER_NAME}' and mimeType='${GOOGLE_DRIVE_CONFIG.MIME_TYPES.FOLDER}' and trashed=false`,
+        'id, name'
+      );
+
+      if (!folderResponse.files || folderResponse.files.length === 0) {
+        console.log('No mokuro-reader folder found, cache is empty');
+        this.cache.set(new Map());
+        this.lastFetchTime = Date.now();
+        return;
+      }
+
+      const appFolderId = folderResponse.files[0].id;
+
+      // Recursively list all .cbz files in the folder structure
+      const allFiles = await this.listAllCbzFiles(appFolderId);
+
+      const cacheMap = new Map<string, BackupFileMetadata>();
+
+      for (const file of allFiles) {
+        if (file.path) {
+          cacheMap.set(file.path, file);
+        }
+      }
+
+      console.log(`Cached ${cacheMap.size} backup files`);
+      this.cache.set(cacheMap);
+      this.lastFetchTime = Date.now();
+    } catch (error) {
+      console.error('Failed to fetch backup cache:', error);
+      // Don't clear cache on error, keep stale data
+    } finally {
+      this.isFetching = false;
+    }
+  }
+
+  /**
+   * Recursively list all .cbz files and build their paths
+   */
+  private async listAllCbzFiles(
+    folderId: string,
+    parentPath: string = ''
+  ): Promise<BackupFileMetadata[]> {
+    const files: BackupFileMetadata[] = [];
+
+    // Get all items in this folder
+    const response = await driveApiClient.listFiles(
+      `'${folderId}' in parents and trashed=false`,
+      'id, name, mimeType, modifiedTime'
+    );
+
+    if (!response.files) return files;
+
+    for (const item of response.files) {
+      const currentPath = parentPath ? `${parentPath}/${item.name}` : item.name;
+
+      if (item.mimeType === GOOGLE_DRIVE_CONFIG.MIME_TYPES.FOLDER) {
+        // Recurse into subfolders
+        const subFiles = await this.listAllCbzFiles(item.id, currentPath);
+        files.push(...subFiles);
+      } else if (item.name.endsWith('.cbz')) {
+        files.push({
+          fileId: item.id,
+          name: item.name,
+          modifiedTime: item.modifiedTime,
+          path: currentPath
+        });
+      }
+    }
+
+    return files;
+  }
+
+  /**
+   * Check if a volume is backed up by constructing its expected path
+   */
+  isBackedUp(seriesTitle: string, volumeTitle: string): boolean {
+    let currentCache: Map<string, BackupFileMetadata> = new Map();
+    this.cache.subscribe((value) => {
+      currentCache = value;
+    })();
+
+    const expectedPath = `${seriesTitle}/${volumeTitle}.cbz`;
+    return currentCache.has(expectedPath);
+  }
+
+  /**
+   * Get backup metadata for a specific volume
+   */
+  getBackupMetadata(seriesTitle: string, volumeTitle: string): BackupFileMetadata | undefined {
+    let currentCache: Map<string, BackupFileMetadata> = new Map();
+    this.cache.subscribe((value) => {
+      currentCache = value;
+    })();
+
+    const expectedPath = `${seriesTitle}/${volumeTitle}.cbz`;
+    return currentCache.get(expectedPath);
+  }
+
+  /**
+   * Add or update a backup entry in the cache after successful upload
+   */
+  updateCache(seriesTitle: string, volumeTitle: string, metadata: BackupFileMetadata): void {
+    this.cache.update((cache) => {
+      const expectedPath = `${seriesTitle}/${volumeTitle}.cbz`;
+      const newCache = new Map(cache);
+      newCache.set(expectedPath, metadata);
+      return newCache;
+    });
+  }
+
+  /**
+   * Clear the entire cache (useful for sign out)
+   */
+  clearCache(): void {
+    this.cache.set(new Map());
+    this.lastFetchTime = null;
+  }
+
+  /**
+   * Get time since last fetch (for debugging/UI)
+   */
+  getLastFetchTime(): number | null {
+    return this.lastFetchTime;
+  }
+}
+
+export const backupCacheManager = new BackupCacheManager();

--- a/src/lib/util/google-drive/constants.ts
+++ b/src/lib/util/google-drive/constants.ts
@@ -1,3 +1,23 @@
+export interface TokenInfo {
+  access_token: string;
+  expires_in: number;
+  expires_at: number;
+  refresh_token?: string;
+}
+
+export interface DriveFile {
+  id: string;
+  name: string;
+  mimeType: string;
+  size?: string;
+}
+
+export interface SyncProgress {
+  phase: 'connecting' | 'downloading' | 'merging' | 'uploading' | 'complete' | 'error';
+  progress: number;
+  status: string;
+}
+
 export const GOOGLE_DRIVE_CONFIG = {
   CLIENT_ID: import.meta.env.VITE_GDRIVE_CLIENT_ID,
   API_KEY: import.meta.env.VITE_GDRIVE_API_KEY,

--- a/src/lib/util/google-drive/drive-files-cache.ts
+++ b/src/lib/util/google-drive/drive-files-cache.ts
@@ -44,10 +44,12 @@ class DriveFilesCacheManager {
       console.log('Fetching all Drive file metadata...');
 
       // Find the mokuro-reader folder
+      console.log('Searching for folder:', GOOGLE_DRIVE_CONFIG.APP_FOLDER_NAME);
       const folderResponse = await driveApiClient.listFiles(
         `name='${GOOGLE_DRIVE_CONFIG.APP_FOLDER_NAME}' and mimeType='${GOOGLE_DRIVE_CONFIG.MIME_TYPES.FOLDER}' and trashed=false`,
         'id, name'
       );
+      console.log('Folder search response:', folderResponse);
 
       if (!folderResponse || folderResponse.length === 0) {
         console.log('No mokuro-reader folder found, cache is empty');
@@ -75,6 +77,11 @@ class DriveFilesCacheManager {
       this.lastFetchTime = Date.now();
     } catch (error) {
       console.error('Failed to fetch Drive files cache:', error);
+      console.error('Error details:', error);
+      if (error instanceof Error) {
+        console.error('Error message:', error.message);
+        console.error('Error stack:', error.stack);
+      }
       // Don't clear cache on error, keep stale data
     } finally {
       this.isFetching = false;

--- a/src/lib/util/google-drive/drive-files-cache.ts
+++ b/src/lib/util/google-drive/drive-files-cache.ts
@@ -49,14 +49,14 @@ class DriveFilesCacheManager {
         'id, name'
       );
 
-      if (!folderResponse.files || folderResponse.files.length === 0) {
+      if (!folderResponse || folderResponse.length === 0) {
         console.log('No mokuro-reader folder found, cache is empty');
         this.cache.set(new Map());
         this.lastFetchTime = Date.now();
         return;
       }
 
-      const appFolderId = folderResponse.files[0].id;
+      const appFolderId = folderResponse[0].id;
 
       // Recursively list all .cbz files in the folder structure
       const allFiles = await this.listAllCbzFiles(appFolderId);
@@ -96,9 +96,9 @@ class DriveFilesCacheManager {
       'id, name, mimeType, modifiedTime, size'
     );
 
-    if (!response.files) return files;
+    if (!response) return files;
 
-    for (const item of response.files) {
+    for (const item of response) {
       const currentPath = parentPath ? `${parentPath}/${item.name}` : item.name;
 
       if (item.mimeType === GOOGLE_DRIVE_CONFIG.MIME_TYPES.FOLDER) {

--- a/src/lib/util/google-drive/drive-files-cache.ts
+++ b/src/lib/util/google-drive/drive-files-cache.ts
@@ -46,7 +46,7 @@ class DriveFilesCacheManager {
       // Query for ALL .cbz files the app can see (no parent folder constraint)
       const allCbzFiles = await driveApiClient.listFiles(
         `name contains '.cbz' and trashed=false`,
-        'id, name, mimeType, modifiedTime, size, parents'
+        'files(id,name,mimeType,modifiedTime,size,parents)'
       );
       console.log('Found .cbz files:', allCbzFiles);
 

--- a/src/lib/util/google-drive/drive-files-cache.ts
+++ b/src/lib/util/google-drive/drive-files-cache.ts
@@ -1,0 +1,223 @@
+import { writable } from 'svelte/store';
+import { driveApiClient } from './api-client';
+import { GOOGLE_DRIVE_CONFIG } from './constants';
+
+export interface DriveFileMetadata {
+  fileId: string;
+  name: string;
+  modifiedTime: string;
+  size?: number;
+  path: string; // Relative path like "series/volume.cbz"
+}
+
+/**
+ * In-memory representation of Google Drive's mokuro-reader folder state
+ *
+ * This cache mirrors the state of ALL .cbz files in Google Drive, serving two purposes:
+ * 1. Detect backup status by checking if local volume paths exist in Drive (path collision check)
+ * 2. Discover remote-only files for download placeholders (future feature)
+ *
+ * The cache is populated with a single bulk API call and lives only for the session.
+ * It does NOT track local files - only what exists in Google Drive.
+ */
+class DriveFilesCacheManager {
+  private cache = writable<Map<string, DriveFileMetadata>>(new Map());
+  private isFetching = false;
+  private lastFetchTime: number | null = null;
+
+  get store() {
+    return this.cache;
+  }
+
+  /**
+   * Fetch metadata for ALL .cbz files in the mokuro-reader folder
+   * and cache them in memory for the session
+   */
+  async fetchAllFiles(): Promise<void> {
+    if (this.isFetching) {
+      console.log('Drive files cache fetch already in progress');
+      return;
+    }
+
+    this.isFetching = true;
+    try {
+      console.log('Fetching all Drive file metadata...');
+
+      // Find the mokuro-reader folder
+      const folderResponse = await driveApiClient.listFiles(
+        `name='${GOOGLE_DRIVE_CONFIG.APP_FOLDER_NAME}' and mimeType='${GOOGLE_DRIVE_CONFIG.MIME_TYPES.FOLDER}' and trashed=false`,
+        'id, name'
+      );
+
+      if (!folderResponse.files || folderResponse.files.length === 0) {
+        console.log('No mokuro-reader folder found, cache is empty');
+        this.cache.set(new Map());
+        this.lastFetchTime = Date.now();
+        return;
+      }
+
+      const appFolderId = folderResponse.files[0].id;
+
+      // Recursively list all .cbz files in the folder structure
+      const allFiles = await this.listAllCbzFiles(appFolderId);
+
+      const cacheMap = new Map<string, DriveFileMetadata>();
+
+      for (const file of allFiles) {
+        if (file.path) {
+          cacheMap.set(file.path, file);
+        }
+      }
+
+      console.log(`Cached ${cacheMap.size} Drive files`);
+      this.cache.set(cacheMap);
+      this.lastFetchTime = Date.now();
+    } catch (error) {
+      console.error('Failed to fetch Drive files cache:', error);
+      // Don't clear cache on error, keep stale data
+    } finally {
+      this.isFetching = false;
+    }
+  }
+
+  /**
+   * Recursively list all .cbz files and build their paths
+   */
+  private async listAllCbzFiles(
+    folderId: string,
+    parentPath: string = ''
+  ): Promise<DriveFileMetadata[]> {
+    const files: DriveFileMetadata[] = [];
+
+    // Get all items in this folder
+    const response = await driveApiClient.listFiles(
+      `'${folderId}' in parents and trashed=false`,
+      'id, name, mimeType, modifiedTime, size'
+    );
+
+    if (!response.files) return files;
+
+    for (const item of response.files) {
+      const currentPath = parentPath ? `${parentPath}/${item.name}` : item.name;
+
+      if (item.mimeType === GOOGLE_DRIVE_CONFIG.MIME_TYPES.FOLDER) {
+        // Recurse into subfolders
+        const subFiles = await this.listAllCbzFiles(item.id, currentPath);
+        files.push(...subFiles);
+      } else if (item.name.endsWith('.cbz')) {
+        files.push({
+          fileId: item.id,
+          name: item.name,
+          modifiedTime: item.modifiedTime,
+          size: item.size ? parseInt(item.size) : undefined,
+          path: currentPath
+        });
+      }
+    }
+
+    return files;
+  }
+
+  /**
+   * Check if a file exists in Google Drive by path
+   * Used to determine if a local volume is already backed up
+   */
+  existsInDrive(seriesTitle: string, volumeTitle: string): boolean {
+    let currentCache: Map<string, DriveFileMetadata> = new Map();
+    this.cache.subscribe((value) => {
+      currentCache = value;
+    })();
+
+    const expectedPath = `${seriesTitle}/${volumeTitle}.cbz`;
+    return currentCache.has(expectedPath);
+  }
+
+  /**
+   * Get Drive file metadata by path
+   */
+  getDriveFile(seriesTitle: string, volumeTitle: string): DriveFileMetadata | undefined {
+    let currentCache: Map<string, DriveFileMetadata> = new Map();
+    this.cache.subscribe((value) => {
+      currentCache = value;
+    })();
+
+    const expectedPath = `${seriesTitle}/${volumeTitle}.cbz`;
+    return currentCache.get(expectedPath);
+  }
+
+  /**
+   * Get all files that exist in Drive
+   * Future use: Discover remote-only volumes for download placeholders
+   */
+  getAllDriveFiles(): DriveFileMetadata[] {
+    let currentCache: Map<string, DriveFileMetadata> = new Map();
+    this.cache.subscribe((value) => {
+      currentCache = value;
+    })();
+
+    return Array.from(currentCache.values());
+  }
+
+  /**
+   * Get all Drive files for a specific series
+   * Future use: Show remote-only volumes in series view
+   */
+  getDriveFilesBySeries(seriesTitle: string): DriveFileMetadata[] {
+    let currentCache: Map<string, DriveFileMetadata> = new Map();
+    this.cache.subscribe((value) => {
+      currentCache = value;
+    })();
+
+    return Array.from(currentCache.values()).filter((file) =>
+      file.path.startsWith(`${seriesTitle}/`)
+    );
+  }
+
+  /**
+   * Add or update the Drive state after successful upload
+   */
+  addDriveFile(seriesTitle: string, volumeTitle: string, metadata: DriveFileMetadata): void {
+    this.cache.update((cache) => {
+      const expectedPath = `${seriesTitle}/${volumeTitle}.cbz`;
+      const newCache = new Map(cache);
+      newCache.set(expectedPath, metadata);
+      return newCache;
+    });
+  }
+
+  /**
+   * Remove from cache after deletion from Drive
+   */
+  removeDriveFile(seriesTitle: string, volumeTitle: string): void {
+    this.cache.update((cache) => {
+      const expectedPath = `${seriesTitle}/${volumeTitle}.cbz`;
+      const newCache = new Map(cache);
+      newCache.delete(expectedPath);
+      return newCache;
+    });
+  }
+
+  /**
+   * Clear the entire cache (useful for sign out)
+   */
+  clearCache(): void {
+    this.cache.set(new Map());
+    this.lastFetchTime = null;
+  }
+
+  /**
+   * Get time since last fetch (for debugging/UI)
+   */
+  getLastFetchTime(): number | null {
+    return this.lastFetchTime;
+  }
+
+  /**
+   * Check if cache is currently being fetched
+   */
+  isFetchingCache(): boolean {
+    return this.isFetching;
+  }
+}
+
+export const driveFilesCache = new DriveFilesCacheManager();

--- a/src/lib/util/google-drive/drive-files-cache.ts
+++ b/src/lib/util/google-drive/drive-files-cache.ts
@@ -69,7 +69,8 @@ class DriveFilesCacheManager {
         }
       }
 
-      console.log(`Cached ${cacheMap.size} Drive files`);
+      console.log(`Cached ${cacheMap.size} Drive files:`);
+      console.log('Cache paths:', Array.from(cacheMap.keys()));
       this.cache.set(cacheMap);
       this.lastFetchTime = Date.now();
     } catch (error) {

--- a/src/lib/util/index.ts
+++ b/src/lib/util/index.ts
@@ -7,3 +7,4 @@ export * from './cloud';
 export * from './sync-store';
 export * from './google-drive';
 export * from './activity-tracker';
+export * from './backup';

--- a/src/routes/[manga]/+page.svelte
+++ b/src/routes/[manga]/+page.svelte
@@ -2,6 +2,7 @@
   import { catalog } from '$lib/catalog';
   import { goto } from '$app/navigation';
   import VolumeItem from '$lib/components/VolumeItem.svelte';
+  import BackupButton from '$lib/components/BackupButton.svelte';
   import { Button, Listgroup } from 'flowbite-svelte';
   import { db } from '$lib/catalog/db';
   import { promptConfirmation, zipManga } from '$lib/util';

--- a/src/routes/[manga]/+page.svelte
+++ b/src/routes/[manga]/+page.svelte
@@ -181,7 +181,7 @@
           <p>Minutes read: {$mangaStats.timeReadInMinutes}</p>
         </div>
       </div>
-      <div class="flex flex-col gap-2">
+      <div class="flex flex-row gap-2 items-start">
         <Button
           color={allBackedUp ? 'green' : 'light'}
           on:click={backupSeries}

--- a/src/routes/[manga]/+page.svelte
+++ b/src/routes/[manga]/+page.svelte
@@ -295,11 +295,10 @@
             {anyBackedUp ? 'Backup remaining volumes' : 'Backup series to Drive'}
           {/if}
         </Button>
-        {#if anyBackedUp}
+        {#if anyBackedUp && isAuthenticated}
           <Button
             color="red"
             on:click={onDeleteFromDrive}
-            disabled={!isAuthenticated}
           >
             <TrashBinSolid class="w-4 h-4 me-2" />
             Delete from Drive

--- a/src/routes/[manga]/+page.svelte
+++ b/src/routes/[manga]/+page.svelte
@@ -279,29 +279,28 @@
         </div>
       </div>
       <div class="flex flex-row gap-2 items-start">
-        <Button
-          color={allBackedUp ? 'green' : 'light'}
-          on:click={backupSeries}
-          disabled={backingUpSeries || allBackedUp || !isAuthenticated}
-        >
-          {#if backingUpSeries}
-            <Spinner size="4" class="me-2" />
-            Backing up {backupProgress}
-          {:else if allBackedUp}
-            <CloudArrowUpOutline class="w-4 h-4 me-2" />
-            Series backed up
-          {:else}
-            <CloudArrowUpOutline class="w-4 h-4 me-2" />
-            {anyBackedUp ? 'Backup remaining volumes' : 'Backup series to Drive'}
-          {/if}
-        </Button>
+        {#if !allBackedUp}
+          <Button
+            color="light"
+            on:click={backupSeries}
+            disabled={backingUpSeries || !isAuthenticated}
+          >
+            {#if backingUpSeries}
+              <Spinner size="4" class="me-2" />
+              Backing up {backupProgress}
+            {:else}
+              <CloudArrowUpOutline class="w-4 h-4 me-2" />
+              {anyBackedUp ? 'Backup remaining volumes' : 'Backup series to Drive'}
+            {/if}
+          </Button>
+        {/if}
         {#if anyBackedUp && isAuthenticated}
           <Button
             color="red"
             on:click={onDeleteFromDrive}
           >
             <TrashBinSolid class="w-4 h-4 me-2" />
-            Delete from Drive
+            Delete series from Drive
           </Button>
         {/if}
         <Button color="alternative" on:click={onDelete}>Remove manga</Button>


### PR DESCRIPTION
This adds the ability to backup individual volumes or entire series to Google Drive as CBZ archives, recreating the functionality from PR #69.

Features:
- Individual volume backup button on each volume in series page
- Backup all series button on cloud page with progress tracking
- Automatic folder organization (mokuro-reader/[series]/[volume].cbz)
- Deduplication: checks for existing files before uploading
- Reuses existing zip/archive creation code for consistency
- Progress tracking for backup operations

Implementation:
- Created backup.ts utility module with helper functions:
  * uploadCbzToDrive() - Handles multipart upload to Google Drive
  * getOrCreateFolder() - Finds or creates folders with deduplication
  * findFile() - Checks for existing files
  * backupVolumeToDrive() - Main backup function with progress callbacks
- Created BackupButton.svelte component for individual volumes
- Extended cloud page with backupAllSeries() function
- Refactored zip.ts to export createArchiveBlob() for reuse
- Moved type definitions to constants.ts to fix import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)