### PR TITLE
Fix activity tracker callbacks firing on every page turn

### DIFF
--- a/src/lib/util/activity-tracker.ts
+++ b/src/lib/util/activity-tracker.ts
@@ -13,6 +13,7 @@ class ActivityTracker {
   private isActive = writable(false);
   private callbacks: ActivityCallback | null = null;
   private timeoutDuration = 5 * 60 * 1000; // 5 minutes in milliseconds
+  private currentActiveState = false;
 
   constructor() {
     if (browser) {
@@ -23,6 +24,7 @@ class ActivityTracker {
         } else {
           this.callbacks?.onInactive();
         }
+        this.currentActiveState = active;
       });
     }
   }
@@ -54,8 +56,10 @@ class ActivityTracker {
       clearTimeout(this.timeoutId);
     }
 
-    // Set active state
-    this.isActive.set(true);
+    // Set active state only if currently inactive to avoid triggering callbacks repeatedly
+    if (!this.currentActiveState) {
+      this.isActive.set(true);
+    }
 
     // Set new timeout
     this.timeoutId = window.setTimeout(() => {


### PR DESCRIPTION
This fixes a bug where the activity tracker's onActive callback was being triggered on every page turn, instead of only when transitioning from inactive to active state.

The issue was that recordActivity() called isActive.set(true) every time, which triggered the Svelte store subscription even when the value was already true. This caused unnecessary callback invocations.

Changes:
- Track current active state in currentActiveState property
- Only call isActive.set(true) when transitioning from inactive to active
- Inactivity timer countdown still resets on each page turn (desired behavior)

This ensures the timer starts only once when activity begins, and callbacks are only triggered on state changes, not on every page turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)