### PR TITLE
Add Google Drive connection state visibility

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -26,7 +26,9 @@
       "Bash(node:*)",
       "WebSearch",
       "Bash(git clean:*)",
-      "Bash(git pull:*)"
+      "Bash(git pull:*)",
+      "Bash(gh pr close:*)",
+      "Bash(gh pr create:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,9 @@
       "Bash(npm install:*)",
       "Bash(Select-String -Pattern \"Error|error|vite\")",
       "Bash(node:*)",
-      "WebSearch"
+      "WebSearch",
+      "Bash(git clean:*)",
+      "Bash(git pull:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/lib/components/BackupButton.svelte
+++ b/src/lib/components/BackupButton.svelte
@@ -21,7 +21,8 @@
     isAuthenticated: false,
     isCacheLoading: false,
     isCacheLoaded: false,
-    isFullyConnected: false
+    isFullyConnected: false,
+    needsAttention: false
   });
   $effect(() => {
     return driveState.subscribe(value => {

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -46,11 +46,7 @@
   }
   
   function handleSync() {
-    if (!state.isAuthenticated) {
-      showSnackbar('Please sign in to Google Drive first', 'error');
-      return;
-    }
-    // Use the syncReadProgress function from the google-drive utility
+    // syncReadProgress handles login if not authenticated or in error state
     syncReadProgress();
   }
   

--- a/src/lib/components/NavBar.svelte
+++ b/src/lib/components/NavBar.svelte
@@ -20,7 +20,8 @@
     isAuthenticated: false,
     isCacheLoading: false,
     isCacheLoaded: false,
-    isFullyConnected: false
+    isFullyConnected: false,
+    needsAttention: false
   });
 
   // Subscribe to drive state
@@ -85,9 +86,11 @@
       <button
         onclick={navigateToCloud}
         class="flex items-center justify-center w-6 h-6"
-        title={state.isFullyConnected ? "Google Drive - Connected" : state.isAuthenticated ? "Google Drive - Loading..." : "Google Drive - Not connected"}
+        title={state.needsAttention ? "Google Drive - Action Required (click to sign in)" : state.isFullyConnected ? "Google Drive - Connected" : state.isAuthenticated ? "Google Drive - Loading..." : "Google Drive - Not connected"}
       >
-        {#if state.isCacheLoading && !state.isCacheLoaded}
+        {#if state.needsAttention}
+          <CloudArrowUpOutline class="w-6 h-6 text-red-600 hover:text-red-700 cursor-pointer" />
+        {:else if state.isCacheLoading && !state.isCacheLoaded}
           <Spinner size="4" />
         {:else if state.isFullyConnected}
           <CloudArrowUpOutline class="w-6 h-6 text-green-600 hover:text-green-700 cursor-pointer" />

--- a/src/lib/util/google-drive/drive-files-cache.ts
+++ b/src/lib/util/google-drive/drive-files-cache.ts
@@ -169,16 +169,6 @@ class DriveFilesCacheManager {
           console.error('Sync after login failed:', err)
         );
       }
-      // Automatically trigger read progress sync after cache refresh if we have data
-      // This ensures we merge and clean up duplicate volume-data.json files
-      else if (volumeDataFiles.length > 0) {
-        console.log('Cache loaded with volume data, triggering auto-sync...');
-
-        const { syncService } = await import('./sync-service');
-        syncService.syncReadProgress().catch(err =>
-          console.error('Auto-sync after cache refresh failed:', err)
-        );
-      }
     } catch (error) {
       console.error('Failed to fetch Drive files cache:', error);
       console.error('Error details:', error);

--- a/src/lib/util/google-drive/drive-files-cache.ts
+++ b/src/lib/util/google-drive/drive-files-cache.ts
@@ -155,7 +155,19 @@ class DriveFilesCacheManager {
       this.lastFetchTime = Date.now();
       this.cacheLoadedStore.set(true);
 
-      // Check if sync was requested after login
+    } catch (error) {
+      console.error('Failed to fetch Drive files cache:', error);
+      console.error('Error details:', error);
+      if (error instanceof Error) {
+        console.error('Error message:', error.message);
+        console.error('Error stack:', error.stack);
+      }
+      // Don't clear cache on error, keep stale data
+    } finally {
+      this.isFetching = false;
+      this.isFetchingStore.set(false);
+
+      // Check if sync was requested after login (do this in finally to ensure fetch is complete)
       const { GOOGLE_DRIVE_CONFIG } = await import('./constants');
       const shouldSync = typeof window !== 'undefined' &&
         localStorage.getItem(GOOGLE_DRIVE_CONFIG.STORAGE_KEYS.SYNC_AFTER_LOGIN) === 'true';
@@ -169,17 +181,6 @@ class DriveFilesCacheManager {
           console.error('Sync after login failed:', err)
         );
       }
-    } catch (error) {
-      console.error('Failed to fetch Drive files cache:', error);
-      console.error('Error details:', error);
-      if (error instanceof Error) {
-        console.error('Error message:', error.message);
-        console.error('Error stack:', error.stack);
-      }
-      // Don't clear cache on error, keep stale data
-    } finally {
-      this.isFetching = false;
-      this.isFetchingStore.set(false);
     }
   }
 

