### PR TITLE
fix(reader): restore night-mode coverage of extension overlays

### DIFF
--- a/e2e/night-mode.spec.ts
+++ b/e2e/night-mode.spec.ts
@@ -1,0 +1,267 @@
+import { test, expect, type Page } from '@playwright/test';
+import http from 'node:http';
+
+/**
+ * E2E coverage for the night-mode red filter.
+ *
+ * Night mode has to tint EVERY pixel the user can see, including surfaces that
+ * a `filter` on the root element never reaches:
+ *
+ *   - content a browser extension injects into <body> or <html>,
+ *   - a cross-origin iframe (how Yomitan renders its dictionary popup),
+ *   - the top layer: modal dialogs, popovers (every Flowbite dropdown), and
+ *     ::backdrop,
+ *   - the propagated canvas background.
+ *
+ * It also has to tint each of them exactly ONCE. The transform is
+ * luminance -> red channel, which is not idempotent: a second pass multiplies
+ * the red channel by 0.2126 and the surface renders ~5x too dark. Non-modal
+ * dialogs (Flowbite's Drawer calls show(), not showModal()) stay in normal flow
+ * and so are already covered by the page-level overlays — filtering them again
+ * via a bare `dialog` selector is the specific bug this asserts against.
+ *
+ * NOTE on the cross-origin case: Chrome only started refusing to paint SVG
+ * reference filters onto cross-origin frames in 151, and Playwright's bundled
+ * Chromium is older, so that assertion only has teeth when E2E_CHROMIUM points
+ * at a real Chrome >= 151. Every other assertion here reproduces on the bundled
+ * build.
+ */
+
+const FRAME_PORT = 8673;
+
+// White and mid-grey patches, so we can check the tint value and not just "is red".
+const FRAME_HTML = `<!doctype html><html><body style="margin:0">
+<div style="position:absolute;left:0;top:0;width:60px;height:60px;background:#ffffff"></div>
+<div style="position:absolute;left:60px;top:0;width:60px;height:60px;background:#808080"></div>
+</body></html>`;
+
+let frameServer: http.Server;
+
+test.beforeAll(async () => {
+  frameServer = http.createServer((_req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/html' });
+    res.end(FRAME_HTML);
+  });
+  await new Promise<void>((resolve) => frameServer.listen(FRAME_PORT, '127.0.0.1', resolve));
+});
+
+test.afterAll(async () => {
+  await new Promise((resolve) => frameServer.close(resolve));
+});
+
+/** Injects the surfaces an extension (and the app itself) can put on screen. */
+async function injectSurfaces(page: Page, framePort: number) {
+  await page.evaluate((port) => {
+    const box = 'position:fixed;top:0;width:60px;height:60px;z-index:2147483647;';
+    const mk = (id: string, css: string, parent: Element) => {
+      const el = document.createElement('div');
+      el.id = id;
+      el.style.cssText = css;
+      parent.appendChild(el);
+      return el;
+    };
+
+    mk('probe-body', box + 'left:0;background:#ffffff', document.body);
+    mk('probe-html', box + 'left:60px;background:#ffffff', document.documentElement);
+
+    const frame = document.createElement('iframe');
+    frame.id = 'probe-frame';
+    frame.style.cssText = box + 'left:120px;width:120px;border:0';
+    frame.src = `http://127.0.0.1:${port}/`;
+    document.documentElement.appendChild(frame);
+
+    const pop = mk(
+      'probe-popover',
+      box + 'left:240px;background:#ffffff;margin:0;border:0',
+      document.body
+    );
+    pop.setAttribute('popover', 'manual');
+    pop.showPopover();
+
+    const modal = document.createElement('dialog');
+    modal.id = 'probe-modal';
+    modal.style.cssText =
+      'position:fixed;top:80px;left:0;margin:0;padding:0;border:0;width:60px;height:60px;background:#ffffff';
+    document.body.appendChild(modal);
+    modal.showModal();
+
+    const nonModal = document.createElement('dialog');
+    nonModal.id = 'probe-nonmodal';
+    nonModal.style.cssText =
+      'position:fixed;top:80px;left:60px;margin:0;padding:0;border:0;width:60px;height:60px;background:#ffffff;z-index:2147483647';
+    document.body.appendChild(nonModal);
+    nonModal.show();
+  }, framePort);
+  // let the cross-origin frame paint
+  await page.waitForTimeout(600);
+}
+
+/**
+ * Mirrors NightModeFilter.svelte: two max-z-index blend layers kept as the last
+ * two children of <html>, plus the variable that drives the top-layer rules.
+ */
+async function setNightMode(page: Page, on: boolean) {
+  await page.evaluate((active) => {
+    const root = document.documentElement;
+    root.querySelectorAll('.night-mode-layer').forEach((el) => el.remove());
+    if (active) {
+      for (const kind of ['desaturate', 'redden']) {
+        const el = document.createElement('div');
+        el.className = `night-mode-layer night-mode-${kind}`;
+        root.appendChild(el);
+      }
+    }
+    root.classList.toggle('night-mode', active);
+    root.style.setProperty('--night-mode-filter', active ? 'url(#night-mode-filter)' : 'none');
+  }, on);
+  await page.waitForTimeout(300);
+}
+
+type Rgb = [number, number, number];
+
+async function pixel(page: Page, x: number, y: number): Promise<Rgb> {
+  const shot = await page.screenshot({ clip: { x, y, width: 1, height: 1 } });
+  // A 1x1 PNG: decode via the browser rather than shipping a decoder.
+  const data = await page.evaluate(async (b64) => {
+    const img = new Image();
+    img.src = 'data:image/png;base64,' + b64;
+    await img.decode();
+    const c = document.createElement('canvas');
+    c.width = c.height = 1;
+    const ctx = c.getContext('2d')!;
+    ctx.drawImage(img, 0, 0);
+    const d = ctx.getImageData(0, 0, 1, 1).data;
+    return [d[0], d[1], d[2]];
+  }, shot.toString('base64'));
+  return data as Rgb;
+}
+
+const SURFACES: Array<{ name: string; x: number; y: number }> = [
+  { name: 'div injected into <body>', x: 30, y: 30 },
+  { name: 'div injected into <html>', x: 90, y: 30 },
+  { name: 'cross-origin iframe (white)', x: 150, y: 30 },
+  { name: 'cross-origin iframe (grey)', x: 210, y: 30 },
+  { name: 'popover (top layer)', x: 270, y: 30 },
+  { name: 'modal dialog (top layer)', x: 30, y: 110 },
+  { name: 'non-modal dialog', x: 90, y: 110 },
+  { name: 'page background', x: 700, y: 600 }
+];
+
+test('night mode tints every visible surface exactly once', async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await page.goto('/');
+  await page.waitForTimeout(1200);
+  await injectSurfaces(page, FRAME_PORT);
+
+  await setNightMode(page, false);
+  const before: Record<string, Rgb> = {};
+  for (const s of SURFACES) before[s.name] = await pixel(page, s.x, s.y);
+
+  await setNightMode(page, true);
+
+  for (const s of SURFACES) {
+    const [r, g, b] = await pixel(page, s.x, s.y);
+    const [r0, g0, b0] = before[s.name];
+    // Rec.709 luma of the untinted colour is what the red channel must become.
+    const luma = 0.2126 * r0 + 0.7152 * g0 + 0.0722 * b0;
+
+    expect(g, `${s.name}: green channel must be removed`).toBeLessThan(40);
+    expect(b, `${s.name}: blue channel must be removed`).toBeLessThan(40);
+    // Catches BOTH "not tinted at all" and "tinted twice" (~0.21x too dark).
+    expect(
+      Math.abs(r - luma),
+      `${s.name}: red channel should be the luma of ${r0},${g0},${b0} (${luma.toFixed(0)}), got ${r}`
+    ).toBeLessThan(20);
+  }
+});
+
+test('turning night mode off restores the original colours', async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await page.goto('/');
+  await page.waitForTimeout(1200);
+  await injectSurfaces(page, FRAME_PORT);
+
+  await setNightMode(page, false);
+  const before = await pixel(page, 30, 30);
+  await setNightMode(page, true);
+  await setNightMode(page, false);
+  const after = await pixel(page, 30, 30);
+
+  expect(after).toEqual(before);
+});
+
+/**
+ * The desaturation and red passes are separate layers, so anything that paints
+ * BETWEEN them gets reddened without being desaturated — greens and blues
+ * collapse to black instead of becoming mid-red. Extensions routinely inject at
+ * z-index 2147483647 (Yomitan included), which is exactly the value that used to
+ * land in that gap. Saturated colours are the only probe that detects this:
+ * white and grey render correctly either way.
+ */
+test('extension content at a maximal z-index is desaturated, not just reddened', async ({
+  page
+}) => {
+  await page.setViewportSize({ width: 500, height: 400 });
+  await page.goto('/');
+  await page.waitForTimeout(1200);
+
+  await page.evaluate((port) => {
+    for (const [i, z] of [1000, 2147483646, 2147483647].entries()) {
+      const f = document.createElement('iframe');
+      f.className = 'probe-z';
+      f.style.cssText = `position:fixed;left:0;top:${i * 50}px;width:240px;height:44px;border:0;z-index:${z}`;
+      f.src = `http://127.0.0.1:${port}/`;
+      document.documentElement.appendChild(f);
+    }
+  }, FRAME_PORT);
+  await page.waitForTimeout(700);
+  await setNightMode(page, true);
+
+  // The served frame is white then mid-grey; add a saturated strip of our own by
+  // sampling a green patch we inject alongside at the same z-index.
+  await page.evaluate(() => {
+    for (const [i, z] of [1000, 2147483646, 2147483647].entries()) {
+      const d = document.createElement('div');
+      d.style.cssText = `position:fixed;left:260px;top:${i * 50}px;width:44px;height:44px;background:#00ff00;z-index:${z}`;
+      document.documentElement.appendChild(d);
+    }
+  });
+  // Re-assert the layers the way the component's MutationObserver does.
+  await setNightMode(page, true);
+
+  for (let i = 0; i < 3; i++) {
+    const [r, g, b] = await pixel(page, 282, i * 50 + 22);
+    // Rec.601 desaturation of #00ff00 is 150; only-multiply would give 0.
+    expect(r, `green patch ${i} must be desaturated before being reddened`).toBeGreaterThan(100);
+    expect(g).toBeLessThan(40);
+    expect(b).toBeLessThan(40);
+  }
+});
+
+test('night mode does not unpin position:fixed elements', async ({ page }) => {
+  await page.setViewportSize({ width: 900, height: 700 });
+  await page.goto('/');
+  await page.waitForTimeout(1200);
+
+  // A filter on <body> (rather than the root) would re-anchor this to the
+  // document and scroll it away — that is why the page-level tint is a blend
+  // overlay pair on the root's pseudo-elements, not a filter on a wrapper.
+  await page.evaluate(() => {
+    const tall = document.createElement('div');
+    tall.style.cssText = 'height:4000px';
+    document.body.appendChild(tall);
+    const hud = document.createElement('div');
+    hud.id = 'probe-hud';
+    hud.style.cssText = 'position:fixed;bottom:0;left:0;width:100px;height:40px;background:#fff';
+    document.body.appendChild(hud);
+  });
+
+  await setNightMode(page, true);
+  await page.evaluate(() => window.scrollTo(0, 1500));
+  await page.waitForTimeout(300);
+
+  const top = await page.evaluate(
+    () => document.getElementById('probe-hud')!.getBoundingClientRect().top
+  );
+  expect(Math.round(top)).toBe(660); // 700px viewport - 40px element
+});

