### PR TITLE
fix: series.json and catalog.json follow deletes, moves and renames

### DIFF
--- a/src/lib/util/sync/unified-cloud-manager.test.ts
+++ b/src/lib/util/sync/unified-cloud-manager.test.ts
@@ -161,9 +161,16 @@ vi.mock('$lib/metadata/catalog-index-sync', () => ({
 
 const reconcileMissingMetadataFiles = vi.fn(async (_files?: unknown) => {});
 const markListingFresh = vi.fn();
+const scheduleSeriesFileWrite = vi.fn();
+const scheduleCatalogFileWrite = vi.fn();
+vi.mock('$lib/metadata/catalog-file-sync', () => ({
+  scheduleCatalogFileWrite: () => scheduleCatalogFileWrite()
+}));
 vi.mock('$lib/metadata/series-file-sync', () => ({
   reconcileMissingMetadataFiles: (files?: unknown) => reconcileMissingMetadataFiles(files),
-  markListingFresh: () => markListingFresh()
+  markListingFresh: () => markListingFresh(),
+  scheduleSeriesFileWrite: (title: string, options?: unknown) =>
+    scheduleSeriesFileWrite(title, options)
 }));
 
 /**
@@ -224,6 +231,43 @@ function oldSeriesFiles(): CloudFileMetadata[] {
 describe('UnifiedCloudManager rename operations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('a cross-series rename schedules series.json rewrites for BOTH folders and a catalog write', async () => {
+    // The old folder keeps other volumes, so its series.json still lists the
+    // moved one until rewritten; the new folder needs the arrival added.
+    const cache = loadedCache();
+    const provider = makeRenameProvider();
+    const files = [
+      ...oldSeriesFiles(),
+      {
+        provider: 'webdav',
+        fileId: 'cbz-2',
+        path: 'Old Series/Volume 2.cbz',
+        modifiedTime: 't',
+        size: 5
+      }
+    ];
+    getActiveProvider.mockReturnValue(provider);
+    getBySeries.mockImplementation((s: string) => files.filter((f) => f.path.startsWith(`${s}/`)));
+    getCache.mockReturnValue(cache);
+    generateSidecars.mockResolvedValue({
+      mokuro: { filename: 'Volume X.mokuro', blob: new Blob(['{}']) }
+    });
+
+    const { unifiedCloudManager } = await import('$lib/util/sync/unified-cloud-manager');
+    await unifiedCloudManager.renameVolume(
+      'Old Series',
+      'Volume 1',
+      'New Series',
+      'Volume X',
+      'uuid-1'
+    );
+
+    const scheduled = scheduleSeriesFileWrite.mock.calls.map((c) => c[0]);
+    expect(scheduled).toContain('Old Series');
+    expect(scheduled).toContain('New Series');
+    expect(scheduleCatalogFileWrite).toHaveBeenCalled();
   });
 
   it('regenerates the .mokuro at the new path, moves cbz+cover, and deletes the stale .mokuro', async () => {
@@ -1015,6 +1059,39 @@ describe('UnifiedCloudManager rename operations', () => {
     // it safe even though volume 1's files still occupy the old directory.
     expect(provider.removeDirectoryIfEmpty).toHaveBeenCalledTimes(1);
     expect(provider.removeDirectoryIfEmpty).toHaveBeenCalledWith('Old Series');
+  });
+});
+
+describe('metadata maintenance on delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('a volume delete schedules a series.json rewrite and a catalog write', async () => {
+    const provider = makeRenameProvider();
+    const files = oldSeriesFiles();
+    getActiveProvider.mockReturnValue(provider);
+    getBySeries.mockImplementation((s: string) => files.filter((f) => f.path.startsWith(`${s}/`)));
+    getCache.mockReturnValue(loadedCache());
+
+    const { unifiedCloudManager } = await import('$lib/util/sync/unified-cloud-manager');
+    await unifiedCloudManager.deleteManagedVolume('Old Series', 'Volume 1');
+
+    expect(scheduleSeriesFileWrite.mock.calls.map((c) => c[0])).toContain('Old Series');
+    expect(scheduleCatalogFileWrite).toHaveBeenCalled();
+  });
+
+  it('a series delete schedules a catalog write', async () => {
+    const provider = makeRenameProvider();
+    const files = oldSeriesFiles();
+    getActiveProvider.mockReturnValue(provider);
+    getBySeries.mockImplementation((s: string) => files.filter((f) => f.path.startsWith(`${s}/`)));
+    getCache.mockReturnValue(loadedCache());
+
+    const { unifiedCloudManager } = await import('$lib/util/sync/unified-cloud-manager');
+    await unifiedCloudManager.deleteSeriesFolder('Old Series');
+
+    expect(scheduleCatalogFileWrite).toHaveBeenCalled();
   });
 });
 

--- a/src/lib/util/sync/unified-cloud-manager.ts
+++ b/src/lib/util/sync/unified-cloud-manager.ts
@@ -483,6 +483,9 @@ class UnifiedCloudManager {
     }
 
     await this.cleanupSeriesFileIfFolderEmptied(seriesTitle);
+    // When the folder still holds volumes, its series.json now lists one too
+    // many; either way the catalog's counts and freshness moved.
+    await this.scheduleMetadataMaintenance([seriesTitle]);
   }
 
   /**
@@ -501,6 +504,31 @@ class UnifiedCloudManager {
    * remote `series.json` — recoverable, since the next write republishes it from
    * the cached index, but it is a destructive step gated on local state.
    */
+  /**
+   * After a delete/rename mutated cloud files, bring the metadata files back
+   * in line: every affected series' `series.json` gets the standard debounced
+   * rewrite (self-gating — an emptied folder writes nothing, a bunko server
+   * merges it as an update request), and one catalog write follows (its own
+   * scheduler refuses on servers that compile their own). Best-effort: the
+   * heal-by-review pass catches anything this loses.
+   */
+  private async scheduleMetadataMaintenance(
+    seriesTitles: Array<string | undefined>
+  ): Promise<void> {
+    try {
+      const [{ scheduleSeriesFileWrite }, { scheduleCatalogFileWrite }] = await Promise.all([
+        import('$lib/metadata/series-file-sync'),
+        import('$lib/metadata/catalog-file-sync')
+      ]);
+      for (const title of new Set(seriesTitles.filter((t): t is string => !!t))) {
+        scheduleSeriesFileWrite(title);
+      }
+      scheduleCatalogFileWrite();
+    } catch (error) {
+      console.debug('Could not schedule metadata maintenance:', error);
+    }
+  }
+
   private async cleanupSeriesFileIfFolderEmptied(seriesTitle: string): Promise<void> {
     try {
       // Same folder the write path uses, and the same key it cached the record
@@ -633,6 +661,13 @@ class UnifiedCloudManager {
       // never be empty, so the prune below would always no-op.
       await this.cleanupSeriesFileIfFolderEmptied(oldFolderTitle);
       await this.pruneSeriesDirectoryIfEmpty(provider, oldFolderTitle);
+    }
+
+    if (changed > 0) {
+      // The old folder's series.json still lists the moved volume (when other
+      // volumes kept the folder alive), the new folder's needs the arrival —
+      // and a plain retitle stales the entry in place. Rewrite both sides.
+      await this.scheduleMetadataMaintenance([oldFolderTitle, newSeriesTitle]);
     }
 
     return changed;
@@ -1009,6 +1044,9 @@ class UnifiedCloudManager {
       // volumes failed and their files still occupy the old directory.
       if (result.renamedVolumeUuids.length > 0) {
         await this.pruneSeriesDirectoryIfEmpty(provider, oldFolderTitle);
+        // The moved series.json still says "series_title": old name inside it,
+        // and the catalog still lists the old folder. Rewrite both.
+        await this.scheduleMetadataMaintenance([oldFolderTitle, newSeriesTitle]);
       }
 
       return result;
@@ -1027,6 +1065,9 @@ class UnifiedCloudManager {
     } catch (error) {
       console.warn(`Failed to move the cached series index to '${newSeriesTitle}':`, error);
     }
+    // The carried series.json still names the old series inside it, and the
+    // catalog still lists the old folder. Rewrite both.
+    await this.scheduleMetadataMaintenance([oldFolderTitle, newSeriesTitle]);
 
     const cache = cacheManager.getCache(provider.type);
     if (cache?.removeById && cache?.add) {
@@ -1823,6 +1864,9 @@ class UnifiedCloudManager {
     } catch (error) {
       console.debug(`Could not drop the cached catalog entry for '${folderTitle}':`, error);
     }
+    // The cloud catalog still lists the deleted series (client-produced
+    // backends); the series write self-gates to nothing for a gone folder.
+    await this.scheduleMetadataMaintenance([]);
     return result;
   }
 


### PR DESCRIPTION
## Summary

Every cloud mutation now finishes with metadata maintenance through the existing debounced schedulers: affected series get a series.json rewrite (old folder prunes the departed entry, new folder gains the arrival, a carried sidecar's inner series_title corrects; self-gating covers emptied folders and server-compiled backends), and one catalog write follows. Wired into volume rename, series rename (fan-out and bulk folder-move paths), volume delete, and series delete.

## Test plan
- 3 new tests pinning the rename/delete scheduling; 2,880 total pass; svelte-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)