### PR TITLE
Implement Drive placeholder and download system

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,7 +28,10 @@
       "Bash(git clean:*)",
       "Bash(git pull:*)",
       "Bash(gh pr close:*)",
-      "Bash(gh pr create:*)"
+      "Bash(gh pr create:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(timeout 2 npm run preview)",
+      "WebFetch(domain:developers.google.com)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -31,7 +31,8 @@
       "Bash(gh pr create:*)",
       "Bash(gh pr diff:*)",
       "Bash(timeout 2 npm run preview)",
-      "WebFetch(domain:developers.google.com)"
+      "WebFetch(domain:developers.google.com)",
+      "Bash(gh pr edit:*)"
     ],
     "deny": [],
     "ask": []

--- a/src/lib/catalog/placeholders.ts
+++ b/src/lib/catalog/placeholders.ts
@@ -1,0 +1,125 @@
+import type { VolumeMetadata } from '$lib/types';
+import type { DriveFileMetadata } from '$lib/util/google-drive/drive-files-cache';
+import { db } from './db';
+import { browser } from '$app/environment';
+
+/**
+ * Generate a deterministic UUID from a string (used for placeholder UUIDs)
+ */
+function generateUuidFromString(str: string): string {
+  // Simple hash-based UUID generation
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash; // Convert to 32bit integer
+  }
+
+  // Format as UUID-like string with placeholder prefix
+  const hex = Math.abs(hash).toString(16).padStart(8, '0');
+  return `placeholder-${hex}`;
+}
+
+/**
+ * Parse series and volume title from Drive file path
+ * Expected format: "SeriesTitle/VolumeTitle.cbz"
+ */
+function parseDrivePath(path: string): { seriesTitle: string; volumeTitle: string } | null {
+  const parts = path.split('/');
+  if (parts.length !== 2) return null;
+
+  const seriesTitle = parts[0];
+  const volumeWithExt = parts[1];
+
+  // Remove .cbz extension
+  const volumeTitle = volumeWithExt.replace(/\.cbz$/i, '');
+
+  return { seriesTitle, volumeTitle };
+}
+
+/**
+ * Generate placeholder VolumeMetadata for a Drive-only file
+ */
+function createPlaceholder(driveFile: DriveFileMetadata, seriesUuid: string): VolumeMetadata | null {
+  const parsed = parseDrivePath(driveFile.path);
+  if (!parsed) return null;
+
+  const { seriesTitle, volumeTitle } = parsed;
+
+  // Use fileId for volume UUID to ensure uniqueness
+  const volumeUuid = generateUuidFromString(driveFile.fileId);
+
+  return {
+    mokuro_version: 'unknown', // Will be filled in after download
+    series_title: seriesTitle,
+    series_uuid: seriesUuid,
+    volume_title: volumeTitle,
+    volume_uuid: volumeUuid,
+    page_count: 0, // Unknown until downloaded
+    character_count: 0, // Unknown until downloaded
+
+    // Placeholder-specific fields
+    isPlaceholder: true,
+    driveFileId: driveFile.fileId,
+    driveModifiedTime: driveFile.modifiedTime,
+    driveSize: driveFile.size
+  };
+}
+
+/**
+ * Identify Drive-only files by comparing Drive cache with local DB
+ * Returns placeholder VolumeMetadata for files that exist in Drive but not locally
+ */
+export async function generatePlaceholders(
+  driveFiles: DriveFileMetadata[]
+): Promise<VolumeMetadata[]> {
+  // Skip during SSR/build - IndexedDB is not available
+  if (!browser) {
+    return [];
+  }
+
+  // Get all local volumes from DB
+  const localVolumes = await db.volumes.toArray();
+
+  // Create a set of local volume paths for fast lookup
+  const localPaths = new Set(
+    localVolumes.map(vol => `${vol.series_title}/${vol.volume_title}.cbz`)
+  );
+
+  // Create a map of series titles to their UUIDs from local volumes
+  const seriesTitleToUuid = new Map<string, string>();
+  for (const vol of localVolumes) {
+    if (!seriesTitleToUuid.has(vol.series_title)) {
+      seriesTitleToUuid.set(vol.series_title, vol.series_uuid);
+    }
+  }
+
+  // Find Drive-only files
+  const driveOnlyFiles = driveFiles.filter(file => !localPaths.has(file.path));
+
+  // Generate placeholders
+  const placeholders: VolumeMetadata[] = [];
+  for (const driveFile of driveOnlyFiles) {
+    const parsed = parseDrivePath(driveFile.path);
+    if (!parsed) continue;
+
+    // Use existing series UUID if we have local volumes with this series title
+    // Otherwise generate a deterministic UUID for a new series
+    const seriesUuid = seriesTitleToUuid.get(parsed.seriesTitle)
+      || generateUuidFromString(parsed.seriesTitle);
+
+    const placeholder = createPlaceholder(driveFile, seriesUuid);
+    if (placeholder) {
+      placeholders.push(placeholder);
+    }
+  }
+
+  return placeholders;
+}
+
+/**
+ * Check if a volume is a placeholder
+ */
+export function isPlaceholder(volume: VolumeMetadata): boolean {
+  return volume.isPlaceholder === true;
+}

--- a/src/lib/components/Catalog.svelte
+++ b/src/lib/components/Catalog.svelte
@@ -183,7 +183,7 @@
               {#if state.isAuthenticated && allPlaceholderVolumes.length > 0}
                 <Button size="sm" color="blue" on:click={downloadAllPlaceholders}>
                   <DownloadSolid class="w-3 h-3 me-1" />
-                  Download all ({allPlaceholderVolumes.length})
+                  Download all
                 </Button>
               {/if}
             </div>

--- a/src/lib/components/Catalog.svelte
+++ b/src/lib/components/Catalog.svelte
@@ -96,14 +96,20 @@
     series.volumes.every(vol => vol.isPlaceholder)
   ));
 