--- a/src/app.html
+++ b/src/app.html
@@ -18,18 +18,82 @@
     <script src="https://accounts.google.com/gsi/client"></script>
     %sveltekit.head%
     <style>
-      /* CSS Variables for night mode */
+      /*
+       * Night mode: turn the whole page into a red monochrome image.
+       *
+       * Two mechanisms, because no single one reaches everything:
+       *
+       * 1. BLEND LAYERS for the document. A `saturation` pass strips colour, then
+       *    a `multiply` pass against pure red keeps only the red channel.
+       *    Blending — unlike `filter` — still composites over cross-origin
+       *    iframes, which is what a browser extension's popup is (Yomitan
+       *    renders its dictionary popup as a chrome-extension:// frame).
+       *    Chrome 151 refuses to paint SVG reference filters onto such frames at
+       *    all (csswg-drafts#13846), and Firefox has never painted a url() filter
+       *    on the root element (Bugzilla 1769223), so
+       *    `html { filter: url(#night-mode-filter) }` covers the extension popup
+       *    in neither engine. The blend layers behave identically in both.
+       *
+       *    They sit on the ROOT rather than on a wrapper, so they blend against
+       *    the canvas background too, and nothing gains a containing block —
+       *    putting a `filter` on <body> instead would re-anchor every
+       *    position:fixed descendant to the document and unpin the reader HUD.
+       *
+       * 2. The SVG matrix for TOP-LAYER content. Modal dialogs, popovers
+       *    (Flowbite dropdowns/tooltips) and fullscreen elements paint as
+       *    siblings of the root, above the blend layers, so blending cannot
+       *    reach them. A url() filter does work on non-root elements in both
+       *    engines.
+       *
+       * The two agree exactly on the whole grey ramp (#000000 -> 0,0,0 and
+       * #ffffff -> 255,0,0 in both) and differ only on fully saturated colours,
+       * where the CSS blending spec's luma function is Rec.601 and the SVG
+       * matrix is Rec.709. On real pages that is a mean error of ~1/255.
+       */
       :root {
         --night-mode-filter: none; /* Default: no filter */
       }
 
