### PR TITLE
fix(reader): smooth trackpad zoom, and make trackpad pinch always zoom (#259)

### DIFF
--- a/docs/INPUT-CONTRACTS.md
+++ b/docs/INPUT-CONTRACTS.md
@@ -82,6 +82,34 @@ Every handler that starts motion opens with the gate call matching its
 intent. Never call `finishNow`/`stop`/`stopPan` combinations inline — add
 to the gate if a new intent appears.
 
+### Wheel granularity decides the zoom's shape (#259)
+
+A wheel stream is classified as **fine** (trackpad, precision wheel,
+synthetic pinch) or **notched** by `WheelStreamClassifier` — once per event,
+at the top of each surface's `handleWheel`, shared by the intent check and
+the zoom so the stateful classifier is never asked twice.
+
+- **Fine streams zoom continuously** at the cursor, through the same
+  anchored path a pinch uses. Stepping a ladder on a device that reports
+  every millimetre of travel is what #259 reported: nothing, nothing,
+  nothing, lurch.
+- **Notched streams keep the level ladder** — one notch is one deliberate
+  step, and mouse users are untouched.
+- **A fine ctrl/meta+wheel is a pinch, so it always zooms**, whatever
+  `swapWheelBehavior` says. Chrome and Firefox deliver trackpad pinch as a
+  synthetic ctrl+wheel; only Safari has real pinch events. Without this a
+  Mac user with the swap on has no working pinch at all. A _notched_
+  ctrl+wheel is a genuine keyboard chord and keeps the swap semantics.
+- Classification is **sticky per stream** and only ever upgrades to fine:
+  trackpad momentum reports large round deltas indistinguishable from
+  notches, while a mouse never reports the small ones. Erring toward fine
+  costs a precision-wheel owner a smooth zoom, which is what they wanted;
+  erring the other way is the bug.
+
+Wheel zoom has no release event, so a fine stream settles on an idle
+timeout (`WHEEL_ZOOM_SETTLE_MS`) — that settle is what clamps the paged
+camera into bounds and reports reading progress.
+
 ### Swipe-to-flip is edge-gated (#186)
 
 A touch swipe flips the page only if no pannable content was hidden in the
@@ -104,15 +132,16 @@ Zoom settles carry a `SettleReason` (`zoom-controller.ts`): only
 
 ## Per-surface policy matrix
 
-| Policy         | PagedViewport                     | Scroll readers                          |
-| -------------- | --------------------------------- | --------------------------------------- |
-| Capture        | deferred (at drag threshold)      | immediate (at pan press)                |
-| Pan deltas     | incremental → `camera.adjustView` | totals → absolute scroll from baselines |
-| Text-box pan   | suppressed for mouse/pen only     | suppressed for all pointer types        |
-| Pinch survivor | keeps panning                     | ignored until fresh press               |
-| Tap commit     | immediate                         | deferred (300 ms)                       |
-| Swipe-to-flip  | yes (mobile setting, edge-gated)  | no (panning is the scroll)              |
-| Wheel          | zoom, gap, or camera glide        | zoom, gap, or (native/strip) scroll     |
+| Policy         | PagedViewport                        | Scroll readers                          |
+| -------------- | ------------------------------------ | --------------------------------------- |
+| Capture        | deferred (at drag threshold)         | immediate (at pan press)                |
+| Pan deltas     | incremental → `camera.adjustView`    | totals → absolute scroll from baselines |
+| Text-box pan   | suppressed for mouse/pen only        | suppressed for all pointer types        |
+| Pinch survivor | keeps panning                        | ignored until fresh press               |
+| Tap commit     | immediate                            | deferred (300 ms)                       |
+| Swipe-to-flip  | yes (mobile setting, edge-gated)     | no (panning is the scroll)              |
+| Wheel          | zoom, gap, or camera glide           | zoom, gap, or (native/strip) scroll     |
+| Wheel zoom     | continuous (fine) / ladder (notched) | continuous (fine) / ladder (notched)    |
 
 Ctrl/meta+shift+wheel is the page-gap adjustment chord on every surface
 (paged writes `pagedGap`; scroll readers write `scrollGap` and sync

--- a/src/lib/components/Reader/HorizontalScrollReader.svelte
+++ b/src/lib/components/Reader/HorizontalScrollReader.svelte
@@ -14,6 +14,7 @@
     GAP_WHEEL_STEP_SIZE,
     MAX_PAGE_GAP,
     WheelAccumulator,
+    WheelStreamClassifier,
     gapWheelSteps,
     normalizeWheelDelta,
     wheelIntentIsGapAdjust,
@@ -356,6 +357,13 @@
 
   const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
 
+  /**
+   * Trackpad vs notched wheel, per stream (#259). Classified once per event
+   * and shared by the intent check and the zoom itself: the classifier is
+   * stateful, so asking it twice would double-count the stream.
+   */
+  const wheelStream = new WheelStreamClassifier();
+
   // The chord drives the continuous-mode dividers: gap > 0 means dividers on,
   // reaching 0 turns them off (the M toggle keeps working independently).
   function adjustGap(delta: number) {
@@ -369,6 +377,7 @@
 
   function handleWheel(e: WheelEvent) {
     if (!scrollContainer) return;
+    const fine = wheelStream.classify(e);
     if (wheelIntentIsGapAdjust(e)) {
       e.preventDefault();
       adjustGap(gapWheelSteps(e, gapAccumulator));
@@ -376,10 +385,10 @@
     }
     const modifier = e.ctrlKey || e.metaKey;
 
-    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
+    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior, fine)) {
       e.preventDefault();
       motion.beforeZoom();
-      zoomController.wheelZoom(e);
+      zoomController.wheelZoom(e, fine);
       return;
     }
 

--- a/src/lib/components/Reader/PagedViewport.svelte
+++ b/src/lib/components/Reader/PagedViewport.svelte
@@ -15,6 +15,7 @@
     GAP_WHEEL_STEP_SIZE,
     MAX_PAGE_GAP,
     WheelAccumulator,
+    WheelStreamClassifier,
     gapWheelSteps,
     normalizeWheelDelta,
     wheelIntentIsGapAdjust,
@@ -143,6 +144,13 @@
 
   const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
 
+  /**
+   * Trackpad vs notched wheel, per stream (#259). Classified once per event
+   * and shared by the intent check and the zoom itself: the classifier is
+   * stateful, so asking it twice would double-count the stream.
+   */
+  const wheelStream = new WheelStreamClassifier();
+
   function adjustGap(delta: number) {
     if (delta === 0) return;
     const next = Math.max(0, Math.min(MAX_PAGE_GAP, ($settings.pagedGap ?? 0) + delta));
@@ -151,16 +159,17 @@
   }
 
   function handleWheel(e: WheelEvent) {
+    const fine = wheelStream.classify(e);
     if (wheelIntentIsGapAdjust(e)) {
       e.preventDefault();
       adjustGap(gapWheelSteps(e, gapAccumulator));
       return;
     }
     const modifier = e.ctrlKey || e.metaKey;
-    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
+    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior, fine)) {
       e.preventDefault();
       motion.beforeZoom();
-      controller.wheelZoom(e);
+      controller.wheelZoom(e, fine);
       return;
     }
     e.preventDefault();

--- a/src/lib/components/Reader/VerticalScrollReader.svelte
+++ b/src/lib/components/Reader/VerticalScrollReader.svelte
@@ -14,6 +14,7 @@
     GAP_WHEEL_STEP_SIZE,
     MAX_PAGE_GAP,
     WheelAccumulator,
+    WheelStreamClassifier,
     gapWheelSteps,
     normalizeWheelDelta,
     wheelIntentIsGapAdjust,
@@ -353,6 +354,13 @@
 
   const gapAccumulator = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
 
+  /**
+   * Trackpad vs notched wheel, per stream (#259). Classified once per event
+   * and shared by the intent check and the zoom itself: the classifier is
+   * stateful, so asking it twice would double-count the stream.
+   */
+  const wheelStream = new WheelStreamClassifier();
+
   // The chord drives the continuous-mode dividers: gap > 0 means dividers on,
   // reaching 0 turns them off (the M toggle keeps working independently).
   function adjustGap(delta: number) {
@@ -366,6 +374,7 @@
 
   function handleWheel(e: WheelEvent) {
     if (!scrollContainer) return;
+    const fine = wheelStream.classify(e);
     if (wheelIntentIsGapAdjust(e)) {
       e.preventDefault();
       adjustGap(gapWheelSteps(e, gapAccumulator));
@@ -373,10 +382,10 @@
     }
     const modifier = e.ctrlKey || e.metaKey;
 
-    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior)) {
+    if (wheelIntentIsZoom(modifier, $settings.swapWheelBehavior, fine)) {
       e.preventDefault();
       motion.beforeZoom();
-      zoomController.wheelZoom(e);
+      zoomController.wheelZoom(e, fine);
       return;
     }
 

--- a/src/lib/reader/zoom-controller.test.ts
+++ b/src/lib/reader/zoom-controller.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { ContinuousZoomController } from './zoom-controller';
-import type { RectLike } from './zoom-math';
+import { ContinuousZoomController, WHEEL_ZOOM_SETTLE_MS } from './zoom-controller';
+import { WHEEL_ZOOM_SENSITIVITY, type RectLike } from './zoom-math';
 
 /**
  * Fake layout world simulating the browser geometry the controller corrects
@@ -321,6 +321,164 @@ describe('ContinuousZoomController — wheel', () => {
     c.wheelZoom({ deltaY: -120, deltaMode: 0, clientX: 500, clientY: 400, timeStamp: 2000 });
     pump();
     expect(c.currentZoom).toBe(3);
+  });
+});
+
+/**
+ * The trackpad path (#259): a fine wheel stream zooms continuously at the
+ * cursor instead of stepping the ladder. Only setTimeout is faked — the
+ * suite's rAF pump and performance.now stubs drive the Animator.
+ */
+describe('ContinuousZoomController — fine wheel (trackpad)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const fineWheel = (deltaY: number, timeStamp: number, x = 500, y = 400) => ({
+    deltaY,
+    deltaMode: 0,
+    clientX: x,
+    clientY: y,
+    timeStamp
+  });
+
+  it('zooms immediately by the event ratio, anchored at the cursor', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+
+    const expected = Math.exp(20 * WHEEL_ZOOM_SENSITIVITY);
+    expect(c.currentZoom).toBeCloseTo(expected, 10);
+    expect(world.zoom).toBeCloseTo(expected, 10);
+    // Content under the cursor (500, 400) → content (500, 700) stays there.
+    expect(world.scrollLeft).toBeCloseTo(500 * expected - 500, 3);
+    expect(world.scrollTop).toBeCloseTo(700 * expected - 400, 3);
+  });
+
+  it('compounds across the stream instead of snapping to a level', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+    c.wheelZoom(fineWheel(-20, 1016), true);
+
+    expect(c.currentZoom).toBeCloseTo(Math.exp(40 * WHEEL_ZOOM_SENSITIVITY), 10);
+  });
+
+  it('scrolling back down undoes the zoom exactly', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-37, 1000), true);
+    c.wheelZoom(fineWheel(37, 1016), true);
+
+    expect(c.currentZoom).toBeCloseTo(1, 10);
+    expect(world.scrollTop).toBeCloseTo(300, 3);
+  });
+
+  it('clamps to the ladder ends', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-4000, 1000), true);
+    expect(c.currentZoom).toBe(3);
+
+    c.wheelZoom(fineWheel(4000, 1016), true);
+    expect(c.currentZoom).toBe(1);
+  });
+
+  it('stays active through the stream, then settles once when it goes idle', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+    c.wheelZoom(fineWheel(-20, 1016), true);
+    expect(c.isActive).toBe(true);
+    expect(settled).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(WHEEL_ZOOM_SETTLE_MS);
+
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(settled).toHaveBeenCalledWith(c.currentZoom, 'gesture');
+    expect(c.zoomTarget).toBe(c.currentZoom);
+    expect(c.isActive).toBe(false);
+  });
+
+  it('an interrupting gesture settles the stream once, not twice', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+    c.finishNow();
+
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(settled).toHaveBeenCalledWith(c.currentZoom, 'interrupt');
+
+    vi.advanceTimersByTime(WHEEL_ZOOM_SETTLE_MS * 2);
+    expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  it('a following notch steps to the adjacent level from the off-level zoom', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-20, 1000), true); // ~1.105
+    vi.advanceTimersByTime(WHEEL_ZOOM_SETTLE_MS);
+
+    c.wheelZoom(fineWheel(-120, 2000), false);
+    pump();
+    expect(c.currentZoom).toBe(1.5);
+  });
+
+  it('reports the zoomed state as the stream moves', () => {
+    const world = tallPageWorld();
+    const zoomed = vi.fn();
+    const c = makeController(world, { zoomed });
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+    expect(zoomed).toHaveBeenLastCalledWith(true);
+
+    c.wheelZoom(fineWheel(20, 1016), true);
+    expect(zoomed).toHaveBeenLastCalledWith(false);
+  });
+
+  it('re-anchors when the cursor moves mid-stream', () => {
+    const world = tallPageWorld();
+    const c = makeController(world);
+
+    c.wheelZoom(fineWheel(-20, 1000, 500, 400), true);
+
+    // Content sitting under the cursor's NEW position, before the next event.
+    const before = c.currentZoom;
+    const content = {
+      x: (world.scrollLeft + 200) / before,
+      y: (world.scrollTop + 600) / before
+    };
+
+    c.wheelZoom(fineWheel(-20, 1016, 200, 600), true);
+
+    const after = c.currentZoom;
+    expect(content.x * after - world.scrollLeft).toBeCloseTo(200, 3);
+    expect(content.y * after - world.scrollTop).toBeCloseTo(600, 3);
+  });
+
+  it('a stalled stream that leaves the timer pending is cleaned up by destroy', () => {
+    const world = tallPageWorld();
+    const settled = vi.fn();
+    const c = makeController(world, { settled });
+
+    c.wheelZoom(fineWheel(-20, 1000), true);
+    c.destroy();
+
+    vi.advanceTimersByTime(WHEEL_ZOOM_SETTLE_MS * 2);
+    expect(settled).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/reader/zoom-controller.ts
+++ b/src/lib/reader/zoom-controller.ts
@@ -26,6 +26,7 @@ import {
   pinchDistance,
   pinchMidpoint,
   WheelAccumulator,
+  wheelZoomRatio,
   zoomProgress,
   type Point,
   type RectLike
@@ -39,6 +40,13 @@ const SNAP_TO_ONE_BELOW = 1.05;
 const DOUBLE_TAP_ZOOM = 2;
 
 const CONTINUOUS_ZOOM_LEVELS: readonly number[] = [1, 1.5, 2, 3];
+
+/**
+ * Idle gap (ms) that ends a continuous wheel-zoom stream. Wheels have no
+ * release event, so the settle — which clamps the paged camera into bounds
+ * and reports reading progress — has to be timed out.
+ */
+export const WHEEL_ZOOM_SETTLE_MS = 250;
 
 /** Structural subset of HTMLElement the controller scrolls. */
 export interface ZoomContainer {
@@ -161,6 +169,9 @@ export class ContinuousZoomController {
   private anchorFy = 0;
 
   private pinching = false;
+  private wheelZooming = false;
+  private wheelSettleTimer: ReturnType<typeof setTimeout> | null = null;
+  private wheelAnchor: Point | null = null;
   private pinchStartDist = 0;
   private pinchStartZoom = 1;
   private gestureBaseZoom = 1;
@@ -189,7 +200,7 @@ export class ContinuousZoomController {
   }
 
   get isActive(): boolean {
-    return this.pinching || this.animator.isAnimating;
+    return this.pinching || this.wheelZooming || this.animator.isAnimating;
   }
 
   /** True when the view is visibly zoomed in. */
@@ -201,9 +212,22 @@ export class ContinuousZoomController {
   // Gestures
   // ============================================================
 
-  /** Wheel event already classified as zoom intent by the caller. */
-  wheelZoom(e: ZoomWheelEventLike): void {
-    const steps = this.wheelAcc.add(normalizeWheelDelta(e.deltaY, e.deltaMode), e.timeStamp);
+  /**
+   * Wheel event already classified as zoom intent by the caller.
+   *
+   * `fine` marks a trackpad-grade stream (WheelStreamClassifier): those zoom
+   * continuously at the cursor, because a device reporting every millimetre
+   * of travel through a ladder of discrete levels is the #259 complaint —
+   * nothing, nothing, nothing, lurch. Notched wheels keep the ladder, where
+   * one notch is one deliberate step.
+   */
+  wheelZoom(e: ZoomWheelEventLike, fine = false): void {
+    const deltaPx = normalizeWheelDelta(e.deltaY, e.deltaMode);
+    if (fine) {
+      this.continuousWheelZoom(deltaPx, { x: e.clientX, y: e.clientY });
+      return;
+    }
+    const steps = this.wheelAcc.add(deltaPx, e.timeStamp);
     if (steps === 0) return;
     const direction = steps > 0 ? 1 : -1;
     let next = this.target;
@@ -211,6 +235,53 @@ export class ContinuousZoomController {
       next = nextZoomLevel(this.levels, next, direction);
     }
     this.stepTo(next, { x: e.clientX, y: e.clientY });
+  }
+
+  /**
+   * One event of a fine wheel stream: multiply the live zoom and pin the
+   * content under the cursor, exactly as a pinch move does.
+   *
+   * The anchor is re-captured only when the cursor moves. A wheel stream
+   * usually holds still, and capture measures every page element.
+   */
+  private continuousWheelZoom(deltaPx: number, cursor: Point): void {
+    if (deltaPx === 0) return;
+    if (!this.wheelZooming) {
+      // A level animation still converging would fight the stream's own
+      // frame writes; land it before taking over.
+      if (this.animator.isAnimating) this.finishNow();
+      this.wheelZooming = true;
+      this.wheelAnchor = null;
+    }
+    if (!this.wheelAnchor || this.wheelAnchor.x !== cursor.x || this.wheelAnchor.y !== cursor.y) {
+      if (!this.captureAnchor(cursor.x, cursor.y)) return;
+      this.wheelAnchor = cursor;
+    }
+    this.startZoom = this.animator.current;
+    this.applyPinchZoom(this.animator.current * wheelZoomRatio(deltaPx), cursor);
+    this.scheduleWheelSettle();
+  }
+
+  private scheduleWheelSettle(): void {
+    if (this.wheelSettleTimer !== null) clearTimeout(this.wheelSettleTimer);
+    this.wheelSettleTimer = setTimeout(() => {
+      this.wheelSettleTimer = null;
+      this.endWheelStream();
+      this.settle('gesture');
+    }, WHEEL_ZOOM_SETTLE_MS);
+  }
+
+  /** Drop the stream's bookkeeping without settling. */
+  private endWheelStream(): void {
+    if (this.wheelSettleTimer !== null) {
+      clearTimeout(this.wheelSettleTimer);
+      this.wheelSettleTimer = null;
+    }
+    this.wheelZooming = false;
+    this.wheelAnchor = null;
+    // Leave the zoom where the gesture left it; the target follows so the
+    // next notch steps from here, the same way pinchEnd hands off.
+    this.target = this.animator.current;
   }
 
   /**
@@ -265,7 +336,7 @@ export class ContinuousZoomController {
    * re-baselines distance/zoom/anchor so the gesture stays continuous.
    */
   pinchStart(points: readonly Point[]): void {
-    if (!this.pinching && this.animator.isAnimating) this.finishNow();
+    if (!this.pinching && this.isActive) this.finishNow();
     const mid = pinchMidpoint(points);
     if (!this.captureAnchor(mid.x, mid.y)) return;
     this.pinching = true;
@@ -300,7 +371,7 @@ export class ContinuousZoomController {
 
   // Safari desktop trackpad pinch (proprietary gesture events).
   gestureStart(x: number, y: number): void {
-    if (!this.pinching && this.animator.isAnimating) this.finishNow();
+    if (!this.pinching && this.isActive) this.finishNow();
     if (!this.captureAnchor(x, y)) return;
     this.pinching = true;
     this.pinchStartDist = 0; // pointer-pair distance unused for gesture events
@@ -348,6 +419,11 @@ export class ContinuousZoomController {
       this.settle(reason);
       return;
     }
+    if (this.wheelZooming) {
+      this.endWheelStream();
+      this.settle(reason);
+      return;
+    }
     if (this.animator.isAnimating) {
       this.animator.snapTo(this.target);
       this.settle(reason);
@@ -356,7 +432,7 @@ export class ContinuousZoomController {
 
   /** Instantly return to 1× (zoom-mode change, viewport resize). */
   reset(): void {
-    if (this.animator.current === 1 && !this.animator.isAnimating && !this.pinching) {
+    if (this.animator.current === 1 && !this.isActive) {
       this.target = 1;
       return;
     }
@@ -371,6 +447,7 @@ export class ContinuousZoomController {
    */
   snapToLevel(level: number): void {
     this.pinching = false;
+    this.endWheelStream();
     this.target = level;
     this.anchorEl = null; // skip anchor correction; layout placement only
     this.animator.snapTo(level);
@@ -378,6 +455,7 @@ export class ContinuousZoomController {
   }
 
   destroy(): void {
+    this.endWheelStream();
     this.animator.destroy();
   }
 

--- a/src/lib/reader/zoom-math.test.ts
+++ b/src/lib/reader/zoom-math.test.ts
@@ -13,7 +13,11 @@ import {
   normalizeWheelDelta,
   WheelAccumulator,
   pinchDistance,
-  pinchMidpoint
+  pinchMidpoint,
+  isFineWheelEvent,
+  WheelStreamClassifier,
+  wheelZoomRatio,
+  WHEEL_ZOOM_SENSITIVITY
 } from './zoom-math';
 
 describe('anchorFraction', () => {
@@ -151,6 +155,16 @@ describe('wheelIntentIsZoom', () => {
     expect(wheelIntentIsZoom(false, true)).toBe(true);
     expect(wheelIntentIsZoom(true, true)).toBe(false);
   });
+
+  it('treats a fine ctrl+wheel as a trackpad pinch, whatever the swap setting', () => {
+    expect(wheelIntentIsZoom(true, true, true)).toBe(true);
+    expect(wheelIntentIsZoom(true, false, true)).toBe(true);
+  });
+
+  it('leaves a fine bare wheel to the swap setting', () => {
+    expect(wheelIntentIsZoom(false, true, true)).toBe(true);
+    expect(wheelIntentIsZoom(false, false, true)).toBe(false);
+  });
 });
 
 describe('normalizeWheelDelta', () => {
@@ -279,5 +293,80 @@ describe('gapWheelSteps', () => {
     const acc = new WheelAccumulator(GAP_WHEEL_STEP_SIZE);
     const px = gapWheelSteps({ deltaX: 0, deltaY: -3, deltaMode: 1, timeStamp: 1000 }, acc);
     expect(px).toBe(6); // 3 lines * 40px = 120 wheel px -> six 20px steps
+  });
+});
+
+describe('isFineWheelEvent', () => {
+  const ev = (deltaY: number, deltaX = 0, deltaMode = 0) => ({ deltaX, deltaY, deltaMode });
+
+  it('rejects classic notches', () => {
+    expect(isFineWheelEvent(ev(-100))).toBe(false);
+    expect(isFineWheelEvent(ev(120))).toBe(false);
+  });
+
+  it('rejects line and page deltas — only a notched wheel reports them', () => {
+    expect(isFineWheelEvent(ev(-3, 0, 1))).toBe(false);
+    expect(isFineWheelEvent(ev(-1, 0, 2))).toBe(false);
+  });
+
+  it('accepts fractional deltas', () => {
+    expect(isFineWheelEvent(ev(-4.5))).toBe(true);
+    expect(isFineWheelEvent(ev(-133.75))).toBe(true);
+  });
+
+  it('accepts sub-notch magnitudes', () => {
+    expect(isFineWheelEvent(ev(-8))).toBe(true);
+    expect(isFineWheelEvent(ev(2))).toBe(true);
+  });
+
+  it('accepts simultaneous two-axis deltas — no mouse steers both at once', () => {
+    expect(isFineWheelEvent(ev(-110, 3))).toBe(true);
+  });
+
+  it('reads no evidence from an empty delta', () => {
+    expect(isFineWheelEvent(ev(0))).toBe(false);
+  });
+});
+
+describe('WheelStreamClassifier', () => {
+  it('stays coarse for a notched-wheel stream', () => {
+    const c = new WheelStreamClassifier();
+    expect(c.classify({ deltaX: 0, deltaY: -100, deltaMode: 0, timeStamp: 1000 })).toBe(false);
+    expect(c.classify({ deltaX: 0, deltaY: -100, deltaMode: 0, timeStamp: 1050 })).toBe(false);
+  });
+
+  it('holds the fine verdict through momentum spikes later in the stream', () => {
+    const c = new WheelStreamClassifier();
+    expect(c.classify({ deltaX: 0, deltaY: -3, deltaMode: 0, timeStamp: 1000 })).toBe(true);
+    // macOS momentum turns a flick into large round deltas mid-gesture.
+    expect(c.classify({ deltaX: 0, deltaY: -240, deltaMode: 0, timeStamp: 1016 })).toBe(true);
+  });
+
+  it('re-classifies after the stream goes idle', () => {
+    const c = new WheelStreamClassifier();
+    c.classify({ deltaX: 0, deltaY: -3, deltaMode: 0, timeStamp: 1000 });
+    expect(c.classify({ deltaX: 0, deltaY: -120, deltaMode: 0, timeStamp: 2000 })).toBe(false);
+  });
+});
+
+describe('wheelZoomRatio', () => {
+  it('zooms in on wheel-up and out on wheel-down', () => {
+    expect(wheelZoomRatio(-100)).toBeGreaterThan(1);
+    expect(wheelZoomRatio(100)).toBeLessThan(1);
+    expect(wheelZoomRatio(0)).toBe(1);
+  });
+
+  it('is exponential, so a split gesture equals the whole one', () => {
+    const whole = wheelZoomRatio(-90);
+    const split = wheelZoomRatio(-30) * wheelZoomRatio(-60);
+    expect(split).toBeCloseTo(whole, 10);
+  });
+
+  it('is symmetric — scrolling back undoes the zoom exactly', () => {
+    expect(wheelZoomRatio(-40) * wheelZoomRatio(40)).toBeCloseTo(1, 10);
+  });
+
+  it('moves immediately for a small nudge', () => {
+    expect(wheelZoomRatio(-10)).toBeCloseTo(Math.exp(10 * WHEEL_ZOOM_SENSITIVITY), 10);
   });
 });

--- a/src/lib/reader/zoom-math.ts
+++ b/src/lib/reader/zoom-math.ts
@@ -107,8 +107,21 @@ export function nextZoomLevel(levels: readonly number[], zoom: number, direction
  * Whether a wheel event means zoom, matching paged-mode semantics:
  * ctrl/meta+wheel zooms by default; swapWheelBehavior inverts so bare wheel
  * zooms and ctrl/meta+wheel scrolls.
+ *
+ * `fine` (a trackpad stream — see WheelStreamClassifier) overrides the swap
+ * for ctrl/meta: Chrome and Firefox deliver a trackpad PINCH as a synthetic
+ * ctrl+wheel, and a pinch means zoom on every surface regardless of what the
+ * user chose for their mouse wheel. Only Safari has real pinch events
+ * (gesturestart/change/end — see pointer-tracker.ts), so without this a
+ * Mac user with the swap on has no working pinch at all (#259). A coarse
+ * ctrl+wheel is a genuine keyboard chord and keeps the swap semantics.
  */
-export function wheelIntentIsZoom(ctrlOrMeta: boolean, swapWheelBehavior: boolean): boolean {
+export function wheelIntentIsZoom(
+  ctrlOrMeta: boolean,
+  swapWheelBehavior: boolean,
+  fine = false
+): boolean {
+  if (fine && ctrlOrMeta) return true;
   return swapWheelBehavior ? !ctrlOrMeta : ctrlOrMeta;
 }
 
@@ -180,6 +193,80 @@ export class WheelAccumulator {
     this.acc -= steps * this.stepSize;
     return steps === 0 ? 0 : -steps;
   }
+}
+
+/**
+ * Largest per-event delta (px) that still reads as fine-grained. A notched
+ * wheel reports a whole notch at once — 100 in Chromium, 120 on Windows,
+ * ~102 for Firefox's pixel mode — so anything well below that came from a
+ * device reporting continuous travel.
+ */
+export const FINE_WHEEL_MAX_DELTA = 50;
+
+/** Idle gap (ms) that ends a wheel stream for classification purposes. */
+export const WHEEL_STREAM_IDLE_MS = 250;
+
+/**
+ * Whether one wheel event carries positive evidence of a fine-grained
+ * (trackpad, precision wheel, synthetic pinch) source rather than a notched
+ * mouse wheel. Absence of evidence is not evidence of a mouse — see
+ * WheelStreamClassifier, which is what callers should use.
+ */
+export function isFineWheelEvent(e: Pick<WheelEvent, 'deltaX' | 'deltaY' | 'deltaMode'>): boolean {
+  // Line and page deltas are a notched wheel by construction: a precision
+  // device has sub-line travel to report and never picks those units.
+  if (e.deltaMode !== 0) return false;
+  const { deltaX, deltaY } = e;
+  if (!Number.isInteger(deltaX) || !Number.isInteger(deltaY)) return true;
+  // No mouse drives both axes at once; a trackpad barely avoids it.
+  if (deltaX !== 0 && deltaY !== 0) return true;
+  const magnitude = Math.max(Math.abs(deltaX), Math.abs(deltaY));
+  return magnitude > 0 && magnitude < FINE_WHEEL_MAX_DELTA;
+}
+
+/**
+ * Classifies a wheel STREAM as fine-grained or notched, sticky until the
+ * stream goes idle.
+ *
+ * Sticky because the evidence is one-sided. A trackpad flick starts with
+ * small deltas and then hands off to momentum, which reports large round
+ * numbers indistinguishable from notches; a mouse never reports the small
+ * ones. So evidence only ever upgrades a stream to fine, and the verdict
+ * holds for the rest of the gesture.
+ *
+ * Erring toward fine is the safe direction: a precision wheel misread as a
+ * trackpad gets smooth zoom, which is what its owner wanted anyway. The
+ * reverse is the #259 bug.
+ */
+export class WheelStreamClassifier {
+  private fine = false;
+  private lastTime = -Infinity;
+
+  constructor(private idleResetMs = WHEEL_STREAM_IDLE_MS) {}
+
+  classify(e: Pick<WheelEvent, 'deltaX' | 'deltaY' | 'deltaMode' | 'timeStamp'>): boolean {
+    if (e.timeStamp - this.lastTime > this.idleResetMs) this.fine = false;
+    this.lastTime = e.timeStamp;
+    if (!this.fine && isFineWheelEvent(e)) this.fine = true;
+    return this.fine;
+  }
+}
+
+/**
+ * Zoom ratio per pixel of fine wheel travel. 100px of travel is ~1.65x,
+ * a shade faster than the level ladder's ~1.4x per notch — a trackpad user
+ * asks for the same zoom range with less finger travel (#259).
+ */
+export const WHEEL_ZOOM_SENSITIVITY = 0.005;
+
+/**
+ * Continuous zoom multiplier for one fine wheel event: scale-invariant
+ * (exponential), so the same finger travel covers the same ratio at any
+ * zoom, splitting a gesture across events changes nothing, and scrolling
+ * back lands exactly where it started.
+ */
+export function wheelZoomRatio(deltaPx: number, sensitivity = WHEEL_ZOOM_SENSITIVITY): number {
+  return Math.exp(-deltaPx * sensitivity);
 }
 
 /** Distance between the first two points; 0 when fewer than two. */


### PR DESCRIPTION
Closes #259.

## The problem

Two defects, both in the wheel path.

**1. Wheel zoom only stepped a discrete ladder.** `WheelAccumulator` swallows deltas until 100px accumulate, then jumps a whole rung (1 → 1.5). On a trackpad that reads as nothing, nothing, nothing, lurch — the "large or unpredictable steps" and "exaggerated gestures" in the report.

**2. Chrome and Firefox deliver a trackpad pinch as a synthetic `ctrl+wheel`.** Only Safari has real pinch events (`gesturestart/change/end`, already handled in `pointer-tracker.ts`). With **Swap mouse wheel scroll/zoom** on — the reporter's exact setup — `wheelIntentIsZoom(ctrl, swap)` routed that to *scroll*, so they had no working pinch at all.

## The fix

`WheelStreamClassifier` tags each wheel *stream* fine-grained (trackpad, precision wheel, synthetic pinch) or notched. Fine streams zoom continuously at the cursor through the same anchored path a pinch uses; notched wheels keep the level ladder untouched. A fine `ctrl+wheel` always zooms regardless of the swap setting; a notched one is a genuine keyboard chord and keeps today's semantics.

Classification is sticky per stream and only ever upgrades to fine: trackpad momentum reports large round deltas a mouse also reports, while a mouse never reports the small ones. Erring toward fine costs a hi-res-wheel owner a smooth zoom — which is what #200 asked for anyway; erring the other way is the bug.

Wheel has no release event, so a fine stream settles on a 250 ms idle timer. That settle is load-bearing: it clamps the paged camera into bounds and reports reading progress.

Applies to all three surfaces (paged, vertical scroll, horizontal scroll).

## Verification

Measured in real Chrome (Playwright, synthetic volume imported through the actual UI), page scale before vs. after:

| Scenario | Pre-fix | Post-fix |
| --- | --- | --- |
| Trackpad scroll-as-zoom, swap ON | 6 × −8px → **0.45 → 0.45** (nothing) | 0.45 → 0.468 → 0.487 → … ×1.0408/event |
| Trackpad **pinch** (ctrl+fine), swap ON | **0.45 → 0.45** (pinch dead) | identical smooth zoom |
| Notched ctrl+wheel, swap OFF | 0.45 → 0.675 → 0.9 | **unchanged** (ladder levels 1.5, 2) |
| Cursor anchoring | — | content under (640,450) still at exactly (640,450) after 0.45 → 0.620 |
| Bare trackpad scroll, swap OFF (default) | no zoom | **unchanged** — still pans |
| Notched ctrl+wheel, swap ON | no zoom | **unchanged** — still scrolls |

Also confirmed in the continuous vertical-scroll reader, and by the author in the running app.

2905/2905 unit tests pass (33 new), `svelte-check` 0 errors / 0 warnings, production build clean.

## Notes

- **Hi-res mouse wheels change behavior too.** Chrome's high-resolution scrolling (Logitech MX and friends) emits fractional deltas, so those now zoom smoothly rather than stepping. That is #200's request, but it reaches past #259's literal scope — easy to gate if that is not wanted.
- No changelog entry or version bump: v1.9.0 is already tagged, so this belongs to the next batch.
- `docs/INPUT-CONTRACTS.md` gained a contract section for the granularity rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)