+  // Collect all placeholder volumes from the entire catalog
+  let allPlaceholderVolumes = $derived(
+    sortedCatalog.flatMap(series =>
+      series.volumes.filter(vol => vol.isPlaceholder)
+    )
+  );
+
   async function downloadAllPlaceholders() {
-    if (!placeholderSeries || placeholderSeries.length === 0) return;
+    if (!allPlaceholderVolumes || allPlaceholderVolumes.length === 0) return;
     if (!state.isAuthenticated) {
       showSnackbar('Please sign in to Google Drive first', 'error');
       return;
     }
 
-    const allPlaceholderVolumes = placeholderSeries.flatMap(series => series.volumes);
     try {
       await downloadSeriesFromDrive(allPlaceholderVolumes);
     } catch (error) {
@@ -173,11 +179,11 @@
         {#if placeholderSeries && placeholderSeries.length > 0}
           <div class="mt-8">
             <div class="flex items-center justify-between px-4 mb-4">
-              <h4 class="text-lg font-semibold text-gray-400">Available in Drive ({placeholderSeries.length})</h4>
-              {#if state.isAuthenticated}
+              <h4 class="text-lg font-semibold text-gray-400">Available in Drive ({placeholderSeries.length} series)</h4>
+              {#if state.isAuthenticated && allPlaceholderVolumes.length > 0}
                 <Button size="sm" color="blue" on:click={downloadAllPlaceholders}>
                   <DownloadSolid class="w-3 h-3 me-1" />
-                  Download all
+                  Download all ({allPlaceholderVolumes.length})
                 </Button>
               {/if}
             </div>

--- a/src/lib/components/Catalog.svelte
+++ b/src/lib/components/Catalog.svelte
@@ -3,12 +3,29 @@
   import { Button, Listgroup, Search } from 'flowbite-svelte';
   import CatalogItem from './CatalogItem.svelte';
   import Loader from './Loader.svelte';
-  import { GridOutline, ListOutline, SortOutline } from 'flowbite-svelte-icons';
+  import { GridOutline, ListOutline, SortOutline, DownloadSolid } from 'flowbite-svelte-icons';
   import { miscSettings, updateMiscSetting, volumes } from '$lib/settings';
   import CatalogListItem from './CatalogListItem.svelte';
   import { isUpgrading } from '$lib/catalog/db';
+  import { driveState } from '$lib/util/google-drive';
+  import { downloadSeriesFromDrive } from '$lib/util/download-from-drive';
+  import { showSnackbar } from '$lib/util';
+  import type { DriveState } from '$lib/util/google-drive';
 
   let search = $state('');
+
+  let state = $state<DriveState>({
+    isAuthenticated: false,
+    isCacheLoading: false,
+    isCacheLoaded: false,
+    isFullyConnected: false,
+    needsAttention: false
+  });
+  $effect(() => {
+    return driveState.subscribe(value => {
+      state = value;
+    });
+  });
 
   function onLayout() {
     if ($miscSettings.galleryLayout === 'list') {
@@ -69,6 +86,30 @@
         return item.title.toLowerCase().indexOf(search.toLowerCase()) !== -1;
       })
   );
+
+  // Separate local series from placeholder-only series
+  let localSeries = $derived(sortedCatalog.filter(series =>
+    series.volumes.some(vol => !vol.isPlaceholder)
+  ));
+
+  let placeholderSeries = $derived(sortedCatalog.filter(series =>
+    series.volumes.every(vol => vol.isPlaceholder)
+  ));
+
+  async function downloadAllPlaceholders() {
+    if (!placeholderSeries || placeholderSeries.length === 0) return;
+    if (!state.isAuthenticated) {
+      showSnackbar('Please sign in to Google Drive first', 'error');
+      return;
+    }
+
+    const allPlaceholderVolumes = placeholderSeries.flatMap(series => series.volumes);
+    try {
+      await downloadSeriesFromDrive(allPlaceholderVolumes);
+    } catch (error) {
+      console.error('Failed to download placeholders:', error);
+    }
+  }
 </script>
 
 {#if $catalog}
@@ -113,19 +154,48 @@
           <p>No results found.</p>
         </div>
       {:else}
+        <!-- Local series -->
         <div class="flex sm:flex-row flex-col gap-5 flex-wrap justify-center sm:justify-start">
           {#if $miscSettings.galleryLayout === 'grid'}
-            {#each sortedCatalog as { series_uuid } (series_uuid)}
+            {#each localSeries as { series_uuid } (series_uuid)}
               <CatalogItem {series_uuid} />
             {/each}
           {:else}
             <Listgroup active class="w-full">
-              {#each sortedCatalog as { series_uuid } (series_uuid)}
+              {#each localSeries as { series_uuid } (series_uuid)}
                 <CatalogListItem {series_uuid} />
               {/each}
             </Listgroup>
           {/if}
         </div>
+
+        <!-- Placeholder series (Drive only) -->
+        {#if placeholderSeries && placeholderSeries.length > 0}
+          <div class="mt-8">
+            <div class="flex items-center justify-between px-4 mb-4">
+              <h4 class="text-lg font-semibold text-gray-400">Available in Drive ({placeholderSeries.length})</h4>
+              {#if state.isAuthenticated}
+                <Button size="sm" color="blue" on:click={downloadAllPlaceholders}>
+                  <DownloadSolid class="w-3 h-3 me-1" />
+                  Download all
+                </Button>
+              {/if}
+            </div>
+            <div class="flex sm:flex-row flex-col gap-5 flex-wrap justify-center sm:justify-start">
+              {#if $miscSettings.galleryLayout === 'grid'}
+                {#each placeholderSeries as { series_uuid } (series_uuid)}
+                  <CatalogItem {series_uuid} />
+                {/each}
+              {:else}
+                <Listgroup active class="w-full">
+                  {#each placeholderSeries as { series_uuid } (series_uuid)}
+                    <CatalogListItem {series_uuid} />
+                  {/each}
+                </Listgroup>
+              {/if}
+            </div>
+          </div>
+        {/if}
       {/if}
     </div>
   {:else}

--- a/src/lib/components/CatalogItem.svelte
+++ b/src/lib/components/CatalogItem.svelte
@@ -50,7 +50,7 @@
 
   // Check if this series is downloading
   let isDownloading = $derived.by(() => {
-    if (!volume || !isPlaceholderOnly) return false;
+    if (!volume) return false;
 
     const seriesProcessId = `download-series-${volume.series_title}`;
     const hasSeriesDownload = progressState.processes.some(p => p.id === seriesProcessId);

--- a/src/lib/components/CatalogItem.svelte
+++ b/src/lib/components/CatalogItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { volumesWithPlaceholders } from '$lib/catalog';
   import { progress } from '$lib/settings';
-  import { CloudArrowUpSolid } from 'flowbite-svelte-icons';
+  import { DownloadSolid } from 'flowbite-svelte-icons';
   import { downloadSeriesFromDrive } from '$lib/util/download-from-drive';
   import { driveState } from '$lib/util/google-drive';
   import { showSnackbar } from '$lib/util';
@@ -67,7 +67,7 @@
     >
       {#if isPlaceholderOnly}
         <div class="sm:w-[250px] sm:h-[350px] bg-black border-gray-900 border flex items-center justify-center">
-          <CloudArrowUpSolid class="w-24 h-24 text-blue-400" />
+          <DownloadSolid class="w-24 h-24 text-blue-400" />
         </div>
       {:else if volume.thumbnail}
         <img

--- a/src/lib/components/CatalogItem.svelte
+++ b/src/lib/components/CatalogItem.svelte
@@ -52,8 +52,8 @@
   let isDownloading = $derived.by(() => {
     if (!volume || !isPlaceholderOnly) return false;
 
-    const status = downloadQueue.getSeriesQueueStatus(volume.series_title);
-    return status.hasQueued || status.hasDownloading;
+    const seriesItems = queueState.filter(item => item.seriesTitle === volume.series_title);
+    return seriesItems.length > 0;
   });
 
   async function handleClick(e: MouseEvent) {

--- a/src/lib/components/CatalogItem.svelte
+++ b/src/lib/components/CatalogItem.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-  import { volumes } from '$lib/catalog';
+  import { volumesWithPlaceholders } from '$lib/catalog';
   import { progress } from '$lib/settings';
+  import { CloudArrowUpSolid } from 'flowbite-svelte-icons';
 
   interface Props {
     series_uuid: string;
@@ -9,7 +10,8 @@
   let { series_uuid }: Props = $props();
 
   let firstUnreadVolume = $derived(
-    Object.values($volumes)
+    Object.values($volumesWithPlaceholders)
+      .filter(v => !v.isPlaceholder)
       .sort((a, b) => a.volume_title.localeCompare(b.volume_title))
       .find(
         (item) =>
@@ -19,21 +21,27 @@
   );
 
   let firstVolume = $derived(
-    Object.values($volumes)
+    Object.values($volumesWithPlaceholders)
       .sort((a, b) => a.volume_title.localeCompare(b.volume_title))
       .find((item) => item.series_uuid === series_uuid)
   );
   let volume = $derived(firstUnreadVolume ?? firstVolume);
   let isComplete = $derived(!firstUnreadVolume);
+  let isPlaceholderOnly = $derived(volume?.isPlaceholder === true);
 </script>
 
 {#if volume}
   <a href={series_uuid}>
     <div
       class:text-green-400={isComplete}
-      class="flex flex-col gap-[5px] text-center items-center bg-slate-900 pb-1 bg-opacity-50 border border-slate-950"
+      class:opacity-70={isPlaceholderOnly}
+      class="flex flex-col gap-[5px] text-center items-center bg-slate-900 pb-1 bg-opacity-50 border border-slate-950 relative"
     >
-      {#if volume.thumbnail}
+      {#if isPlaceholderOnly}
+        <div class="sm:w-[250px] sm:h-[350px] bg-black border-gray-900 border flex items-center justify-center">
+          <CloudArrowUpSolid class="w-24 h-24 text-blue-400" />
+        </div>
+      {:else if volume.thumbnail}
         <img
           src={URL.createObjectURL(volume.thumbnail)}
           alt="img"
@@ -43,6 +51,9 @@
       <p class="font-semibold sm:w-[250px] line-clamp-1">
         {volume.series_title}
       </p>
+      {#if isPlaceholderOnly}
+        <p class="text-xs text-blue-400">In Drive</p>
+      {/if}
     </div>
   </a>
 {/if}

--- a/src/lib/components/CatalogItem.svelte
+++ b/src/lib/components/CatalogItem.svelte
@@ -69,6 +69,11 @@
     if (isPlaceholderOnly) {
       e.preventDefault();
 
+      // Prevent re-clicking during download
+      if (isDownloading) {
+        return;
+      }
+
       let authenticated = false;
       driveState.subscribe(state => {
         authenticated = state.isAuthenticated;
@@ -94,11 +99,13 @@
     >
       {#if isPlaceholderOnly}
         <div class="sm:w-[250px] sm:h-[350px] bg-black border-gray-900 border flex items-center justify-center">
-          {#if isDownloading}
-            <Spinner size="16" color="blue" />
-          {:else}
-            <DownloadSolid class="w-24 h-24 text-blue-400" />
-          {/if}
+          <div class="w-24 h-24 flex items-center justify-center">
+            {#if isDownloading}
+              <Spinner size="16" color="blue" />
+            {:else}
+              <DownloadSolid class="w-24 h-24 text-blue-400" />
+            {/if}
+          </div>
         </div>
       {:else if volume.thumbnail}
         <img

--- a/src/lib/components/CatalogItem.svelte
+++ b/src/lib/components/CatalogItem.svelte
@@ -50,7 +50,7 @@
 
   // Check if this series is downloading
   let isDownloading = $derived.by(() => {
-    if (!volume) return false;
+    if (!volume || !isPlaceholderOnly) return false;
 
     const seriesProcessId = `download-series-${volume.series_title}`;
     const hasSeriesDownload = progressState.processes.some(p => p.id === seriesProcessId);

--- a/src/lib/components/CatalogListItem.svelte
+++ b/src/lib/components/CatalogListItem.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-  import { volumes } from '$lib/catalog';
+  import { volumesWithPlaceholders } from '$lib/catalog';
   import { ListgroupItem } from 'flowbite-svelte';
   import { progress } from '$lib/settings';
+  import { CloudArrowUpSolid } from 'flowbite-svelte-icons';
 
   interface Props {
     series_uuid: string;
@@ -10,7 +11,8 @@
   let { series_uuid }: Props = $props();
 
   let firstUnreadVolume = $derived(
-    Object.values($volumes)
+    Object.values($volumesWithPlaceholders)
+      .filter(v => !v.isPlaceholder)
       .sort((a, b) => a.volume_title.localeCompare(b.volume_title))
       .find(
         (item) =>
@@ -20,21 +22,29 @@
   );
 
   let firstVolume = $derived(
-    Object.values($volumes)
+    Object.values($volumesWithPlaceholders)
       .sort((a, b) => a.volume_title.localeCompare(b.volume_title))
       .find((item) => item.series_uuid === series_uuid)
   );
   let volume = $derived(firstUnreadVolume ?? firstVolume);
   let isComplete = $derived(!firstUnreadVolume);
+  let isPlaceholderOnly = $derived(volume?.isPlaceholder === true);
 </script>
 
 {#if volume}
-  <div>
+  <div class:opacity-70={isPlaceholderOnly}>
     <ListgroupItem>
       <a href={series_uuid} class="h-full w-full">
         <div class="flex justify-between items-center">
-          <p class:text-green-400={isComplete} class="font-semibold">{volume.series_title}</p>
-          {#if volume.thumbnail}
+          <div class="flex items-center gap-2">
+            <p class:text-green-400={isComplete} class="font-semibold">{volume.series_title}</p>
+            {#if isPlaceholderOnly}
+              <span class="text-xs text-blue-400">In Drive</span>
+            {/if}
+          </div>
+          {#if isPlaceholderOnly}
+            <CloudArrowUpSolid class="w-[50px] h-[70px] text-blue-400" />
+          {:else if volume.thumbnail}
             <img
               src={URL.createObjectURL(volume.thumbnail)}
               alt="img"

--- a/src/lib/components/CatalogListItem.svelte
+++ b/src/lib/components/CatalogListItem.svelte
@@ -69,6 +69,11 @@
     if (isPlaceholderOnly) {
       e.preventDefault();
 
+      // Prevent re-clicking during download
+      if (isDownloading) {
+        return;
+      }
+
       let authenticated = false;
       driveState.subscribe(state => {
         authenticated = state.isAuthenticated;
@@ -96,11 +101,13 @@
             {/if}
           </div>
           {#if isPlaceholderOnly}
-            {#if isDownloading}
-              <Spinner size="12" color="blue" />
-            {:else}
-              <DownloadSolid class="w-[50px] h-[70px] text-blue-400" />
-            {/if}
+            <div class="w-[50px] h-[70px] flex items-center justify-center">
+              {#if isDownloading}
+                <Spinner size="12" color="blue" />
+              {:else}
+                <DownloadSolid class="w-[50px] h-[70px] text-blue-400" />
+              {/if}
+            </div>
           {:else if volume.thumbnail}
             <img
               src={URL.createObjectURL(volume.thumbnail)}

--- a/src/lib/components/CatalogListItem.svelte
+++ b/src/lib/components/CatalogListItem.svelte
@@ -50,7 +50,7 @@
 
   // Check if this series is downloading
   let isDownloading = $derived.by(() => {
-    if (!volume || !isPlaceholderOnly) return false;
+    if (!volume) return false;
 
     const seriesProcessId = `download-series-${volume.series_title}`;
     const hasSeriesDownload = progressState.processes.some(p => p.id === seriesProcessId);

--- a/src/lib/components/CatalogListItem.svelte
+++ b/src/lib/components/CatalogListItem.svelte
@@ -2,7 +2,7 @@
   import { volumesWithPlaceholders } from '$lib/catalog';
   import { ListgroupItem } from 'flowbite-svelte';
   import { progress } from '$lib/settings';
-  import { CloudArrowUpSolid } from 'flowbite-svelte-icons';
+  import { DownloadSolid } from 'flowbite-svelte-icons';
   import { downloadSeriesFromDrive } from '$lib/util/download-from-drive';
   import { driveState } from '$lib/util/google-drive';
   import { showSnackbar } from '$lib/util';
@@ -70,7 +70,7 @@
             {/if}
           </div>
           {#if isPlaceholderOnly}
-            <CloudArrowUpSolid class="w-[50px] h-[70px] text-blue-400" />
+            <DownloadSolid class="w-[50px] h-[70px] text-blue-400" />
           {:else if volume.thumbnail}
             <img
               src={URL.createObjectURL(volume.thumbnail)}

--- a/src/lib/components/CatalogListItem.svelte
+++ b/src/lib/components/CatalogListItem.svelte
@@ -50,7 +50,7 @@
 
   // Check if this series is downloading
   let isDownloading = $derived.by(() => {
-    if (!volume) return false;
+    if (!volume || !isPlaceholderOnly) return false;
 
     const seriesProcessId = `download-series-${volume.series_title}`;
     const hasSeriesDownload = progressState.processes.some(p => p.id === seriesProcessId);

--- a/src/lib/components/CatalogListItem.svelte
+++ b/src/lib/components/CatalogListItem.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { volumesWithPlaceholders } from '$lib/catalog';
-  import { ListgroupItem } from 'flowbite-svelte';
+  import { ListgroupItem, Spinner } from 'flowbite-svelte';
   import { progress } from '$lib/settings';
   import { DownloadSolid } from 'flowbite-svelte-icons';
   import { downloadSeriesFromDrive } from '$lib/util/download-from-drive';
   import { driveState } from '$lib/util/google-drive';
   import { showSnackbar } from '$lib/util';
+  import { progressTrackerStore } from '$lib/util/progress-tracker';
 
   interface Props {
     series_uuid: string;
@@ -39,6 +40,31 @@
   let isComplete = $derived(!firstUnreadVolume);
   let isPlaceholderOnly = $derived(volume?.isPlaceholder === true);
 
+  // Track download progress
+  let progressState = $state($progressTrackerStore);
+  $effect(() => {
+    return progressTrackerStore.subscribe(value => {
+      progressState = value;
+    });
+  });
+
+  // Check if this series is downloading
+  let isDownloading = $derived.by(() => {
+    if (!volume || !isPlaceholderOnly) return false;
+
+    const seriesProcessId = `download-series-${volume.series_title}`;
+    const hasSeriesDownload = progressState.processes.some(p => p.id === seriesProcessId);
+
+    if (hasSeriesDownload) return true;
+
+    // Check if any individual volume in this series is downloading
+    const volumeIds = allSeriesVolumes
+      .filter(v => v.driveFileId)
+      .map(v => `download-${v.driveFileId}`);
+
+    return progressState.processes.some(p => volumeIds.includes(p.id));
+  });
+
   async function handleClick(e: MouseEvent) {
     if (isPlaceholderOnly) {
       e.preventDefault();
@@ -70,7 +96,11 @@
             {/if}
           </div>
           {#if isPlaceholderOnly}
-            <DownloadSolid class="w-[50px] h-[70px] text-blue-400" />
+            {#if isDownloading}
+              <Spinner size="12" color="blue" />
+            {:else}
+              <DownloadSolid class="w-[50px] h-[70px] text-blue-400" />
+            {/if}
           {:else if volume.thumbnail}
             <img
               src={URL.createObjectURL(volume.thumbnail)}

--- a/src/lib/components/PlaceholderVolumeItem.svelte
+++ b/src/lib/components/PlaceholderVolumeItem.svelte
@@ -1,0 +1,74 @@
+<script lang="ts">
+  import type { VolumeMetadata } from '$lib/types';
+  import { Frame, ListgroupItem, Button, Spinner } from 'flowbite-svelte';
+  import { DownloadSolid, CloudArrowUpSolid } from 'flowbite-svelte-icons';
+  import { downloadVolumeFromDrive } from '$lib/util/download-from-drive';
+  import { progressTrackerStore } from '$lib/util/progress-tracker';
+
+  interface Props {
+    volume: VolumeMetadata;
+  }
+
+  let { volume }: Props = $props();
+
+  const volName = decodeURI(volume.volume_title);
+
+  // Format file size
+  let sizeDisplay = $derived.by(() => {
+    if (!volume.driveSize) return 'Unknown size';
+    const mb = (volume.driveSize / (1024 * 1024)).toFixed(1);
+    return `${mb} MB`;
+  });
+
+  // Track download state from progress tracker
+  let progressState = $state($progressTrackerStore);
+  $effect(() => {
+    return progressTrackerStore.subscribe(value => {
+      progressState = value;
+    });
+  });
+
+  let processId = $derived(`download-${volume.driveFileId}`);
+  let downloadProcess = $derived.by(() => {
+    return progressState.processes.find(p => p.id === processId);
+  });
+
+  let isDownloading = $derived(!!downloadProcess);
+  let downloadProgress = $derived(downloadProcess?.progress || 0);
+  let downloadStatus = $derived(downloadProcess?.status || '');
+
+  async function onDownloadClicked(e: Event) {
+    e.stopPropagation();
+
+    try {
+      await downloadVolumeFromDrive(volume);
+    } catch (error) {
+      console.error('Download failed:', error);
+    }
+  }
+</script>
+
+<Frame rounded border class="divide-y divide-gray-200 dark:divide-gray-600">
+  <ListgroupItem normalClass="py-4 opacity-70">
+    <CloudArrowUpSolid class="w-[50px] h-[70px] text-blue-400 mr-3" />
+    <div class="flex flex-row gap-5 items-center justify-between w-full">
+      <div>
+        <p class="font-semibold text-gray-400">{volName}</p>
+        <p class="text-sm text-gray-500">In Drive • {sizeDisplay}</p>
+      </div>
+      <div class="flex gap-2 items-center">
+        {#if isDownloading}
+          <Button color="light" disabled={true}>
+            <Spinner size="4" class="me-2" />
+            {downloadProgress}%
+          </Button>
+        {:else}
+          <Button color="blue" onclick={onDownloadClicked}>
+            <DownloadSolid class="w-4 h-4 me-2" />
+            Download
+          </Button>
+        {/if}
+      </div>
+    </div>
+  </ListgroupItem>
+</Frame>

--- a/src/lib/components/PlaceholderVolumeItem.svelte
+++ b/src/lib/components/PlaceholderVolumeItem.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { VolumeMetadata } from '$lib/types';
   import { Frame, ListgroupItem, Button, Spinner } from 'flowbite-svelte';
-  import { DownloadSolid, CloudArrowUpSolid, TrashBinSolid } from 'flowbite-svelte-icons';
+  import { DownloadSolid, TrashBinSolid } from 'flowbite-svelte-icons';
   import { downloadVolumeFromDrive } from '$lib/util/download-from-drive';
   import { progressTrackerStore } from '$lib/util/progress-tracker';
   import { driveApiClient } from '$lib/util/google-drive/api-client';
@@ -75,7 +75,7 @@
 
 <Frame rounded border class="divide-y divide-gray-200 dark:divide-gray-600">
   <ListgroupItem normalClass="py-4 opacity-70">
-    <CloudArrowUpSolid class="w-[50px] h-[70px] text-blue-400 mr-3" />
+    <DownloadSolid class="w-[50px] h-[70px] text-blue-400 mr-3" />
     <div class="flex flex-row gap-5 items-center justify-between w-full">
       <div>
         <p class="font-semibold text-gray-400">{volName}</p>

--- a/src/lib/components/PlaceholderVolumeItem.svelte
+++ b/src/lib/components/PlaceholderVolumeItem.svelte
@@ -45,7 +45,7 @@
   });
 
   // Check both queue and active download states
-  let isQueued = $derived(downloadQueue.isVolumeInQueue(volume.volume_uuid));
+  let isQueued = $derived(queueState.some(item => item.volumeUuid === volume.volume_uuid));
   let isActivelyDownloading = $derived(!!downloadProcess);
   let isDownloading = $derived(isQueued || isActivelyDownloading);
   let downloadProgress = $derived(downloadProcess?.progress || 0);

--- a/src/lib/components/ProgressTracker.svelte
+++ b/src/lib/components/ProgressTracker.svelte
@@ -57,14 +57,16 @@
               <div class="text-xs text-gray-600 dark:text-gray-400 mb-1">{process.status}</div>
             {/if}
 
-            <div class="flex justify-between text-xs mb-1">
-              <span>{Math.round(process.progress)}%</span>
-              {#if process.bytesLoaded !== undefined && process.totalBytes !== undefined}
-                <span>{formatBytes(process.bytesLoaded)} / {formatBytes(process.totalBytes)}</span>
-              {/if}
-            </div>
+            {#if process.progress > 0}
+              <div class="flex justify-between text-xs mb-1">
+                <span>{Math.round(process.progress)}%</span>
+                {#if process.bytesLoaded !== undefined && process.totalBytes !== undefined}
+                  <span>{formatBytes(process.bytesLoaded)} / {formatBytes(process.totalBytes)}</span>
+                {/if}
+              </div>
 
-            <Progressbar progress={process.progress.toString()} size="h-2" />
+              <Progressbar progress={process.progress.toString()} size="h-2" />
+            {/if}
           </div>
         {/each}
       </div>

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -22,6 +22,12 @@ export interface VolumeMetadata {
   page_count: number;
   character_count: number;
   thumbnail?: File;
+
+  // Placeholder fields for Drive-only volumes (not yet downloaded locally)
+  isPlaceholder?: boolean;
+  driveFileId?: string;
+  driveModifiedTime?: string;
+  driveSize?: number;
 }
 
 export interface VolumeData {

--- a/src/lib/util/download-from-drive.ts
+++ b/src/lib/util/download-from-drive.ts
@@ -1,0 +1,233 @@
+import type { VolumeMetadata, VolumeData } from '$lib/types';
+import { tokenManager } from './google-drive/token-manager';
+import { progressTrackerStore } from './progress-tracker';
+import { showSnackbar } from './snackbar';
+import { db } from '$lib/catalog/db';
+import { generateThumbnail } from '$lib/catalog/thumbnails';
+import DownloadWorker from '$lib/workers/download-worker?worker';
+
+interface MokuroData {
+  version: string;
+  title: string;
+  title_uuid: string;
+  pages: any[];
+  chars: number;
+  volume: string;
+  volume_uuid: string;
+}
+
+interface DecompressedEntry {
+  filename: string;
+  data: ArrayBuffer;
+}
+
+/**
+ * Download a volume from Google Drive and save it to IndexedDB
+ * Converts a placeholder into a real volume with all data
+ */
+export async function downloadVolumeFromDrive(placeholder: VolumeMetadata): Promise<void> {
+  if (!placeholder.isPlaceholder || !placeholder.driveFileId) {
+    throw new Error('Can only download placeholders with Drive file IDs');
+  }
+
+  const processId = `download-${placeholder.driveFileId}`;
+
+  try {
+    // Get access token
+    let token = '';
+    tokenManager.token.subscribe((value) => {
+      token = value;
+    })();
+    if (!token) {
+      throw new Error('No access token available');
+    }
+
+    progressTrackerStore.addProcess({
+      id: processId,
+      description: `Downloading ${placeholder.volume_title}`,
+      progress: 0,
+      status: 'Starting download...'
+    });
+
+    // Create and start worker
+    const worker = new DownloadWorker();
+    const downloadPromise = new Promise<DecompressedEntry[]>((resolve, reject) => {
+      worker.onmessage = (event) => {
+        const message = event.data;
+
+        if (message.type === 'progress') {
+          const percent = Math.round((message.loaded / message.total) * 100);
+          progressTrackerStore.updateProcess(processId, {
+            progress: percent,
+            status: `Downloading... ${percent}%`
+          });
+        } else if (message.type === 'complete') {
+          worker.terminate();
+          resolve(message.entries);
+        } else if (message.type === 'error') {
+          worker.terminate();
+          reject(new Error(message.error));
+        }
+      };
+
+      worker.onerror = (error) => {
+        worker.terminate();
+        reject(error);
+      };
+
+      // Start download
+      worker.postMessage({
+        fileId: placeholder.driveFileId,
+        fileName: placeholder.volume_title + '.cbz',
+        accessToken: token
+      });
+    });
+
+    const entries = await downloadPromise;
+
+    progressTrackerStore.updateProcess(processId, {
+      progress: 90,
+      status: 'Processing files...'
+    });
+
+    // Find .mokuro file
+    const mokuroEntry = entries.find((e) => e.filename.endsWith('.mokuro'));
+    if (!mokuroEntry) {
+      throw new Error('No .mokuro file found in CBZ');
+    }
+
+    // Parse mokuro JSON
+    const mokuroText = new TextDecoder().decode(mokuroEntry.data);
+    const mokuroData: MokuroData = JSON.parse(mokuroText);
+
+    // Create VolumeMetadata from mokuro data
+    const metadata: VolumeMetadata = {
+      mokuro_version: mokuroData.version,
+      series_title: mokuroData.title,
+      series_uuid: mokuroData.title_uuid,
+      volume_title: mokuroData.volume,
+      volume_uuid: mokuroData.volume_uuid,
+      page_count: mokuroData.pages.length,
+      character_count: mokuroData.chars
+    };
+
+    // Convert image entries to File objects
+    const files: Record<string, File> = {};
+    for (const entry of entries) {
+      if (!entry.filename.endsWith('.mokuro') && !entry.filename.includes('__MACOSX')) {
+        const blob = new Blob([entry.data]);
+        files[entry.filename] = new File([blob], entry.filename);
+      }
+    }
+
+    // Create VolumeData
+    const volumeData: VolumeData = {
+      volume_uuid: mokuroData.volume_uuid,
+      pages: mokuroData.pages,
+      files
+    };
+
+    // Generate thumbnail from first image
+    const fileNames = Object.keys(files).sort((a, b) =>
+      a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+    );
+    if (fileNames.length > 0) {
+      metadata.thumbnail = await generateThumbnail(files[fileNames[0]]);
+    }
+
+    // Save to IndexedDB
+    const existingVolume = await db.volumes
+      .where('volume_uuid')
+      .equals(metadata.volume_uuid)
+      .first();
+
+    if (!existingVolume) {
+      await db.transaction('rw', db.volumes, db.volumes_data, async () => {
+        await db.volumes.add(metadata);
+        await db.volumes_data.add(volumeData);
+      });
+    }
+
+    progressTrackerStore.updateProcess(processId, {
+      progress: 100,
+      status: 'Download complete'
+    });
+
+    showSnackbar(`Downloaded ${metadata.volume_title} successfully`, 'success');
+  } catch (error) {
+    console.error('Failed to download volume:', error);
+    progressTrackerStore.updateProcess(processId, {
+      progress: 0,
+      status: `Error: ${error instanceof Error ? error.message : 'Unknown error'}`
+    });
+    showSnackbar(
+      `Failed to download: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      'error'
+    );
+    throw error;
+  } finally {
+    setTimeout(() => progressTrackerStore.removeProcess(processId), 3000);
+  }
+}
+
+/**
+ * Download all volumes in a series from Google Drive
+ */
+export async function downloadSeriesFromDrive(placeholders: VolumeMetadata[]): Promise<void> {
+  const seriesTitle = placeholders[0]?.series_title;
+  if (!seriesTitle) return;
+
+  const processId = `download-series-${seriesTitle}`;
+
+  try {
+    progressTrackerStore.addProcess({
+      id: processId,
+      description: `Downloading ${seriesTitle}`,
+      progress: 0,
+      status: `0/${placeholders.length} volumes`
+    });
+
+    let successCount = 0;
+    let failCount = 0;
+
+    placeholders.sort((a, b) => {
+      if (a.series_title === b.series_title) {
+        return a.volume_title.localeCompare(b.volume_title, undefined, {
+          numeric: true,
+          sensitivity: 'base'
+        });
+      } else {
+        return a.series_title.localeCompare(b.series_title, undefined, {
+          numeric: true,
+          sensitivity: 'base'
+        });
+      }
+    });
+
+    for (let i = 0; i < placeholders.length; i++) {
+      const placeholder = placeholders[i];
+      const progress = Math.round(((i + 1) / placeholders.length) * 100);
+
+      progressTrackerStore.updateProcess(processId, {
+        progress,
+        status: `${i + 1}/${placeholders.length}: ${placeholder.volume_title}`
+      });
+
+      try {
+        await downloadVolumeFromDrive(placeholder);
+        successCount++;
+      } catch (error) {
+        console.error(`Failed to download ${placeholder.volume_title}:`, error);
+        failCount++;
+      }
+    }
+
+    if (failCount === 0) {
+      showSnackbar(`Successfully downloaded ${successCount} volumes`, 'success');
+    } else {
+      showSnackbar(`Downloaded ${successCount} volumes, ${failCount} failed`, 'error');
+    }
+  } finally {
+    progressTrackerStore.removeProcess(processId);
+  }
+}

--- a/src/lib/util/download-queue.ts
+++ b/src/lib/util/download-queue.ts
@@ -1,0 +1,167 @@
+import { writable, get } from 'svelte/store';
+import type { VolumeMetadata } from '$lib/types';
+import { downloadVolumeFromDrive } from './download-from-drive';
+
+export interface QueueItem {
+	volumeUuid: string;
+	driveFileId: string;
+	seriesTitle: string;
+	volumeTitle: string;
+	volumeMetadata: VolumeMetadata;
+	status: 'queued' | 'downloading';
+}
+
+interface SeriesQueueStatus {
+	hasQueued: boolean;
+	hasDownloading: boolean;
+	queuedCount: number;
+	downloadingCount: number;
+}
+
+// Internal queue state
+const queueStore = writable<QueueItem[]>([]);
+let isProcessing = false;
+
+/**
+ * Add a single volume to the download queue
+ */
+export function queueVolume(volume: VolumeMetadata): void {
+	if (!volume.isPlaceholder || !volume.driveFileId) {
+		console.warn('Can only queue placeholder volumes with Drive file IDs');
+		return;
+	}
+
+	const queue = get(queueStore);
+
+	// Check for duplicates by volumeUuid or driveFileId
+	const isDuplicate = queue.some(
+		item => item.volumeUuid === volume.volume_uuid || item.driveFileId === volume.driveFileId
+	);
+
+	if (isDuplicate) {
+		console.log(`Volume ${volume.volume_title} already in queue`);
+		return;
+	}
+
+	const queueItem: QueueItem = {
+		volumeUuid: volume.volume_uuid,
+		driveFileId: volume.driveFileId,
+		seriesTitle: volume.series_title,
+		volumeTitle: volume.volume_title,
+		volumeMetadata: volume,
+		status: 'queued'
+	};
+
+	queueStore.update(q => [...q, queueItem]);
+
+	// Start processing if not already running
+	if (!isProcessing) {
+		processQueue();
+	}
+}
+
+/**
+ * Add multiple volumes from a series to the queue
+ */
+export function queueSeriesVolumes(volumes: VolumeMetadata[]): void {
+	const placeholders = volumes.filter(v => v.isPlaceholder && v.driveFileId);
+
+	if (placeholders.length === 0) {
+		console.warn('No placeholder volumes to queue');
+		return;
+	}
+
+	// Sort alphabetically by series title first, then by volume title
+	placeholders.sort((a, b) => {
+		const seriesCompare = a.series_title.localeCompare(b.series_title, undefined, {
+			numeric: true,
+			sensitivity: 'base'
+		});
+		if (seriesCompare !== 0) {
+			return seriesCompare;
+		}
+		return a.volume_title.localeCompare(b.volume_title, undefined, {
+			numeric: true,
+			sensitivity: 'base'
+		});
+	});
+
+	// Add each volume individually (duplicate check happens in queueVolume)
+	placeholders.forEach(volume => queueVolume(volume));
+}
+
+/**
+ * Check if a specific volume is in the queue
+ */
+export function isVolumeInQueue(volumeUuid: string): boolean {
+	const queue = get(queueStore);
+	return queue.some(item => item.volumeUuid === volumeUuid);
+}
+
+/**
+ * Get queue status for an entire series
+ */
+export function getSeriesQueueStatus(seriesTitle: string): SeriesQueueStatus {
+	const queue = get(queueStore);
+	const seriesItems = queue.filter(item => item.seriesTitle === seriesTitle);
+
+	return {
+		hasQueued: seriesItems.some(item => item.status === 'queued'),
+		hasDownloading: seriesItems.some(item => item.status === 'downloading'),
+		queuedCount: seriesItems.filter(item => item.status === 'queued').length,
+		downloadingCount: seriesItems.filter(item => item.status === 'downloading').length
+	};
+}
+
+/**
+ * Process the queue sequentially (one download at a time)
+ */
+async function processQueue(): Promise<void> {
+	if (isProcessing) {
+		return;
+	}
+
+	isProcessing = true;
+
+	while (true) {
+		const queue = get(queueStore);
+
+		// Find first queued item (not downloading)
+		const nextItem = queue.find(item => item.status === 'queued');
+
+		if (!nextItem) {
+			// Queue is empty or all items are downloading
+			break;
+		}
+
+		// Mark as downloading
+		queueStore.update(q =>
+			q.map(item =>
+				item.volumeUuid === nextItem.volumeUuid
+					? { ...item, status: 'downloading' as const }
+					: item
+			)
+		);
+
+		try {
+			// Download the volume
+			await downloadVolumeFromDrive(nextItem.volumeMetadata);
+		} catch (error) {
+			console.error(`Failed to download ${nextItem.volumeTitle}:`, error);
+		}
+
+		// Remove from queue after completion (success or failure)
+		queueStore.update(q => q.filter(item => item.volumeUuid !== nextItem.volumeUuid));
+	}
+
+	isProcessing = false;
+}
+
+// Export the store for reactive subscriptions
+export const downloadQueue = {
+	subscribe: queueStore.subscribe,
+	queueVolume,
+	queueSeriesVolumes,
+	isVolumeInQueue,
+	getSeriesQueueStatus
+};

--- a/src/lib/util/google-drive/api-client.ts
+++ b/src/lib/util/google-drive/api-client.ts
@@ -200,6 +200,49 @@ class DriveApiClient {
     await Promise.all(promises);
   }
 
+  /**
+   * Check if the current user can edit a file
+   * Returns false for viewer-only shared files
+   */
+  async canEditFile(fileId: string): Promise<boolean> {
+    return this.handleApiCall(async () => {
+      const { result } = await gapi.client.drive.files.get({
+        fileId,
+        fields: 'capabilities/canEdit'
+      });
+      return result.capabilities?.canEdit ?? false;
+    });
+  }
+
+  /**
+   * Get file metadata
+   * @param fileId The file ID
+   * @param fields Comma-separated list of fields to retrieve (e.g., 'description', 'name,description')
+   */
+  async getFileMetadata(fileId: string, fields: string): Promise<any> {
+    return this.handleApiCall(async () => {
+      const { result } = await gapi.client.drive.files.get({
+        fileId,
+        fields
+      });
+      return result;
+    });
+  }
+
+  /**
+   * Update a file's description field
+   * Used to store verified series title for sideloaded files
+   */
+  async updateFileDescription(fileId: string, description: string): Promise<void> {
+    return this.handleApiCall(async () => {
+      await gapi.client.drive.files.update({
+        fileId,
+        resource: { description },
+        fields: 'id,description'
+      });
+    });
+  }
+
   private getCurrentToken(): string {
     let token = '';
     tokenManager.token.subscribe(value => { token = value; })();

--- a/src/lib/util/google-drive/drive-files-cache.ts
+++ b/src/lib/util/google-drive/drive-files-cache.ts
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store';
 import { driveApiClient } from './api-client';
 import { GOOGLE_DRIVE_CONFIG } from './constants';
+import { syncService } from './sync-service';
 
 export interface DriveFileMetadata {
   fileId: string;
@@ -168,7 +169,6 @@ class DriveFilesCacheManager {
       this.isFetchingStore.set(false);
 
       // Check if sync was requested after login (do this in finally to ensure fetch is complete)
-      const { GOOGLE_DRIVE_CONFIG } = await import('./constants');
       const shouldSync = typeof window !== 'undefined' &&
         localStorage.getItem(GOOGLE_DRIVE_CONFIG.STORAGE_KEYS.SYNC_AFTER_LOGIN) === 'true';
 
@@ -176,7 +176,6 @@ class DriveFilesCacheManager {
         console.log('Cache loaded, triggering requested sync...');
         localStorage.removeItem(GOOGLE_DRIVE_CONFIG.STORAGE_KEYS.SYNC_AFTER_LOGIN);
 
-        const { syncService } = await import('./sync-service');
         syncService.syncReadProgress().catch(err =>
           console.error('Sync after login failed:', err)
         );

--- a/src/lib/util/google-drive/drive-files-cache.ts
+++ b/src/lib/util/google-drive/drive-files-cache.ts
@@ -10,6 +10,7 @@ export interface DriveFileMetadata {
   size?: number;
   path: string; // Relative path like "series/volume.cbz"
   description?: string; // Verified series title for sideloaded files
+  parentId?: string; // Parent folder ID (for deleting series folders)
 }
 
 /**
@@ -125,7 +126,8 @@ class DriveFilesCacheManager {
             modifiedTime: file.modifiedTime || new Date().toISOString(),
             size: file.size ? parseInt(file.size) : undefined,
             path: path,
-            description: file.description
+            description: file.description,
+            parentId: parentId
           };
 
           const existing = cacheMap.get(path);

--- a/src/lib/util/google-drive/token-manager.ts
+++ b/src/lib/util/google-drive/token-manager.ts
@@ -3,6 +3,7 @@ import { browser } from '$app/environment';
 import { GOOGLE_DRIVE_CONFIG, type TokenInfo } from './constants';
 import { showSnackbar } from '../snackbar';
 import { syncService } from './sync-service';
+import { driveFilesCache } from './drive-files-cache';
 
 class TokenManager {
   private tokenStore = writable<string>('');
@@ -192,12 +193,9 @@ class TokenManager {
 
           // Fetch Drive cache after successful login
           // The cache will automatically trigger sync when loaded if SYNC_AFTER_LOGIN flag is set
-          // Import dynamically to avoid circular dependency
-          import('./drive-files-cache').then(({ driveFilesCache }) => {
-            driveFilesCache.fetchAllFiles().catch(err =>
-              console.error('Failed to fetch Drive files cache after login:', err)
-            );
-          });
+          driveFilesCache.fetchAllFiles().catch(err =>
+            console.error('Failed to fetch Drive files cache after login:', err)
+          );
         }
       }
     });

--- a/src/lib/util/update-drive-descriptions.ts
+++ b/src/lib/util/update-drive-descriptions.ts
@@ -1,0 +1,72 @@
+import { driveApiClient } from './google-drive/api-client';
+import { driveFilesCache } from './google-drive/drive-files-cache';
+
+interface DecompressedEntry {
+  filename: string;
+  data: ArrayBuffer;
+}
+
+interface MokuroData {
+  title: string;
+  volume: string;
+}
+
+/**
+ * Update Drive file descriptions for sideloaded files downloaded via cloud page
+ * Adds series title tag if not already present in the description
+ * This helps future placeholder generation work correctly even if folder names don't match
+ */
+export async function updateDriveFileDescriptionForEntries(
+  fileId: string,
+  fileName: string,
+  entries: DecompressedEntry[]
+): Promise<void> {
+  try {
+    // Find the .mokuro file in the entries
+    const mokuroEntry = entries.find((e) => e.filename.endsWith('.mokuro'));
+    if (!mokuroEntry) {
+      console.log(`No .mokuro file found in ${fileName}, skipping description update`);
+      return;
+    }
+
+    // Parse the mokuro data
+    const mokuroText = new TextDecoder().decode(mokuroEntry.data);
+    const mokuroData: MokuroData = JSON.parse(mokuroText);
+
+    const actualSeriesTitle = mokuroData.title;
+
+    // Get file metadata (capabilities and description) in a single API call
+    const fileMetadata = await driveApiClient.getFileMetadata(fileId, 'capabilities/canEdit,description');
+    const canEdit = fileMetadata.capabilities?.canEdit ?? false;
+    const currentDescription = fileMetadata.description || '';
+
+    if (!canEdit) {
+      console.log(`Skipping description update for ${fileName} - file is read-only`);
+      return;
+    }
+
+    // Check if description already has a "Series:" tag (case-insensitive)
+    const hasSeriesTag = /^series:\s*.+/im.test(currentDescription);
+
+    if (hasSeriesTag) {
+      console.log(`Description for ${fileName} already has Series tag, skipping update`);
+      return;
+    }
+
+    // Append our series tag to the existing description
+    const seriesTag = `Series: ${actualSeriesTitle}`;
+    const newDescription = currentDescription
+      ? `${seriesTag}\n${currentDescription}`
+      : seriesTag;
+
+    console.log(`Updating description for ${fileName}: "${newDescription}"`);
+
+    await driveApiClient.updateFileDescription(fileId, newDescription);
+    driveFilesCache.updateFileDescription(fileId, newDescription);
+
+    console.log(`Successfully updated description for ${fileName}`);
+  } catch (error) {
+    // Log but don't fail the entire process
+    console.warn(`Failed to update Drive file description for ${fileName}:`, error);
+  }
+}

--- a/src/routes/cloud/+page.svelte
+++ b/src/routes/cloud/+page.svelte
@@ -32,6 +32,7 @@
   import { GoogleSolid } from 'flowbite-svelte-icons';
   import { catalog } from '$lib/catalog';
   import type { VolumeMetadata } from '$lib/types';
+  import { updateDriveFileDescriptionForEntries } from '$lib/util/update-drive-descriptions';
 
   // Subscribe to stores
   let accessToken = $state('');
@@ -465,17 +466,22 @@
               });
 
               console.log(`Processing ${data.entries.length} decompressed entries from ${data.fileName}`);
-              
+
               // Create File objects for each entry
               const files = data.entries.map(entry => {
                 return new File([entry.data], entry.filename);
               });
-              
+
               console.log(`Created ${files.length} file objects from decompressed entries`);
-              
+
               // Process all the files
               await processFiles(files);
               console.log(`Successfully processed ${files.length} decompressed files from ${data.fileName}`);
+
+              // Update Drive file description if needed (for sideloaded files)
+              // This runs in the background and won't fail the download if it errors
+              updateDriveFileDescriptionForEntries(fileInfo.id, data.fileName, data.entries)
+                .catch(err => console.warn('Background description update failed:', err));
 
               // Mark as completed
               completedFiles++;


### PR DESCRIPTION
## Summary
Complete reimplementation of PR #119 with updated architecture and improved functionality:

- **Placeholder System**: Identifies and displays Drive-only volumes that haven't been downloaded locally
- **Download Functionality**: One-click download for individual volumes or entire series from Google Drive
- **Duplicate Detection & Cleanup**: Identifies and removes duplicate Drive files with same path
- **UI Integration**: Visual distinction between local and Drive-only content with download icons and badges
- **Build Optimizations**: Fixed dynamic import warnings and SSR compatibility issues

## Changes

### Core Architecture

**Type Extensions** (`src/lib/types/index.ts`):
- Extended `VolumeMetadata` with optional placeholder fields:
  - `isPlaceholder`: Boolean flag for Drive-only volumes
  - `driveFileId`: Google Drive file ID for downloading
  - `driveModifiedTime`: Last modification timestamp
  - `driveSize`: File size for display

**Placeholder Generation** (`src/lib/catalog/placeholders.ts`):
- Reconciles Drive cache against local IndexedDB volumes
- Generates deterministic placeholder UUIDs from Drive file IDs
- Reuses series UUIDs for partially downloaded series
- Handles SSR/build environment safely (no IndexedDB access)

**Download System** (`src/lib/util/download-from-drive.ts`):
- `downloadVolumeFromDrive()`: Downloads CBZ, extracts ZIP, reads mokuro JSON, writes to IndexedDB
- `downloadSeriesFromDrive()`: Bulk download with progress tracking
- Updates Drive cache after successful downloads
- Comprehensive error handling and user feedback

**Catalog Integration** (`src/lib/catalog/index.ts`):
- New `volumesWithPlaceholders` store merges local volumes with Drive placeholders
- Catalog derives from combined store for complete content view
- Graceful error handling with fallback to local-only content

### Duplicate Detection & Cleanup

**Series Page** (`src/routes/[manga]/+page.svelte`):
- Detects duplicate Drive files with identical paths (same series/volume)
- Shows warning banner with count when duplicates found
- "Clean Duplicates" button removes older duplicates, keeps most recent
- Uses Drive file modification timestamps to determine which to keep
- Updates cache after deletion

### UI Components

**PlaceholderVolumeItem** (`src/lib/components/PlaceholderVolumeItem.svelte`):
- Displays Drive-only volumes with download icon and file size
- Download button with loading state and progress integration
- Delete button to remove from Drive
- Authentication check before actions

**Catalog Page** (`src/lib/components/Catalog.svelte`):
- Separates local series from placeholder-only series
- "Available in Drive" section for Drive-only series
- Bulk download button for all placeholder series

**Series Page** (`src/routes/[manga]/+page.svelte`):
- Renders PlaceholderVolumeItem for Drive-only volumes
- "Available in Drive" section with bulk download
- Mixed local/placeholder volume support
- Duplicate detection and cleanup UI

**Catalog Components** (`CatalogItem.svelte`, `CatalogListItem.svelte`):
- Download icon on placeholder-only series
- Visual distinction in grid and list views

### Build & Performance Fixes

**Static Imports** (`src/lib/util/google-drive/`):
- Replaced dynamic `import()` with static imports
- Eliminates Vite build warnings about mixed import types
- Prevents unnecessary code-splitting chunks
- Cleaner build output

## Testing Checklist

- [x] Sign in to Google Drive
- [x] Verify placeholder volumes show with download icons in series pages
- [x] Verify placeholder series show with "In Drive" badge in catalog
- [x] Test downloading individual placeholder volumes
- [x] Test bulk series download button
- [x] Test deleting individual placeholders from Drive
- [x] Verify placeholders disappear after successful download
- [x] Verify downloaded volumes work correctly in reader
- [x] Test duplicate detection on series with multiple backups
- [x] Test duplicate cleanup keeps most recent file
- [x] Build succeeds without warnings
- [x] No errors during SSR/build

## Implementation Notes

- Placeholders use deterministic UUIDs to avoid conflicts with real volumes
- Download process replaces placeholder with real volume metadata from mokuro JSON
- Progress tracking persists across navigation via progressTrackerStore
- Browser environment checks prevent IndexedDB access during SSR/build
- Static imports safe after Google Drive module refactoring resolved circular dependencies
- Duplicate detection looks at Drive cache only, independent of local download status
- Cleanup keeps most recent file based on Drive's `modifiedTime` timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)