-      /* Apply the filter to the html element */
-      html {
-        filter: var(--night-mode-filter);
+      /*
+       * BOTH layers carry the maximum z-index, and NightModeFilter.svelte keeps
+       * them the last two children of <html>.
+       *
+       * This is load-bearing, not belt-and-braces. Extensions routinely inject at
+       * z-index 2147483647 (Yomitan included). Ties are broken by tree order, so
+       * anything at that z-index painting between the two layers would be
+       * multiplied but never desaturated — its greens and blues would collapse to
+       * black. Equal z-index plus last-in-tree-order puts both layers above such
+       * an element. This is also why they cannot be html::before/::after: a
+       * ::before box is the FIRST child and loses every tie.
+       */
+      html.night-mode > .night-mode-layer {
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 2147483647;
       }
 
-      /* Also apply to dialog elements in the top layer (showModal promotes dialogs outside the html filter) */
-      dialog {
+      /* Paint order within the pair comes from tree order: desaturate, then redden. */
+      html.night-mode > .night-mode-desaturate {
+        background-color: #000;
+        mix-blend-mode: saturation;
+      }
+
+      html.night-mode > .night-mode-redden {
+        background-color: #f00;
+        mix-blend-mode: multiply;
+      }
+
+      /*
+       * Top layer. `dialog:modal` — not bare `dialog` — because a non-modal
+       * dialog (Flowbite's Drawer calls show(), not showModal()) stays in normal
+       * flow, where the overlays already cover it; filtering it as well would
+       * apply the transform twice and the matrix is not idempotent.
+       */
+      dialog:modal,
+      :popover-open,
+      :fullscreen:not(:root),
+      ::backdrop {
         filter: var(--night-mode-filter);
       }
     </style>
@@ -37,7 +101,7 @@
     <svg width="0" height="0" style="position: absolute; z-index: -9999; visibility: hidden">
       <defs>
         <filter id="night-mode-filter" color-interpolation-filters="sRGB">
-          <!-- Convert to grayscale first -->
+          <!-- Luminance -> red channel, everything else zeroed -->
           <feColorMatrix
             type="matrix"
             values="0.2126 0.7152 0.0722 0 0

--- a/src/lib/components/NightModeFilter.svelte
+++ b/src/lib/components/NightModeFilter.svelte
@@ -3,163 +3,69 @@
   import { browser } from '$app/environment';
   import { onDestroy } from 'svelte';
 
-  // Elements for Firefox overlay approach
-  let grayscaleLayer: HTMLDivElement | null = null;
-  let redOverlay: HTMLDivElement | null = null;
-  let dialogObserver: MutationObserver | null = null;
-  let isFirefox = browser && navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+  // The colour maths lives in the <style> block in src/app.html, which explains
+  // why night mode is a blend-layer pair plus a top-layer filter rather than one
+  // filter on the root. This component owns the two layer elements.
+  //
+  // Both engines take the same path now: the Firefox-specific overlay branch is
+  // gone, because the layers it used are what every browser uses.
 
-  // Firefox: Apply overlays inside a dialog for top-layer support
-  function applyFirefoxOverlaysToDialog(dialog: HTMLDialogElement, active: boolean) {
-    const existingGrayscale = dialog.querySelector('#dialog-grayscale-layer');
-    const existingRed = dialog.querySelector('#dialog-red-overlay');
+  let desaturate: HTMLDivElement | null = null;
+  let redden: HTMLDivElement | null = null;
+  let observer: MutationObserver | null = null;
 
-    if (active) {
-      if (!existingGrayscale) {
-        const grayscale = document.createElement('div');
-        grayscale.id = 'dialog-grayscale-layer';
-        grayscale.style.position = 'fixed';
-        grayscale.style.top = '0';
-        grayscale.style.left = '0';
-        grayscale.style.width = '100vw';
-        grayscale.style.height = '100vh';
-        grayscale.style.backgroundColor = 'rgba(0, 0, 0, 1)';
-        grayscale.style.pointerEvents = 'none';
-        grayscale.style.zIndex = '999998';
-        grayscale.style.mixBlendMode = 'saturation';
-        dialog.appendChild(grayscale);
-      }
-      if (!existingRed) {
-        const red = document.createElement('div');
-        red.id = 'dialog-red-overlay';
-        red.style.position = 'fixed';
-        red.style.top = '0';
-        red.style.left = '0';
-        red.style.width = '100vw';
-        red.style.height = '100vh';
-        red.style.backgroundColor = 'rgba(255, 0, 0, 1)';
-        red.style.pointerEvents = 'none';
-        red.style.zIndex = '999999';
-        red.style.mixBlendMode = 'multiply';
-        dialog.appendChild(red);
-      }
-    } else {
-      existingGrayscale?.remove();
-      existingRed?.remove();
-    }
+  function makeLayer(kind: 'desaturate' | 'redden') {
+    const el = document.createElement('div');
+    el.className = `night-mode-layer night-mode-${kind}`;
+    el.setAttribute('aria-hidden', 'true');
+    return el;
   }
 
-  // Firefox: Update all open dialogs
-  function updateFirefoxDialogs(active: boolean) {
-    document.querySelectorAll('dialog[open]').forEach((dialog) => {
-      applyFirefoxOverlaysToDialog(dialog as HTMLDialogElement, active);
-    });
+  /**
+   * Keep the pair as the last two children of <html>, in this order.
+   *
+   * Both layers sit at the maximum z-index, so paint order against an extension
+   * that injects at the same z-index is decided by tree order. If an extension
+   * appends its popup after us, it would land above the desaturation layer and
+   * render with its colour channels crushed instead of tinted, so we move back
+   * on top whenever the root's children change.
+   */
+  function ensureOnTop() {
+    const root = document.documentElement;
+    if (!desaturate || !redden) return;
+    if (root.lastElementChild === redden && redden.previousElementSibling === desaturate) return;
+    root.appendChild(desaturate);
+    root.appendChild(redden);
   }
 
-  // Firefox: Set up observer to watch for dialog open/close
-  function setupDialogObserver(active: boolean) {
-    if (!isFirefox || !browser) return;
-
-    // Clean up existing observer
-    dialogObserver?.disconnect();
-
-    if (active) {
-      dialogObserver = new MutationObserver((mutations) => {
-        mutations.forEach((mutation) => {
-          if (mutation.type === 'attributes' && mutation.attributeName === 'open') {
-            const dialog = mutation.target as HTMLDialogElement;
-            if (dialog.tagName === 'DIALOG') {
-              applyFirefoxOverlaysToDialog(dialog, dialog.hasAttribute('open'));
-            }
-          }
-          // Also check for new dialogs being added to the DOM
-          mutation.addedNodes.forEach((node) => {
-            if (node instanceof HTMLDialogElement && node.hasAttribute('open')) {
-              applyFirefoxOverlaysToDialog(node, true);
-            }
-          });
-        });
-      });
-
-      dialogObserver.observe(document.body, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ['open']
-      });
-
-      // Apply to any already-open dialogs
-      updateFirefoxDialogs(true);
-    } else {
-      // Remove overlays from all dialogs
-      updateFirefoxDialogs(false);
-    }
-  }
-
-  // Function to apply the night mode filter
   function applyNightModeFilter(active: boolean) {
     if (!browser) return;
+    const root = document.documentElement;
 
-    if (isFirefox) {
-      // Firefox approach: Use overlays with blend modes
-      if (active) {
-        // Create grayscale layer if it doesn't exist
-        if (!grayscaleLayer) {
-          grayscaleLayer = document.createElement('div');
-          grayscaleLayer.id = 'grayscale-saturation-layer';
-          grayscaleLayer.style.position = 'fixed';
-          grayscaleLayer.style.top = '0';
-          grayscaleLayer.style.left = '0';
-          grayscaleLayer.style.width = '100%';
-          grayscaleLayer.style.height = '100%';
-          grayscaleLayer.style.backgroundColor = 'rgba(0, 0, 0, 1)';
-          grayscaleLayer.style.pointerEvents = 'none';
-          grayscaleLayer.style.zIndex = '999998';
-          grayscaleLayer.style.mixBlendMode = 'saturation'; // Removes color saturation
-          grayscaleLayer.style.display = 'block';
-          document.body.appendChild(grayscaleLayer);
-        }
+    if (active) {
+      desaturate ??= makeLayer('desaturate');
+      redden ??= makeLayer('redden');
+      ensureOnTop();
 
-        // Create red overlay if it doesn't exist
-        if (!redOverlay) {
-          redOverlay = document.createElement('div');
-          redOverlay.id = 'red-overlay';
-          redOverlay.style.position = 'fixed';
-          redOverlay.style.top = '0';
-          redOverlay.style.left = '0';
-          redOverlay.style.width = '100%';
-          redOverlay.style.height = '100%';
-          redOverlay.style.backgroundColor = 'rgba(255, 0, 0, 1)';
-          redOverlay.style.pointerEvents = 'none';
-          redOverlay.style.zIndex = '999999'; // Higher than grayscale
-          redOverlay.style.mixBlendMode = 'multiply';
-          redOverlay.style.display = 'block';
-          document.body.appendChild(redOverlay);
-        }
-      } else {
-        // Remove overlays if night mode is off
-        if (grayscaleLayer) {
-          grayscaleLayer.remove();
-          grayscaleLayer = null;
-        }
-        if (redOverlay) {
-          redOverlay.remove();
-          redOverlay = null;
-        }
-      }
-
-      // Also handle dialogs in top layer for Firefox
-      setupDialogObserver(active);
+      // Only observe the root's own child list — this fires on extension
+      // injection, not on anything the app renders inside <body>.
+      observer ??= new MutationObserver(ensureOnTop);
+      observer.observe(root, { childList: true });
     } else {
-      // Non-Firefox approach: Use CSS variables with SVG filter
-      const rootElement = document.documentElement;
-
-      if (active) {
-        rootElement.style.setProperty('--night-mode-filter', 'url(#night-mode-filter)');
-      } else {
-        rootElement.style.setProperty('--night-mode-filter', 'none');
-      }
+      observer?.disconnect();
+      observer = null;
+      desaturate?.remove();
+      redden?.remove();
+      desaturate = null;
+      redden = null;
     }
+
+    // Gates the layer styles.
+    root.classList.toggle('night-mode', active);
+
+    // Drives the top-layer rules (modal dialogs, popovers, fullscreen,
+    // ::backdrop) — those paint above the layers, so they filter themselves.
+    root.style.setProperty('--night-mode-filter', active ? 'url(#night-mode-filter)' : 'none');
   }
 
   // React to nightModeActive store changes (includes schedule-based activation)
@@ -167,22 +73,9 @@
     applyNightModeFilter($nightModeActive);
   }
 
-  // Clean up
   onDestroy(() => {
-    if (browser) {
-      if (grayscaleLayer) {
-        grayscaleLayer.remove();
-      }
-      if (redOverlay) {
-        redOverlay.remove();
-      }
-      dialogObserver?.disconnect();
-      // Clean up dialog overlays
-      document.querySelectorAll('#dialog-grayscale-layer, #dialog-red-overlay').forEach((el) => {
-        el.remove();
-      });
-    }
+    if (browser) applyNightModeFilter(false);
   });
 </script>
 
-<!-- No visible elements - just applies the filter via CSS variables or overlays -->
+<!-- No markup: the two blend layers are appended to <html>, above everything. -->


### PR DESCRIPTION
Night mode's red filter stopped tinting browser-extension popups. **The regression is in Chrome, not in this repo.**

From Chrome 151, an SVG *reference* filter is no longer painted onto cross-origin or restricted frames ([csswg-drafts#13846](https://github.com/w3c/csswg-drafts/pull/13846)). Yomitan renders its dictionary popup as a `chrome-extension://` iframe, so `html { filter: url(#night-mode-filter) }` skips it.

Measured on the version boundary:

| browser | cross-origin frame tinted? |
| --- | --- |
| Chromium 145 | yes |
| Chromium 150 | yes |
| Chrome 151.0.7922.71 | **no** |

No placement of a `url()` filter brings it back — blocked on the root *and* directly on the iframe. Any SVG filter in the ancestor chain also suppresses that frame's own function filters.

## The fix

The root filter is replaced by a pair of blend layers on `<html>`: a `saturation` pass, then a `multiply` pass against pure red. Blending, unlike `filter`, still composites over cross-origin frames. The SVG matrix survives, used only for top-layer content.

**Colour is preserved where it matters.** Greys are pixel-identical to the old matrix — `#000000` → `0,0,0`, `#ffffff` → `255,0,0`, every ramp step exact. Only fully saturated colours differ, by ≤32/255, because the CSS blending spec fixes its luma function at Rec.601 while the SVG matrix is Rec.709. Over five real manga covers that is a mean error of **1.3/255**.

**Both layers carry the maximum z-index and are kept as the last two children of `<html>`.** This is load-bearing. Extensions routinely inject at `z-index: 2147483647` (Yomitan included); anything landing *between* the two passes is reddened but never desaturated, collapsing its greens and blues to black. Ties resolve by tree order, so a `MutationObserver` on the root re-asserts the pair when an extension injects. It is also why the layers cannot be pseudo-elements — a `::before` box is the first child and loses every tie.

**Firefox now takes the same path.** Its overlay hack existed because Gecko silently drops `url()` filters on the root element ([Bugzilla 1769223](https://bugzilla.mozilla.org/show_bug.cgi?id=1769223), still NEW — reconfirmed on 153.0.1 against inline, external and `data:` references and every stacking-context workaround). Since the blend layers are what both engines use, the `isFirefox` branch and its dialog `MutationObserver` are deleted rather than ported. Net −169 lines in that component.

## Three more surfaces the root filter never reached

- **`[popover]` top-layer content** — every Flowbite dropdown, tooltip and popover — was untinted. Now covered via `:popover-open`, along with `::backdrop` and non-root `:fullscreen`.
- **The bare `dialog` rule double-filtered non-modal dialogs.** Flowbite's Drawer calls `show()`, not `showModal()`, so it stays in normal flow and was already tinted; the matrix is not idempotent, so the **Settings drawer rendered ~5× too dark**. Narrowed to `dialog:modal`.
- **On light themes the page background escaped entirely**, because a root filter does not apply to the propagated canvas background. The full-viewport blend layers cover it.

## Rejected alternatives

- **CSS filter-function chains cannot express luminance→red-only.** Any chain containing `grayscale(1)` operates on greys afterward, where every remaining function scales all three channels equally. Best fit found had RMS error 0.32 and crushed tonal range to ~43%.
- **`filter` on `<body>` or `html > *`** makes it a containing block for `position: fixed` descendants — the reader HUD unpins and scrolls away. Measured in both engines.
- **`backdrop-filter`** is exact and reaches extension frames in Chrome, but Firefox does not paint it at all (confirmed on system Firefox 153.0.1, not just the Playwright build) and it costs ~2× the frame time.

## Cost

~25 ms/frame vs a 16.7 ms baseline on a 1920×1080 pan in Chrome (Firefox: 19 vs 17), and only while night mode is on. Accepted as the price of covering extension popups.

## Verification

Chrome 151.0.7922.71 and Firefox 153.0, driven against the running app with the real setting — every surface tints exactly once, and turning night mode off restores the original pixels.

New `e2e/night-mode.spec.ts` covers the surfaces, the exactly-once requirement, the max-z-index layering, and that `position: fixed` stays pinned. It fails on the previous code with the reported symptom, and its z-index case fails on a split-z-index layering.

`svelte-check` 0 errors · 960 unit tests pass · 17/17 e2e pass (zoom suite unaffected) · ESLint clean on changed files.

> [!NOTE]
> CHANGELOG is intentionally untouched — happy to add entries in whatever split you prefer, since the drawer, dropdown and light-theme-background fixes are arguably separate user-visible lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
