### PR TITLE
Fix Google Drive API pagination to support >1000 files

### DIFF
--- a/src/lib/util/google-drive/api-client.ts
+++ b/src/lib/util/google-drive/api-client.ts
@@ -92,12 +92,25 @@ class DriveApiClient {
 
   async listFiles(query: string, fields = 'files(id, name, mimeType)'): Promise<DriveFile[]> {
     return this.handleApiCall(async () => {
-      const { result } = await gapi.client.drive.files.list({
-        q: query,
-        fields,
-        pageSize: 1000
-      });
-      return result.files || [];
+      const allFiles: DriveFile[] = [];
+      let pageToken: string | undefined = undefined;
+
+      do {
+        const { result } = await gapi.client.drive.files.list({
+          q: query,
+          fields: `nextPageToken, ${fields}`,
+          pageSize: 1000,
+          pageToken
+        });
+
+        if (result.files) {
+          allFiles.push(...(result.files as DriveFile[]));
+        }
+
+        pageToken = result.nextPageToken;
+      } while (pageToken);
+
+      return allFiles;
     });
   }
 


### PR DESCRIPTION
## Summary
- Implement pagination in `listFiles()` method to fetch all Drive files, not just first 1000
- Use `nextPageToken` to iterate through all pages of results

## Technical Details
The Google Drive API returns results in pages of max 1000 items. The previous implementation only fetched the first page, which meant users with >1000 files in Drive would have incomplete cache data and incorrect backup status indicators.

This fix:
- Adds a do-while loop to fetch all pages
- Accumulates results across all pages
- Includes `nextPageToken` in fields to enable pagination
- Passes `pageToken` to each subsequent request

## Test plan
- [ ] Test with Drive account containing <1000 files (should work as before)
- [ ] Test with Drive account containing >1000 files (should now see all files in cache)
- [ ] Verify backup status indicators work correctly with large file counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)