--- a/src/lib/util/google-drive/drive-files-cache.ts
+++ b/src/lib/util/google-drive/drive-files-cache.ts
@@ -22,11 +22,21 @@ export interface DriveFileMetadata {
  */
 class DriveFilesCacheManager {
   private cache = writable<Map<string, DriveFileMetadata[]>>(new Map());
+  private isFetchingStore = writable<boolean>(false);
+  private cacheLoadedStore = writable<boolean>(false);
   private isFetching = false;
   private lastFetchTime: number | null = null;
 
   get store() {
     return this.cache;
+  }
+
+  get isFetchingState() {
+    return this.isFetchingStore;
+  }
+
+  get cacheLoaded() {
+    return this.cacheLoadedStore;
   }
 
   getVolumeDataFileId(): string | null {
@@ -54,6 +64,7 @@ class DriveFilesCacheManager {
     }
 
     this.isFetching = true;
+    this.isFetchingStore.set(true);
     try {
       console.log('Fetching all Drive file metadata...');
 
@@ -142,6 +153,7 @@ class DriveFilesCacheManager {
       console.log(`Cached ${cbzFiles.length} .cbz files and ${volumeDataFiles.length} volume-data.json file(s)`);
       this.cache.set(cacheMap);
       this.lastFetchTime = Date.now();
+      this.cacheLoadedStore.set(true);
 
       // Automatically trigger read progress sync after cache refresh
       // This ensures we merge and clean up duplicate volume-data.json files
@@ -165,6 +177,7 @@ class DriveFilesCacheManager {
       // Don't clear cache on error, keep stale data
     } finally {
       this.isFetching = false;
+      this.isFetchingStore.set(false);
     }
   }
 
@@ -346,6 +359,7 @@ class DriveFilesCacheManager {
    */
   clearCache(): void {
     this.cache.set(new Map());
+    this.cacheLoadedStore.set(false);
     this.lastFetchTime = null;
   }
 

--- a/src/lib/util/google-drive/drive-state.ts
+++ b/src/lib/util/google-drive/drive-state.ts
@@ -1,0 +1,23 @@
+import { derived, type Readable } from 'svelte/store';
+import { tokenManager } from './token-manager';
+import { driveFilesCache } from './drive-files-cache';
+
+export interface DriveState {
+	isAuthenticated: boolean;
+	isCacheLoading: boolean;
+	isCacheLoaded: boolean;
+	isFullyConnected: boolean;
+}
+
+export const driveState: Readable<DriveState> = derived(
+	[tokenManager.token, driveFilesCache.isFetchingState, driveFilesCache.cacheLoaded],
+	([$token, $isFetching, $cacheLoaded]) => {
+		const isAuthenticated = $token !== '';
+		return {
+			isAuthenticated,
+			isCacheLoading: $isFetching,
+			isCacheLoaded: $cacheLoaded,
+			isFullyConnected: isAuthenticated && $cacheLoaded
+		};
+	}
+);

--- a/src/lib/util/google-drive/drive-state.ts
+++ b/src/lib/util/google-drive/drive-state.ts
@@ -7,17 +7,19 @@ export interface DriveState {
 	isCacheLoading: boolean;
 	isCacheLoaded: boolean;
 	isFullyConnected: boolean;
+	needsAttention: boolean;
 }
 
 export const driveState: Readable<DriveState> = derived(
-	[tokenManager.token, driveFilesCache.isFetchingState, driveFilesCache.cacheLoaded],
-	([$token, $isFetching, $cacheLoaded]) => {
+	[tokenManager.token, tokenManager.needsAttention, driveFilesCache.isFetchingState, driveFilesCache.cacheLoaded],
+	([$token, $needsAttention, $isFetching, $cacheLoaded]) => {
 		const isAuthenticated = $token !== '';
 		return {
 			isAuthenticated,
 			isCacheLoading: $isFetching,
 			isCacheLoaded: $cacheLoaded,
-			isFullyConnected: isAuthenticated && $cacheLoaded
+			isFullyConnected: isAuthenticated && $cacheLoaded,
+			needsAttention: $needsAttention
 		};
 	}
 );

--- a/src/lib/util/google-drive/index.ts
+++ b/src/lib/util/google-drive/index.ts
@@ -31,22 +31,13 @@ export async function initGoogleDriveApi(): Promise<void> {
     await driveApiClient.initialize();
 
     if (tokenManager.isAuthenticated()) {
-      // Fetch Drive files cache for backup status
+      // Set flag to sync after cache loads
+      localStorage.setItem(GOOGLE_DRIVE_CONFIG.STORAGE_KEYS.SYNC_AFTER_LOGIN, 'true');
+
+      // Fetch Drive files cache - will auto-trigger sync when complete
       driveFilesCache.fetchAllFiles().catch(err =>
         console.error('Failed to fetch Drive files cache:', err)
       );
-
-      // Check if we need to sync after login (flag set by syncReadProgress when no token)
-      const shouldSync = localStorage.getItem(GOOGLE_DRIVE_CONFIG.STORAGE_KEYS.SYNC_AFTER_LOGIN);
-      if (shouldSync === 'true') {
-        localStorage.removeItem(GOOGLE_DRIVE_CONFIG.STORAGE_KEYS.SYNC_AFTER_LOGIN);
-        setTimeout(() => syncService.syncReadProgress(), 500);
-      }
-      // Auto-sync on page load if authenticated
-      else {
-        console.log('Auto-syncing on page load...');
-        setTimeout(() => syncService.syncReadProgress(), 500);
-      }
     }
   } catch (error) {
     console.error('Failed to initialize Google Drive API:', error);

--- a/src/lib/util/google-drive/index.ts
+++ b/src/lib/util/google-drive/index.ts
@@ -58,17 +58,8 @@ export async function initGoogleDriveApi(): Promise<void> {
 export function signInToGoogleDrive(): void {
   if (!tokenManager.isAuthenticated()) {
     // Will auto-detect if first-time (consent) or re-auth (minimal)
+    // Cache fetch happens automatically in token manager callback
     tokenManager.requestNewToken(false, false);
-
-    // Fetch cache after successful sign-in
-    // Note: This will be called when the token callback fires
-    tokenManager.token.subscribe(token => {
-      if (token) {
-        driveFilesCache.fetchAllFiles().catch(err =>
-          console.error('Failed to fetch Drive files cache after sign-in:', err)
-        );
-      }
-    });
   }
 }
 

--- a/src/lib/util/google-drive/index.ts
+++ b/src/lib/util/google-drive/index.ts
@@ -3,12 +3,14 @@ import { tokenManager } from './token-manager';
 import { driveApiClient, DriveApiError } from './api-client';
 import { syncService } from './sync-service';
 import { driveFilesCache } from './drive-files-cache';
+import { driveState } from './drive-state';
 import { GOOGLE_DRIVE_CONFIG } from './constants';
 
 // Re-export the main modules
-export { tokenManager, driveApiClient, DriveApiError, syncService, driveFilesCache, GOOGLE_DRIVE_CONFIG };
+export { tokenManager, driveApiClient, DriveApiError, syncService, driveFilesCache, driveState, GOOGLE_DRIVE_CONFIG };
 export type { TokenInfo, DriveFile, SyncProgress } from './types';
 export type { DriveFileMetadata } from './drive-files-cache';
+export type { DriveState } from './drive-state';
 
 // Backward compatibility exports for old API
 // TODO: Migrate cloud/+page.svelte to use tokenManager, syncService directly

--- a/src/lib/util/google-drive/token-manager.ts
+++ b/src/lib/util/google-drive/token-manager.ts
@@ -191,21 +191,13 @@ class TokenManager {
           gapi.client.setToken({ access_token });
 
           // Fetch Drive cache after successful login
+          // The cache will automatically trigger sync when loaded if SYNC_AFTER_LOGIN flag is set
           // Import dynamically to avoid circular dependency
           import('./drive-files-cache').then(({ driveFilesCache }) => {
             driveFilesCache.fetchAllFiles().catch(err =>
               console.error('Failed to fetch Drive files cache after login:', err)
             );
           });
-
-          // Check if we need to sync after login
-          if (browser) {
-            const shouldSync = localStorage.getItem(GOOGLE_DRIVE_CONFIG.STORAGE_KEYS.SYNC_AFTER_LOGIN);
-            if (shouldSync === 'true') {
-              localStorage.removeItem(GOOGLE_DRIVE_CONFIG.STORAGE_KEYS.SYNC_AFTER_LOGIN);
-              setTimeout(() => syncService.syncReadProgress(), 500);
-            }
-          }
         }
       }
     });

--- a/src/lib/util/google-drive/token-manager.ts
+++ b/src/lib/util/google-drive/token-manager.ts
@@ -190,6 +190,14 @@ class TokenManager {
           this.setToken(access_token, expires_in);
           gapi.client.setToken({ access_token });
 
+          // Fetch Drive cache after successful login
+          // Import dynamically to avoid circular dependency
+          import('./drive-files-cache').then(({ driveFilesCache }) => {
+            driveFilesCache.fetchAllFiles().catch(err =>
+              console.error('Failed to fetch Drive files cache after login:', err)
+            );
+          });
+
           // Check if we need to sync after login
           if (browser) {
             const shouldSync = localStorage.getItem(GOOGLE_DRIVE_CONFIG.STORAGE_KEYS.SYNC_AFTER_LOGIN);

--- a/src/routes/[manga]/+page.svelte
+++ b/src/routes/[manga]/+page.svelte
@@ -50,7 +50,8 @@
     isAuthenticated: false,
     isCacheLoading: false,
     isCacheLoaded: false,
-    isFullyConnected: false
+    isFullyConnected: false,
+    needsAttention: false
   });
   $effect(() => {
     return driveState.subscribe(value => {

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -44,7 +44,8 @@
     isAuthenticated: false,
     isCacheLoading: false,
     isCacheLoaded: false,
-    isFullyConnected: false
+    isFullyConnected: false,
+    needsAttention: false
   });
 
   $effect(() => {

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -23,6 +23,8 @@
     API_KEY,
     backupVolumeToDrive
   } from '$lib/util';
+  import { driveState } from '$lib/util/google-drive';
+  import type { DriveState } from '$lib/util/google-drive';
   import { progressTrackerStore } from '$lib/util/progress-tracker';
   import { get } from 'svelte/store';
   import { Badge, Button, Toggle } from 'flowbite-svelte';
@@ -38,13 +40,21 @@
   let profilesId = $state('');
   let tokenClient = $state(null);
 
+  let state = $state<DriveState>({
+    isAuthenticated: false,
+    isCacheLoading: false,
+    isCacheLoaded: false,
+    isFullyConnected: false
+  });
+
   $effect(() => {
     const unsubscribers = [
       accessTokenStore.subscribe(value => { accessToken = value; }),
       readerFolderIdStore.subscribe(value => { readerFolderId = value.reader; }),
       volumeDataIdStore.subscribe(value => { volumeDataId = value; }),
       profilesIdStore.subscribe(value => { profilesId = value; }),
-      tokenClientStore.subscribe(value => { tokenClient = value; })
+      tokenClientStore.subscribe(value => { tokenClient = value; }),
+      driveState.subscribe(value => { state = value; })
     ];
     return () => unsubscribers.forEach(unsub => unsub());
   });
@@ -808,7 +818,14 @@
   {#if accessToken}
     <div class="flex justify-between items-center gap-6 flex-col">
       <div class="flex justify-between items-center w-full max-w-3xl">
-        <h2 class="text-3xl font-semibold text-center pt-2">Google Drive:</h2>
+        <div class="flex items-center gap-3">
+          <h2 class="text-3xl font-semibold text-center pt-2">Google Drive:</h2>
+          {#if state.isCacheLoading && !state.isCacheLoaded}
+            <Badge color="yellow">Loading Drive data...</Badge>
+          {:else if state.isCacheLoaded}
+            <Badge color="green">Connected</Badge>
+          {/if}
+        </div>
         <Button color="red" on:click={logout}>Log out</Button>
       </div>
       <p class="text-center">


### PR DESCRIPTION
## Summary
- Add visual indicators for Google Drive connection state in navbar
- Show loading spinner while cache is loading
- Show green icon when fully connected (authenticated + cache loaded)
- Show yellow icon when authenticated but cache still loading
- Show red icon when user attention needed (expired token, access denied, etc.)
- Fix sync button to trigger login when not authenticated
- Fix race condition where cache wouldn't load when logging in via sync button
- Fix race condition causing duplicate volume-data.json files

## Changes
- Added `drive-state.ts` to aggregate Drive state from token manager and cache
- Updated NavBar to show different icon states based on Drive connection
- Modified sync button to trigger login if not authenticated
- Fixed cache loading to trigger from token manager callback for all login paths
- Moved sync trigger to cache completion to prevent race conditions

## Test plan
- [x] Test login via cloud page - cache loads, icon turns green
- [x] Test login via sync button - cache loads, icon turns green
- [x] Test sync button when not logged in - triggers login popup
- [x] Verify no duplicate volume-data.json files created
- [x] Test error states show red icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)