### PR TITLE
feat: unified cover requests and sync-time metadata resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,6 +471,17 @@ must not break. Highlights:
 - Each surface owns its gestures via `PointerGestureTracker` config; Reader owns only keyboard + intent callbacks
 - Before starting any motion, handlers call their surface's `MotionGate` intent method instead of ad-hoc `finishNow()`/`stop()` combinations
 
+### Cloud covers
+
+`requestCover(vol)` (`src/lib/catalog/cover-service.ts`) is the only way anything obtains a
+cloud cover: surfaces through `createCoverClaims`, the series-open pass through
+`installCoversForSeries` (a candidate builder), the backfill's stale refresh with
+`{ refresh: true }`. Its ladder: fresh row thumbnail → cached in `cloud_covers` (PROMOTED
+onto the row when the volume is metadata-only AND read, `coverBelongsOnRow`) → fetch. The
+write queue (`cover-persist.ts`) routes by the same predicate. Never fetch or write a cover
+from anywhere else. Synced-progress rows are minted after every progress sync
+(`resolveSyncedProgress`), never from a view mount.
+
 ### Modal Button Z-Index
 
 **Always add `relative z-10` to action button containers in modals.**

--- a/docs/superpowers/plans/2026-09-02-unified-cover-requests.md
+++ b/docs/superpowers/plans/2026-09-02-unified-cover-requests.md
@@ -1,0 +1,1303 @@
+# Unified Cover Requests + Sync-Time Metadata Resolution — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `requestCover` the one entry point every cover installer goes through — promoting cached covers onto rows the user has read — and run synced-progress metadata resolution once after every progress sync instead of from view mounts, then refit the progress tracker onto both.
+
+**Architecture:** Part A rewrites `cover-service.ts`'s `resolveAndDeliver` into a five-step ladder (skip → cached/promote → row → indexed placeholder → bare placeholder) with an outcome-recording dedupe ledger, and turns `cover-install.ts` and the backfill's stale refresh into candidate builders over it. Part B retains the series-index refresh promise on `unifiedCloudManager`, adds `resolveSyncedProgress()` in `hole-patch.ts` (awaits that promise, then the uncapped enrich→sweep→enrich), and starts it from `syncProgress()` via a dynamic import. Part C (on `feat/progress-tracker`) moves the tracker card onto `createCoverClaims`.
+
+**Tech Stack:** SvelteKit 5 (runes), Dexie 4 over IndexedDB, Vitest + fake-indexeddb, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-unified-cover-requests-design.md`
+
+## Global Constraints
+
+- Never write the string `mokuro.moe` anywhere (code, comments, commits, docs).
+- No Dexie schema version bump: the new `CloudCover` fields are non-indexed.
+- `cloudPath` and the `cloudThumbnail*` fields stay listing decorations on in-memory copies; never persist them on a `volumes` row.
+- Every path stays best-effort: nothing in parts A or B may reject into a view, a sync result, or a store subscriber.
+- `perf-contracts.test.ts` must stay green untouched (CONTRACTS 1–6).
+- Commit messages follow the repo's `type(scope): summary` style; each commit passes `lint-staged` (Prettier). Do not run `git stash`.
+- Parts A and B land on `feat/unified-cover-requests` (worktree `/home/nathan/Projects/mokuro-reader-worktrees/feat-unified-cover-requests`). Part C lands on `feat/progress-tracker` (worktree `.../feat-progress-tracker`) after merging the first branch in.
+- Run a single test file with `npx vitest run <path>`; the whole suite with `npx vitest run`; types with `npm run check`.
+
+---
+
+## File map
+
+Part A (branch `feat/unified-cover-requests`):
+
+- Modify `src/lib/settings/reading-activity.ts` — no change (imported as-is).
+- Modify `src/lib/catalog/cloud-covers.ts` — `CloudCover.cover_size?`/`cover_modified?`.
+- Modify `src/lib/catalog/cover-persist.ts` — export `coverBelongsOnRow`; write stamps on cache rows.
+- Modify `src/lib/catalog/cover-service.ts` — `CoverOutcome`, options object, ledger `Map`, promotion step, return values.
+- Modify `src/lib/catalog/cover-claims.svelte.ts` — `requestCover(vol, { stillNear })`.
+- Modify `src/lib/catalog/cover-install.ts` — candidate builder over `requestCover`.
+- Modify `src/lib/metadata/series-backfill.ts` — `refreshStaleCover` over `requestCover`.
+- Tests: `cover-persist.test.ts`, `cover-service.test.ts` (+ new `cover-service.promote.test.ts`), `cover-install.test.ts`, `series-backfill.test.ts`, `cover-claims.test.ts`.
+
+Part B (same branch):
+
+- Modify `src/lib/util/sync/unified-cloud-manager.ts` — retain index-refresh promise; `whenSeriesIndexesSettled()`; `progressResolution`; start resolution in `syncProgress`.
+- Modify `src/lib/metadata/hole-patch.ts` — `resolveSyncedProgress`; remove caps, memo, `patchProgressHolesWhenListingReady`.
+- Modify `src/lib/metadata/history-rows.ts` — remove the two caps.
+- Modify `src/lib/util/sync/init-providers.ts`, `src/lib/views/CatalogView.svelte`, `src/lib/views/ReadingSpeedView.svelte`.
+- Tests: `hole-patch.test.ts`, `history-rows.test.ts`, `unified-cloud-manager.test.ts` (new describe).
+
+Part C (branch `feat/progress-tracker`):
+
+- Modify `src/lib/components/VolumeCard.svelte`, `src/lib/views/ProgressTrackerView.svelte`.
+- Delete `docs/superpowers/plans/2026-08-31-metadata-resolution-trigger.md`.
+- Tests: new `src/lib/components/__tests__/VolumeCard.covers.test.ts`; e2e `e2e/progress-tracker.spec.ts` re-run.
+
+---
+
+## Part A — Unified cover requests
+
+### Task A1: `coverBelongsOnRow` predicate + stamps on cache rows
+
+**Files:**
+
+- Modify: `src/lib/catalog/cloud-covers.ts:22-40` (the `CloudCover` interface)
+- Modify: `src/lib/catalog/cover-persist.ts:608-716` (`flushOneBatch`) and add the export
+- Test: `src/lib/catalog/cover-persist.test.ts`
+
+**Interfaces:**
+
+- Produces: `export function coverBelongsOnRow(row: VolumeMetadata | undefined, history: ReadingHistoryEntry | undefined): boolean` in `cover-persist.ts`; `CloudCover.cover_size?: number; cover_modified?: number`.
+
+- [ ] **Step 1: Write the failing tests** (append to `cover-persist.test.ts`; follow its existing harness — real Dexie via `CatalogDexieV3`, hand-rolled `volumes` store mock, `_getCloudCoversForTests`):
+
+```ts
+import { coverBelongsOnRow } from './cover-persist';
+
+describe('coverBelongsOnRow', () => {
+  const base = {
+    volume_uuid: 'u',
+    series_uuid: 's',
+    series_title: 'S',
+    volume_title: 'V',
+    mokuro_version: '0.4.11',
+    page_count: 1,
+    character_count: 1,
+    page_char_counts: []
+  } as VolumeMetadata;
+
+  it('is false with no row at all', () => {
+    expect(coverBelongsOnRow(undefined, { progress: 3 })).toBe(false);
+  });
+  it('is false for an installed row — its cover comes from its own pages', () => {
+    expect(coverBelongsOnRow(base, { progress: 3 })).toBe(false);
+  });
+  it('is false for a metadata-only row with no reading activity', () => {
+    expect(coverBelongsOnRow({ ...base, metadata_only: true }, undefined)).toBe(false);
+    expect(coverBelongsOnRow({ ...base, metadata_only: true }, { progress: 0 })).toBe(false);
+  });
+  it('is true for a metadata-only row the user has read', () => {
+    expect(coverBelongsOnRow({ ...base, metadata_only: true }, { completed: true })).toBe(true);
+  });
+});
+
+describe('cache rows carry the cover stamp', () => {
+  it('writes cover_size/cover_modified on the cloud_covers row', async () => {
+    // no row → routed to the cache; scope from the mocked provider
+    installCover(
+      { volume_uuid: 'no-row', cloudPath: 'S/V.cbz' },
+      { file: new File(['x'], 'V.webp'), width: 1, height: 2 },
+      { size: 321, modifiedTime: '2026-01-02T00:00:00.000Z' }
+    );
+    await flushPendingCoverPersists();
+    const cached = await _getCloudCoversForTests('<scope used by this file>', ['S/V.cbz']);
+    expect(cached.get('S/V.cbz')).toMatchObject({
+      cover_size: 321,
+      cover_modified: Math.floor(Date.parse('2026-01-02T00:00:00.000Z') / 1000)
+    });
+  });
+});
+```
+
+(Read the existing file's `beforeEach` to copy the exact scope string its provider mock reports.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/lib/catalog/cover-persist.test.ts`
+Expected: FAIL — `coverBelongsOnRow` is not exported; `cover_size` undefined on the cache row.
+
+- [ ] **Step 3: Implement**
+
+In `cloud-covers.ts`, extend the interface (after `height`):
+
+```ts
+  /**
+   * The listing stamp of the cover sidecar this blob was fetched from —
+   * bytes + epoch seconds, the same two fields with the same guards as
+   * `VolumeMetadata.cover_size`/`cover_modified`. Written by
+   * `cover-persist.ts` at flush; read by `cover-service.ts` when it PROMOTES
+   * a cached cover onto a row the user has since read, so the row inherits
+   * the freshness the blob actually has rather than the listing's current
+   * one. Absent on rows cached before this existed, which the staleness rule
+   * treats as never-stale (the migration-safety inversion everywhere else).
+   */
+  cover_size?: number;
+  cover_modified?: number;
+```
+
+In `cover-persist.ts`, add the predicate (above `installCover`) and use it in `flushOneBatch`:
+
+```ts
+/**
+ * Does a cloud cover for this volume belong ON ITS `volumes` ROW?
+ *
+ * Yes exactly when the row exists, its pages are not on this device
+ * (`needsDownload` — an installed volume's thumbnail was measured from its
+ * own pages and is never replaced by a cloud guess) and the user has actually
+ * read it (`hasReadingActivity`). Everything else — no row, a row minted
+ * purely by browsing — is catalog knowledge and belongs in `cloud_covers`.
+ *
+ * ONE definition, consulted at REQUEST time (`cover-service.ts`, to decide
+ * whether a cached cover should be promoted and what outcome to report) and
+ * at FLUSH time (below, against the row re-read inside the write
+ * transaction). Two copies of this rule would let the service promise a row
+ * the queue then refuses.
+ */
+export function coverBelongsOnRow(
+  row: VolumeMetadata | undefined,
+  history: ReadingHistoryEntry | undefined
+): boolean {
+  if (!row) return false;
+  if (!needsDownload(row)) return false;
+  return hasReadingActivity(history);
+}
+```
+
+In `flushOneBatch`, replace the `hasRelationship` block with:
+
+```ts
+        if (fresh && coverBelongsOnRow(fresh, readingHistory[volumeUuid])) {
+          if (mode === 'fill' && fresh.thumbnail) continue;
+          ... (unchanged patch + update)
+          continue;
+        }
+```
+
+and in the cache branch add the stamp fields:
+
+```ts
+forCoverTable.push({
+  account_scope: scope,
+  path: cachePath,
+  thumbnail: result.file,
+  width: result.width,
+  height: result.height,
+  cached_at: Date.now(),
+  ...(coverSize !== undefined ? { cover_size: coverSize } : {}),
+  ...(coverModified !== undefined ? { cover_modified: coverModified } : {})
+});
+```
+
+Remove the now-unused `isVolumeInstalled` import if nothing else uses it.
+
+- [ ] **Step 4: Run the file and the perf contracts**
+
+Run: `npx vitest run src/lib/catalog/cover-persist.test.ts src/lib/catalog/__tests__/perf-contracts.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/catalog/cloud-covers.ts src/lib/catalog/cover-persist.ts src/lib/catalog/cover-persist.test.ts
+git commit -m "feat(covers): name the row-vs-cache routing rule, stamp cache rows"
+```
+
+### Task A2: `requestCover` — options object, outcomes, outcome-recording ledger
+
+**Files:**
+
+- Modify: `src/lib/catalog/cover-service.ts:165-232` (ledger), `:604-777` (`resolveAndDeliver`, `requestCover`)
+- Modify: `src/lib/catalog/cover-claims.svelte.ts:296-300` (the request effect)
+- Test: `src/lib/catalog/cover-service.test.ts` (adjust the dedupe describe), `src/lib/catalog/cover-claims.test.ts` (probe assertion shape)
+
+**Interfaces:**
+
+- Produces:
+  ```ts
+  export type CoverOutcome = 'row' | 'cache' | 'none' | 'skipped' | 'unresolved';
+  export interface RequestCoverOptions {
+    stillNear?: () => boolean;
+    refresh?: boolean;
+  }
+  export function requestCover(
+    vol: VolumeMetadata,
+    options?: RequestCoverOptions
+  ): Promise<CoverOutcome>;
+  ```
+- Consumes: `coverBelongsOnRow` (A1).
+
+- [ ] **Step 1: Write the failing tests** — in `cover-service.test.ts`, replace the `dedupe` describe with:
+
+```ts
+describe('dedupe: the ledger records what was delivered, keyed by scope + uuid + listing stamp', () => {
+  it('two requests before settling share ONE fetch; a request after settling is skipped', async () => {
+    await db.volumes.put(row('u1'));
+    const vol = row('u1', {
+      cloudProvider: 'webdav',
+      cloudThumbnailFileId: 'c',
+      cloudPath: 'One Piece/Volume 01.cbz'
+    });
+    const [a, b] = await Promise.all([requestCover(vol), requestCover(vol)]);
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(1);
+    expect(a).toBe('row');
+    expect(b).toBe('row');
+    expect(await requestCover(vol)).toBe('skipped');
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a changed listing stamp is a fresh request, not a skip', async () => {
+    await db.volumes.put(row('u1'));
+    const vol = row('u1', {
+      cloudProvider: 'webdav',
+      cloudThumbnailFileId: 'c',
+      cloudPath: 'One Piece/Volume 01.cbz',
+      cloudThumbnailSize: 10,
+      cloudThumbnailModifiedTime: '2026-01-01T00:00:00.000Z'
+    });
+    expect(await requestCover(vol)).toBe('row');
+    await waitForCover('u1');
+    const thumbed = {
+      ...(await db.volumes.get('u1'))!,
+      ...vol,
+      cloudThumbnailSize: 11,
+      cloudThumbnailModifiedTime: '2026-02-01T00:00:00.000Z'
+    } as VolumeMetadata;
+    expect(await requestCover(thumbed)).toBe('row');
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("'unresolved' never writes the ledger: the next request retries", async () => {
+    fetchCloudThumbnailMock.mockResolvedValue(null);
+    await db.volumes.put(row('u1'));
+    const vol = row('u1', {
+      cloudProvider: 'webdav',
+      cloudThumbnailFileId: 'c',
+      cloudPath: 'One Piece/Volume 01.cbz'
+    });
+    vi.useFakeTimers();
+    const p = requestCover(vol);
+    await vi.advanceTimersByTimeAsync(11000);
+    expect(await p).toBe('unresolved');
+    vi.useRealTimers();
+    fetchCloudThumbnailMock.mockResolvedValue(coverResult());
+    expect(await requestCover(vol)).toBe('row');
+  });
+
+  it('refresh: true bypasses the ledger and fetches again with mode overwrite', async () => {
+    await db.volumes.put(row('u1'));
+    const vol = row('u1', {
+      cloudProvider: 'webdav',
+      cloudThumbnailFileId: 'c',
+      cloudPath: 'One Piece/Volume 01.cbz'
+    });
+    expect(await requestCover(vol)).toBe('row');
+    const withThumb = await waitForCover('u1');
+    const update = vi.spyOn(db.volumes, 'update');
+    expect(
+      await requestCover(
+        { ...withThumb, ...vol, thumbnail: withThumb.thumbnail },
+        { refresh: true }
+      )
+    ).toBe('row');
+    await flushPendingCoverPersists();
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(2);
+    expect(update).toHaveBeenCalled();
+    update.mockRestore();
+  });
+});
+```
+
+Adjust the retry suite (`cover-service.retry.test.ts`) expectations to the returned outcomes where it inspects behaviour (it should still pass with fire-and-forget usage; only add `expect(await p).toBe('unresolved')` where it awaits the schedule).
+
+In `cover-claims.test.ts`, the probe tests assert `requestCover` was called with `(vol, probe)`; change to `(vol, expect.objectContaining({ stillNear: expect.any(Function) }))` and read the probe from `mock.calls[0][1].stillNear`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/lib/catalog/cover-service.test.ts src/lib/catalog/cover-claims.test.ts`
+Expected: FAIL — `requestCover` returns `undefined`; second positional arg shape.
+
+- [ ] **Step 3: Implement** — in `cover-service.ts`:
+
+Replace the ledger declarations:
+
+```ts
+export type CoverOutcome = 'row' | 'cache' | 'none' | 'skipped' | 'unresolved';
+
+export interface RequestCoverOptions {
+  /** Liveness probe: is the requesting surface still near the viewport? Orders fetches only. */
+  stillNear?: () => boolean;
+  /**
+   * The caller has already decided the cover on hand is STALE (a stamp it
+   * computed against the listing): skip the target test, the cache
+   * short-circuit and the ledger, fetch, and overwrite whatever is there.
+   */
+  refresh?: boolean;
+}
+
+/** What a settled request delivered, and against which listing stamp. */
+interface SettledCover {
+  target: 'row' | 'cache' | 'none';
+  stamp: string;
+}
+
+/** Ledger key → what was delivered. See {@link ledgerKey} and {@link isRedundant}. */
+const settled = new Map<string, SettledCover>();
+/** Ledger key → the request currently running for it. */
+const inFlight = new Map<string, Promise<CoverOutcome>>();
+
+/** The listing's cover-sidecar stamp this request is made against; `':'` when unknown. */
+function listingStamp(vol: VolumeMetadata): string {
+  return `${vol.cloudThumbnailSize ?? ''}:${vol.cloudThumbnailModifiedTime ?? ''}`;
+}
+
+/**
+ * Is there nothing left for a request to do? Only when a request for this
+ * key already settled against the SAME listing stamp, and delivered to a
+ * target at least as good as this volume needs now: a `'row'` or `'none'`
+ * answer is final for that stamp; a `'cache'` answer is final only while the
+ * volume still has no relationship (once it is read, the same cover must be
+ * promoted onto its row).
+ */
+function isRedundant(vol: VolumeMetadata, entry: SettledCover | undefined): boolean {
+  if (!entry || entry.stamp !== listingStamp(vol)) return false;
+  if (entry.target !== 'cache') return true;
+  return !wantsRow(vol);
+}
+
+/** Request-time view of `coverBelongsOnRow`: the volume as the caller holds it, plus the reading store. */
+function wantsRow(vol: VolumeMetadata): boolean {
+  if (vol.isPlaceholder) return false;
+  const history = get(readingHistoryStore) as Record<string, ReadingHistoryEntry>;
+  return coverBelongsOnRow(vol, history[vol.volume_uuid]);
+}
+```
+
+(`get` from `svelte/store`, `volumes as readingHistoryStore` from `$lib/settings/volume-data`, `ReadingHistoryEntry` from `$lib/settings/reading-activity`, `coverBelongsOnRow` from `./cover-persist`.)
+
+Change `resolveAndDeliver`'s signature to `(vol, options): Promise<CoverOutcome | 'retry'>` — every `return true` becomes the outcome it delivered (`'row'`/`'cache'`/`'none'`), every `return false` becomes `'retry'`. Concretely: case 1 → `wantsRow(vol) ? 'row' : 'cache'` after `deliverToRow`, `'none'` when the row has no `cloudThumbnailFileId`; the `!vol.isPlaceholder` no-row exit → `'none'`; case 2 → `'cache'` (or `'none'` with no cover id); case 3/4 → `'foreign'` → `'none'`, no cover → `'none'`, delivered → `'cache'`. The cached fast path returns `'cache'` for now (Task A3 turns it into promotion). `deliverToRow`'s `hadThumbnailAlready` becomes `!!vol.thumbnail || !!options.refresh`.
+
+Rewrite `requestCover`:
+
+```ts
+export function requestCover(
+  vol: VolumeMetadata,
+  options: RequestCoverOptions = {}
+): Promise<CoverOutcome> {
+  const uuid = vol.volume_uuid;
+  if (!uuid) return Promise.resolve('skipped');
+  const key = ledgerKey(uuid);
+  const running = inFlight.get(key);
+  if (running) return running;
+  if (!options.refresh) {
+    if (isRedundant(vol, settled.get(key))) return Promise.resolve('skipped');
+    if (!isCoverFetchTarget(vol)) return Promise.resolve('skipped');
+  }
+
+  const run = (async (): Promise<CoverOutcome> => {
+    for (let attempt = 0; ; attempt++) {
+      try {
+        const outcome = await resolveAndDeliver(vol, options);
+        if (outcome !== 'retry') {
+          settled.set(key, { target: outcome, stamp: listingStamp(vol) });
+          return outcome;
+        }
+        if (attempt >= RETRY_DELAYS_MS.length) return 'unresolved';
+        await sleep(RETRY_DELAYS_MS[attempt]);
+      } catch (error) {
+        if (attempt >= RETRY_DELAYS_MS.length) {
+          console.warn(`Cover request failed for ${vol.volume_title}:`, error);
+          return 'unresolved';
+        }
+        await sleep(RETRY_DELAYS_MS[attempt]);
+      }
+    }
+  })();
+
+  inFlight.set(key, run);
+  void run.finally(() => {
+    if (inFlight.get(key) === run) inFlight.delete(key);
+  });
+  return run;
+}
+```
+
+Update the module doc's DEDUPE paragraph to describe the outcome ledger. In `cover-claims.svelte.ts` the effect becomes `for (const vol of fetchTargets) void requestCover(vol, { stillNear });`. Update `_resetCoverServiceForTests` (`settled.clear()` still works on a Map).
+
+- [ ] **Step 4: Run**
+
+Run: `npx vitest run src/lib/catalog/`
+Expected: PASS (cover-install and perf contracts included).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/catalog/cover-service.ts src/lib/catalog/cover-claims.svelte.ts src/lib/catalog/cover-service.test.ts src/lib/catalog/cover-claims.test.ts src/lib/catalog/cover-service.retry.test.ts
+git commit -m "feat(covers): requestCover reports its outcome and dedupes on what it delivered"
+```
+
+### Task A3: Promotion — a cached cover reaches the row the volume has earned
+
+**Files:**
+
+- Modify: `src/lib/catalog/cover-service.ts` (the cached fast path in `resolveAndDeliver`)
+- Test: create `src/lib/catalog/cover-service.promote.test.ts` (copy the harness header of `cover-service.test.ts` verbatim — the mocks, `row()`, `drainQueues`, `waitForCover`).
+
+**Interfaces:**
+
+- Consumes: `coverBelongsOnRow`, `CloudCover.cover_size/cover_modified` (A1); `isSidecarStale`, `isoToEpochSeconds` (`$lib/metadata/cloud-sidecar-stamps`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+async function cacheCover(
+  path: string,
+  stamp: { cover_size?: number; cover_modified?: number } = {}
+) {
+  await putCloudCovers([
+    {
+      account_scope: 'mega:a@b.com',
+      path,
+      thumbnail: new File(['cached'], 'c.webp', { type: 'image/webp' }),
+      width: 100,
+      height: 150,
+      cached_at: Date.now(),
+      ...stamp
+    }
+  ]);
+}
+
+describe('promotion: a cached cover is installed onto a row the user has read, with no fetch', () => {
+  it('copies the cached blob and ITS stamp onto the row', async () => {
+    await db.volumes.put(row('u1'));
+    await cacheCover('One Piece/Volume 01.cbz', { cover_size: 5, cover_modified: 1700000000 });
+    const update = vi.spyOn(db.volumes, 'update');
+    const outcome = await requestCover(
+      row('u1', {
+        cloudProvider: 'webdav',
+        cloudThumbnailFileId: 'c',
+        cloudPath: 'One Piece/Volume 01.cbz',
+        cloudThumbnailSize: 5,
+        cloudThumbnailModifiedTime: '2023-11-14T22:13:20.000Z'
+      })
+    );
+    await flushPendingCoverPersists();
+    expect(outcome).toBe('row');
+    expect(fetchCloudThumbnailMock).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith(
+      'u1',
+      expect.objectContaining({
+        thumbnail: expect.any(File),
+        thumbnail_width: 100,
+        thumbnail_height: 150,
+        cover_size: 5,
+        cover_modified: 1700000000
+      })
+    );
+    update.mockRestore();
+  });
+
+  it('a cached cover with no relationship stays in the cache and is not fetched', async () => {
+    await cacheCover('One Piece/Volume 01.cbz');
+    expect(await requestCover(indexedPlaceholder('p1', { cloudThumbnailFileId: 'c' }))).toBe(
+      'cache'
+    );
+    expect(fetchCloudThumbnailMock).not.toHaveBeenCalled();
+    expect(await db.volumes.count()).toBe(0);
+  });
+
+  it('a STALE cached cover is fetched fresh instead of promoted', async () => {
+    await db.volumes.put(row('u1'));
+    await cacheCover('One Piece/Volume 01.cbz', { cover_size: 5, cover_modified: 1 });
+    const outcome = await requestCover(
+      row('u1', {
+        cloudProvider: 'webdav',
+        cloudThumbnailFileId: 'c',
+        cloudPath: 'One Piece/Volume 01.cbz',
+        cloudThumbnailSize: 9,
+        cloudThumbnailModifiedTime: '2026-01-01T00:00:00.000Z'
+      })
+    );
+    expect(outcome).toBe('row');
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('settled as cache while browsed, then promoted the first time it is rendered as read', async () => {
+    // browsed: indexed placeholder, no row → cache
+    expect(await requestCover(indexedPlaceholder('u1', { cloudThumbnailFileId: 'c' }))).toBe(
+      'cache'
+    );
+    await drainQueues();
+    // read elsewhere, row materialized, history arrived → same uuid, same stamp
+    await db.volumes.put(row('u1'));
+    fetchCloudThumbnailMock.mockClear();
+    const outcome = await requestCover(
+      row('u1', {
+        cloudProvider: 'webdav',
+        cloudThumbnailFileId: 'c',
+        cloudPath: 'One Piece/Volume 01.cbz'
+      })
+    );
+    expect(outcome).toBe('row');
+    expect(fetchCloudThumbnailMock).not.toHaveBeenCalled();
+    await waitForCover('u1');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/lib/catalog/cover-service.promote.test.ts`
+Expected: FAIL — outcome `'cache'`, no row update.
+
+- [ ] **Step 3: Implement** — replace the cached fast path at the top of `resolveAndDeliver`:
+
+```ts
+if (!options.refresh && !vol.thumbnail && vol.cloudPath) {
+  const cached = await readCachedCover(vol.cloudPath);
+  if (cached === 'error') {
+    // fall through: fetching is the safe answer when the cache is unreadable
+  } else if (cached) {
+    if (!wantsRow(vol)) return 'cache';
+    const cachedStamp = { size: cached.cover_size, modified: cached.cover_modified };
+    const current = {
+      size: vol.cloudThumbnailSize,
+      modified: isoToEpochSeconds(vol.cloudThumbnailModifiedTime)
+    };
+    if (!isSidecarStale(cachedStamp, current)) {
+      // PROMOTION: the blob this account already holds, with the freshness
+      // it actually has. `installCover` takes the stamp as (bytes, ISO) —
+      // hand it the cached epoch back as ISO so the row records the same
+      // seconds the cache row did.
+      installCover(
+        { volume_uuid: vol.volume_uuid, cloudPath: vol.cloudPath },
+        { file: cached.thumbnail, width: cached.width, height: cached.height },
+        {
+          size: cached.cover_size,
+          modifiedTime:
+            cached.cover_modified !== undefined
+              ? new Date(cached.cover_modified * 1000).toISOString()
+              : undefined
+        },
+        'fill'
+      );
+      return 'row';
+    }
+    // Stale: fall through to a fetch, which the queue routes onto the row.
+  }
+}
+```
+
+with
+
+```ts
+/**
+ * The cached cover row for `cloudPath` under the active account — blob
+ * included, deliberately: this is the ONE read that wants the bytes, because
+ * it is about to copy them onto a `volumes` row. Everything else that asks
+ * "is it cached?" stays keys-only. `undefined` = not cached; `'error'` = the
+ * cache could not be consulted (treated as a miss by the caller, exactly as
+ * `withoutCachedCovers` used to).
+ */
+async function readCachedCover(cloudPath: string): Promise<CloudCover | undefined | 'error'> {
+  try {
+    const scope = activeAccountScope();
+    if (!scope) return undefined;
+    return await db.cloud_covers.get([scope, normalizeCachePath(cloudPath)]);
+  } catch (error) {
+    console.debug('[cover-service] could not consult the cover cache:', error);
+    return 'error';
+  }
+}
+```
+
+Delete `isCachedCoverPath` and the `cachedCoverPaths` import if no longer used. Move the module doc's "RE-DOWNLOAD GUARD" paragraph onto `readCachedCover` and add a PROMOTION paragraph to the module doc (case 2 in the ladder, per the spec).
+
+- [ ] **Step 4: Run**
+
+Run: `npx vitest run src/lib/catalog/`
+Expected: PASS. Check the perf contracts especially: CONTRACT 3 asserts no `volumes` rows are written for cache-only covers — placeholders never `wantsRow`, so it holds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/catalog/cover-service.ts src/lib/catalog/cover-service.promote.test.ts
+git commit -m "feat(covers): promote a cached cover onto the row a read volume has earned"
+```
+
+### Task A4: `installCoversForSeries` becomes a candidate builder
+
+**Files:**
+
+- Modify: `src/lib/catalog/cover-install.ts` (whole `runCoverInstall`, delete `withoutCachedCovers`, `MAX_CONCURRENT_COVER_INSTALLS`)
+- Test: `src/lib/catalog/cover-install.test.ts`
+
+**Interfaces:**
+
+- Consumes: `requestCover(vol): Promise<CoverOutcome>` (A2/A3).
+- Produces: `installCoversForSeries(seriesTitle): Promise<number>` unchanged signature (count of `'row' | 'cache'` outcomes).
+
+- [ ] **Step 1: Retarget the tests.** Keep every `it` in `cover-install.test.ts` except the `concurrency pinning` describe (delete it and the `MAX_CONCURRENT_COVER_INSTALLS` import). Add, since the pass now goes through the service, a mock so `cover-service` is real but observable:
+
+```ts
+const { requestCoverSpy } = vi.hoisted(() => ({ requestCoverSpy: vi.fn() }));
+vi.mock('$lib/catalog/cover-service', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/catalog/cover-service')>();
+  return {
+    ...actual,
+    requestCover: (...a: Parameters<typeof actual.requestCover>) => {
+      requestCoverSpy(...a);
+      return actual.requestCover(...a);
+    }
+  };
+});
+```
+
+Add `_resetCoverServiceForTests()` to `beforeEach` (import from `./cover-service`). Add one new case:
+
+```ts
+it('hands every candidate to requestCover, decorated from the LISTING, never storing cloud fields', async () => {
+  await addRow();
+  await installCoversForSeries('Dr Stone');
+  expect(requestCoverSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      volume_uuid: 'uuid-1',
+      cloudProvider: 'webdav',
+      cloudPath: 'Dr Stone/Volume 1.cbz',
+      cloudThumbnailFileId: 'cover-1',
+      cloudThumbnailPath: 'Dr Stone/Volume 1.webp',
+      cloudThumbnailSize: 1,
+      cloudThumbnailModifiedTime: '2026-01-02T00:00:00.000Z'
+    })
+  );
+  const stored = await db.volumes.get('uuid-1');
+  expect(stored).not.toHaveProperty('cloudPath');
+  expect(stored).not.toHaveProperty('cloudThumbnailFileId');
+});
+
+it('promotes a cached cover onto a READ row without fetching', async () => {
+  await addRow();
+  history.set({ 'uuid-1': { progress: 3 } });
+  await db.cloud_covers.put({
+    account_scope: 'webdav:a@b.com',
+    path: 'Dr Stone/Volume 1.cbz',
+    thumbnail: new File(['c'], 'c.webp'),
+    width: 10,
+    height: 15,
+    cached_at: Date.now()
+  });
+  expect(await installCoversForSeries('Dr Stone')).toBe(1);
+  expect(fetchCloudThumbnail).not.toHaveBeenCalled();
+  expect((await db.volumes.get('uuid-1'))?.thumbnail_width).toBe(10);
+});
+```
+
+The existing "never re-downloads a cover this account already has cached" case changes its second expectation: the second pass returns `0` still (the row now HAS the cover or the request is `'skipped'`) — keep as written; if the cached relationship-less row's second request returns `'cache'` again (it is `'skipped'` by the ledger), the count is 0 either way.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/lib/catalog/cover-install.test.ts`
+Expected: FAIL on the two new cases (no `requestCover` call; fetch called for the cached row).
+
+- [ ] **Step 3: Implement** — replace `runCoverInstall` (keep `coverKey`, `foldCoverIndex`, `foldArchiveIndex`, `installCoversForSeries`'s dedupe wrapper):
+
+```ts
+async function runCoverInstall(seriesTitle: string): Promise<number> {
+  const provider = unifiedCloudManager.getActiveProvider();
+  if (!provider) return 0;
+
+  const listing = unifiedCloudManager.getAllCloudVolumes();
+  const covers = foldCoverIndex(indexCoverSidecarsByBasePath(listing));
+  if (covers.size === 0) return 0;
+  const archivePaths = foldArchiveIndex(listing);
+
+  const seriesKey = normalizeSeriesKey(seriesTitle);
+  const rows = (await db.volumes
+    .where('series_title')
+    .equalsIgnoreCase(seriesTitle)
+    .toArray()) as VolumeMetadata[];
+
+  // The listing's cover and archive for each row, decorated onto a COPY —
+  // the same shape the catalog hands a card (`cloudFieldsForRemovedVolume`),
+  // so `requestCover` sees exactly what it would see from a render. Nothing
+  // here is ever written back to the row.
+  const requests: Promise<CoverOutcome>[] = [];
+  for (const row of rows) {
+    if (normalizeSeriesKey(row.series_title) !== seriesKey) continue;
+    if (!needsDownload(row) || row.thumbnail) continue;
+    const key = coverKey(row.series_title, row.volume_title);
+    const info = covers.get(key);
+    if (!info) continue;
+    const decorated: VolumeMetadata = {
+      ...row,
+      cloudProvider: provider.type,
+      cloudPath: archivePaths.get(key) ?? row.cloudPath,
+      cloudThumbnailFileId: info.fileId,
+      cloudThumbnailPath: info.path,
+      ...(isArchiveSize(info.size) ? { cloudThumbnailSize: info.size } : {}),
+      ...(info.modifiedTime ? { cloudThumbnailModifiedTime: info.modifiedTime } : {})
+    };
+    requests.push(requestCover(decorated));
+  }
+  if (requests.length === 0) return 0;
+
+  const outcomes = await Promise.all(requests);
+  const installed = outcomes.filter((o) => o === 'row' || o === 'cache').length;
+  // Drain what this pass queued before returning (see the doc above): the
+  // caller awaits a series open or a backfill, and "installed" should mean
+  // the covers have actually landed.
+  if (installed > 0) await flushPendingCoverPersists();
+  return installed;
+}
+```
+
+Imports: `requestCover, type CoverOutcome` from `./cover-service`; `isArchiveSize` from `$lib/metadata/series-file`; drop `fetchCloudThumbnail`, `cachedCoverPaths`, `activeAccountScope`, `normalizeCachePath`, `installCover`. Rewrite the module doc: this module decides WHICH rows to ask for and from WHICH listing files; `cover-service.ts` decides everything after that (cache, promotion, fetch, routing). Note the dirty re-scan is unchanged.
+
+Check for an import cycle: `cover-service.ts` imports `series-backfill.ts`, which imports `cover-install.ts`, which now imports `cover-service.ts`. That is a cycle (`cover-service → series-backfill → cover-install → cover-service`). Break it the way `cover-persist.ts` already does for its own case: `cover-install.ts` imports `requestCover` lazily —
+
+```ts
+async function requestCoverLazy(vol: VolumeMetadata): Promise<CoverOutcome> {
+  const { requestCover } = await import('./cover-service');
+  return requestCover(vol);
+}
+```
+
+— and imports only `type CoverOutcome` statically. Document why in one paragraph (the cycle above; `series-backfill.ts` imports this module for its post-write flesh-out).
+
+- [ ] **Step 4: Run**
+
+Run: `npx vitest run src/lib/catalog/ src/lib/metadata/series-open.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/catalog/cover-install.ts src/lib/catalog/cover-install.test.ts
+git commit -m "refactor(covers): the series pass builds candidates and asks the one cover service"
+```
+
+### Task A5: the backfill's stale refresh is a `refresh: true` request
+
+**Files:**
+
+- Modify: `src/lib/metadata/series-backfill.ts:410-440` (`refreshStaleCover`), imports at `:4-6`
+- Test: `src/lib/metadata/series-backfill.test.ts` (the `fetchCloudThumbnail`/`installCover` mocks and the stale-cover cases at ~902–1100)
+
+- [ ] **Step 1: Retarget the tests.** Replace the `cloud-thumbnails` mock with a `cover-service` mock:
+
+```ts
+const requestCover = vi.fn(async (_vol: unknown, _opts?: unknown) => 'row' as const);
+vi.mock('$lib/catalog/cover-service', () => ({
+  requestCover: (...a: Parameters<typeof requestCover>) => requestCover(...a)
+}));
+```
+
+Every assertion `expect(fetchCloudThumbnail).toHaveBeenCalledTimes(1)` on a stale-cover case becomes
+
+```ts
+expect(requestCover).toHaveBeenCalledTimes(1);
+expect(requestCover).toHaveBeenCalledWith(
+  expect.objectContaining({
+    volume_uuid: '<uuid the case uses>',
+    cloudThumbnailFileId: '<cover fileId>',
+    cloudThumbnailSize: 900,
+    cloudThumbnailModifiedTime: '2026-07-01T00:00:00.000Z',
+    cloudPath: '<archive path>'
+  }),
+  { refresh: true }
+);
+```
+
+and `expect(fetchCloudThumbnail).not.toHaveBeenCalled()` becomes `expect(requestCover).not.toHaveBeenCalled()`. The "download finished mid-fetch" case (~963–1000) tested the write queue's guard through the old direct call; with the fetch inside the service that guard is the service's and cover-persist's own (covered in their suites) — reduce that case to asserting the request was made and nothing else was written by this module.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/lib/metadata/series-backfill.test.ts`
+Expected: FAIL — `requestCover` never called.
+
+- [ ] **Step 3: Implement**
+
+```ts
+async function refreshStaleCover(
+  providerType: SyncProvider['type'],
+  volumeUuid: string,
+  cover: CloudFileMetadata,
+  archivePath: string | undefined
+): Promise<void> {
+  const row = (await db.volumes.get(volumeUuid)) as VolumeMetadata | undefined;
+  if (!row || !needsDownload(row)) return;
+
+  // The stale sidecar's OWN listing stamp rides as the `cloudThumbnail*`
+  // decoration, so the service records exactly the bytes it is about to
+  // fetch; `refresh: true` is what tells it not to trust the cache or its
+  // ledger for this uuid. Decorated on a copy, never stored.
+  await requestCover(
+    {
+      ...row,
+      cloudProvider: providerType,
+      cloudPath: archivePath ?? row.cloudPath,
+      cloudThumbnailFileId: cover.fileId,
+      cloudThumbnailPath: cover.path,
+      ...(isArchiveSize(cover.size) ? { cloudThumbnailSize: cover.size } : {}),
+      ...(cover.modifiedTime ? { cloudThumbnailModifiedTime: cover.modifiedTime } : {})
+    },
+    { refresh: true }
+  );
+  await flushPendingCoverPersists();
+}
+```
+
+Imports: `requestCover` from `$lib/catalog/cover-service` — BUT `cover-service.ts` imports this module statically (`acquireBackfillSlot`, `pullMokuroEntry`, …), so this is the same cycle as A4: use the lazy `await import('$lib/catalog/cover-service')` inside the function, keep `flushPendingCoverPersists` from `cover-persist`, drop `fetchCloudThumbnail` and `installCover`. Trim the doc comment to what is still true.
+
+- [ ] **Step 4: Run**
+
+Run: `npx vitest run src/lib/metadata/ src/lib/catalog/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/metadata/series-backfill.ts src/lib/metadata/series-backfill.test.ts
+git commit -m "refactor(covers): the backfill's stale refresh is a refresh request to the cover service"
+```
+
+### Task A6: Part A gate
+
+- [ ] **Step 1:** `npm run check` → 0 errors. `npx vitest run` → all green. `npm run lint` → warnings at the develop baseline (272), 0 errors.
+- [ ] **Step 2:** `grep -rn "fetchCloudThumbnail\|installCover(" src --include=*.ts --include=*.svelte | grep -v test | grep -v "catalog/cover-service\|catalog/cover-persist\|catalog/cloud-thumbnails"` → no callers outside the service. Report the output.
+- [ ] **Step 3:** Update `CLAUDE.md`'s "Zoom architecture"-style bullet list? No — add ONE line under **Reader Input Handling**'s sibling sections is wrong; instead append to the `## Important Patterns` a short subsection:
+
+```markdown
+### Cloud covers
+
+`requestCover(vol)` (`src/lib/catalog/cover-service.ts`) is the only way anything obtains a
+cloud cover: surfaces through `createCoverClaims`, the series-open pass through
+`installCoversForSeries` (a candidate builder), the backfill's stale refresh with
+`{ refresh: true }`. Its ladder: fresh row thumbnail → cached in `cloud_covers` (promoted
+onto the row when the volume is metadata-only AND read — `coverBelongsOnRow`) → fetch.
+The write queue (`cover-persist.ts`) routes by the same predicate. Never fetch or write a
+cover from anywhere else.
+```
+
+- [ ] **Step 4: Commit** `docs: cloud cover entry point in CLAUDE.md`.
+
+---
+
+## Part B — Resolution after every progress sync
+
+### Task B1: the manager retains the index refresh and exposes it
+
+**Files:**
+
+- Modify: `src/lib/util/sync/unified-cloud-manager.ts:247-300` (`refreshSeriesIndexesInBackground`), add a field and method
+- Test: `src/lib/util/sync/unified-cloud-manager.test.ts` (new describe; the file mocks `cache-manager`, `provider-manager`, `unified-sync-service`; add a mock for `$lib/metadata/series-index-sync` exposing `refreshSeriesIndexes`)
+
+**Interfaces:**
+
+- Produces: `unifiedCloudManager.whenSeriesIndexesSettled(): Promise<void>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+const refreshSeriesIndexes = vi.fn(async () => {});
+vi.mock('$lib/metadata/series-index-sync', () => ({
+  refreshSeriesIndexes: (...a: unknown[]) => refreshSeriesIndexes(...a)
+}));
+vi.mock('$lib/metadata/catalog-index-sync', () => ({ refreshCatalogIndex: vi.fn(async () => {}) }));
+vi.mock('$lib/metadata/series-file-sync', () => ({
+  markListingFresh: vi.fn(),
+  reconcileMissingMetadataFiles: vi.fn(async () => {})
+}));
+vi.mock('$lib/util/sync/sidecar-backfill', () => ({
+  sweepInstalledVolumesForSidecarBackfill: vi.fn(async () => {})
+}));
+
+describe('whenSeriesIndexesSettled', () => {
+  it('resolves immediately when no refresh is running', async () => {
+    await expect(unifiedCloudManager.whenSeriesIndexesSettled()).resolves.toBeUndefined();
+  });
+
+  it('waits for the refresh the last listing started', async () => {
+    let release!: () => void;
+    refreshSeriesIndexes.mockReturnValueOnce(new Promise<void>((r) => (release = r)));
+    getActiveProvider.mockReturnValue({ type: 'webdav' });
+    getAllFiles.mockReturnValue([{ path: 'S/V.cbz', fileId: '1', size: 1, modifiedTime: '' }]);
+    unifiedCloudManager.refreshSeriesIndexesInBackground();
+    let settled = false;
+    const p = unifiedCloudManager.whenSeriesIndexesSettled().then(() => (settled = true));
+    await Promise.resolve();
+    expect(settled).toBe(false);
+    release();
+    await p;
+    expect(settled).toBe(true);
+  });
+
+  it('never rejects, even when the refresh does', async () => {
+    refreshSeriesIndexes.mockRejectedValueOnce(new Error('boom'));
+    getActiveProvider.mockReturnValue({ type: 'webdav' });
+    getAllFiles.mockReturnValue([{ path: 'S/V.cbz', fileId: '1', size: 1, modifiedTime: '' }]);
+    unifiedCloudManager.refreshSeriesIndexesInBackground();
+    await expect(unifiedCloudManager.whenSeriesIndexesSettled()).resolves.toBeUndefined();
+  });
+});
+```
+
+(Check the existing mocks at the top of that file first: some of these modules may already be mocked — reuse rather than duplicate.)
+
+- [ ] **Step 2: Run** — `npx vitest run src/lib/util/sync/unified-cloud-manager.test.ts` → FAIL, method missing.
+
+- [ ] **Step 3: Implement** — in the class:
+
+```ts
+  /**
+   * The `series.json` refresh the most recent listing started, or `null`.
+   * Retained so a caller that needs the cached indexes to be CURRENT — the
+   * post-sync progress resolution — can await the run already in flight
+   * instead of starting a second one. Always a settled-without-rejecting
+   * promise (the refresh logs its own failures).
+   */
+  private seriesIndexRefresh: Promise<void> | null = null;
+
+  whenSeriesIndexesSettled(): Promise<void> {
+    return this.seriesIndexRefresh ?? Promise.resolve();
+  }
+```
+
+and in `refreshSeriesIndexesInBackground` replace the first `void Promise.resolve(refreshSeriesIndexes(...))` with:
+
+```ts
+const refresh = Promise.resolve(refreshSeriesIndexes(listing, provider.type)).catch((error) =>
+  console.warn('Series index refresh failed:', error)
+);
+this.seriesIndexRefresh = refresh;
+void refresh.finally(() => {
+  if (this.seriesIndexRefresh === refresh) this.seriesIndexRefresh = null;
+});
+```
+
+- [ ] **Step 4: Run** → PASS. **Step 5: Commit** `feat(sync): retain the series-index refresh so resolution can await it`.
+
+### Task B2: `resolveSyncedProgress` and the uncapped sweep
+
+**Files:**
+
+- Modify: `src/lib/metadata/hole-patch.ts` (remove `MAX_HOLE_PATCHES_PER_RUN`, `attemptedThisSession`, `resetHolePatchSessionForTests`, `patchProgressHolesWhenListingReady`, the `limit` option; add `resolveSyncedProgress`)
+- Modify: `src/lib/metadata/history-rows.ts` (remove `MAX_HISTORY_ROWS_PER_RUN`, `MAX_HISTORY_SERIES_PER_RUN`, the `limit`/`seriesLimit` options and both cap checks)
+- Test: `src/lib/metadata/hole-patch.test.ts`, `src/lib/metadata/history-rows.test.ts`
+
+**Interfaces:**
+
+- Produces: `export async function resolveSyncedProgress(): Promise<void>` (never rejects).
+- Consumes: `unifiedCloudManager.whenSeriesIndexesSettled()` (B1).
+
+- [ ] **Step 1: Retarget tests.**
+
+`hole-patch.test.ts`: delete `de-duplicates by series and caps the run` (replace with `de-duplicates by series and pulls every dangling series in one run` asserting 7 distinct titles → 7 `openSeries` calls), delete the three session-memo cases (`does not re-attempt…`, `does not count an attempt left off…`, and the memo half of `is a no-op and memoizes nothing…` — keep the listing-gate half), delete the whole `patchProgressHolesWhenListingReady` describe, drop `resetHolePatchSessionForTests` from imports/`beforeEach`. Add to the manager mock `whenSeriesIndexesSettled: () => indexRefresh` where `let indexRefresh: Promise<void> = Promise.resolve();` and add:
+
+```ts
+describe('resolveSyncedProgress', () => {
+  it('does nothing before the listing is loaded', async () => {
+    cacheLoaded = false;
+    progress = { v1: { series_title: 'Ghost' } };
+    await resolveSyncedProgress();
+    expect(materializeHistoryRows).not.toHaveBeenCalled();
+    expect(enrichAllOrphanedVolumes).not.toHaveBeenCalled();
+  });
+
+  it('waits for the index refresh before sweeping', async () => {
+    let release!: () => void;
+    indexRefresh = new Promise<void>((r) => (release = r));
+    progress = { v1: { series_title: 'Ghost' } };
+    const run = resolveSyncedProgress();
+    await Promise.resolve();
+    expect(materializeHistoryRows).not.toHaveBeenCalled();
+    release();
+    await run;
+    expect(materializeHistoryRows).toHaveBeenCalledTimes(1);
+    expect(openSeries).toHaveBeenCalledWith('Ghost');
+  });
+
+  it('enriches before AND after the sweep', async () => {
+    const order: string[] = [];
+    enrichAllOrphanedVolumes.mockImplementation(async () => {
+      order.push('enrich');
+    });
+    materializeHistoryRows.mockImplementation(async () => {
+      order.push('sweep');
+      return 0;
+    });
+    await resolveSyncedProgress();
+    expect(order).toEqual(['enrich', 'sweep', 'enrich']);
+  });
+
+  it('never rejects', async () => {
+    materializeHistoryRows.mockRejectedValueOnce(new Error('boom'));
+    await expect(resolveSyncedProgress()).resolves.toBeUndefined();
+  });
+});
+```
+
+`history-rows.test.ts`: delete `honours the per-run cap and drains across runs` and `bounds the SERIES a run touches…`; in the large-library describe keep `writes only the volumes with history, in ONE transaction, without reading a row` and add an assertion that ALL seeded history volumes (make it more than 1000 across more than 200 series, e.g. 1200 volumes over 240 series) get a row in ONE run and ONE `readwrite` transaction (the describe already counts transactions with `countIdbOps`). Drop the two constant imports.
+
+- [ ] **Step 2: Run** → FAIL (imports missing / caps still applied).
+
+- [ ] **Step 3: Implement.**
+
+`history-rows.ts`: delete the two constants and their doc blocks; `materializeHistoryRows(options?: { readIndexes?: ... })`; in step 4 remove `if (plannedUuids.size >= limit) break;` and the `plan.size >= seriesLimit` skip. Update the module doc's WORST-CASE WORK paragraph: the set is bounded by the user's reading history, and one run drains it entirely.
+
+`hole-patch.ts`: delete `MAX_HOLE_PATCHES_PER_RUN`, `attemptedThisSession`, `resetHolePatchSessionForTests`, `patchProgressHolesWhenListingReady`; `patchProgressHoles()` takes no options and iterates `wanted` whole; keep the `listingIsLoaded()` re-check per attempt. Add:
+
+```ts
+/**
+ * THE trigger. Runs once per progress sync, from
+ * `unifiedCloudManager.syncProgress()` — never from a view.
+ *
+ * Waits for the `series.json` refresh the listing started, because that is
+ * what phase 1 resolves against: measured 2026-08-31, the same sweep
+ * materialized 5 of 30 series against a cold index cache and 30 of 30 against
+ * a warm one, and on a network provider the startup sweep always ran cold.
+ * With the refresh awaited, phase 1 is in-memory plus one bulk read, and
+ * phase 2 only ever downloads an index the listing shows but the refresh
+ * failed to cache.
+ *
+ * Starts no I/O the sync did not already imply: no listing is fetched here
+ * (a Drive listing fetch can itself trigger a post-login sync, and a
+ * resolution that fetched would close that loop). Without a loaded listing
+ * it is a no-op; the next sync catches up. Never rejects.
+ */
+export async function resolveSyncedProgress(): Promise<void> {
+  try {
+    if (!listingIsLoaded()) return;
+    await unifiedCloudManager.whenSeriesIndexesSettled();
+    await patchProgressHolesAndEnrich();
+  } catch (error) {
+    console.debug('[hole-patch] resolution failed:', error);
+  }
+}
+```
+
+Rewrite the module doc for `patchProgressHoles` (no cap, no memo; why — the spec's B3 paragraph).
+
+- [ ] **Step 4: Run** `npx vitest run src/lib/metadata/hole-patch.test.ts src/lib/metadata/history-rows.test.ts` → PASS.
+
+- [ ] **Step 5: Commit** `feat(metadata): resolveSyncedProgress — await the index refresh, drop the coverage caps`.
+
+### Task B3: wire the trigger; remove the view-mount triggers
+
+**Files:**
+
+- Modify: `src/lib/util/sync/unified-cloud-manager.ts:2017-2035` (`syncProgress`)
+- Modify: `src/lib/util/sync/init-providers.ts:3,154-155`
+- Modify: `src/lib/views/CatalogView.svelte:1-20`, `src/lib/views/ReadingSpeedView.svelte:19,704-733`
+- Test: `src/lib/util/sync/unified-cloud-manager.test.ts`
+
+- [ ] **Step 1: Write the failing test** (same file as B1; mock `$lib/metadata/hole-patch` with a hoisted `resolveSyncedProgress` spy):
+
+```ts
+describe('syncProgress starts resolution behind the result', () => {
+  it('runs resolveSyncedProgress after a successful sync, without waiting for it', async () => {
+    getActiveProvider.mockReturnValue({ type: 'webdav' });
+    let release!: () => void;
+    resolveSyncedProgress.mockReturnValueOnce(new Promise<void>((r) => (release = r)));
+    (unifiedSyncService.syncProvider as Mock).mockResolvedValue({ success: true });
+    const result = await unifiedCloudManager.syncProgress({ silent: true });
+    expect(result.succeeded).toBe(1);
+    expect(resolveSyncedProgress).toHaveBeenCalledTimes(1);
+    release();
+    await unifiedCloudManager.progressResolution;
+  });
+
+  it('does not start resolution after a failed sync', async () => {
+    getActiveProvider.mockReturnValue({ type: 'webdav' });
+    (unifiedSyncService.syncProvider as Mock).mockResolvedValue({ success: false });
+    await unifiedCloudManager.syncProgress();
+    expect(resolveSyncedProgress).not.toHaveBeenCalled();
+  });
+});
+```
+
+Because the manager uses a dynamic import, mock the module path with `vi.mock('$lib/metadata/hole-patch', () => ({ resolveSyncedProgress: (...a) => resolveSyncedProgress(...a) }))` — `vi.mock` intercepts dynamic imports too.
+
+- [ ] **Step 2: Run** → FAIL.
+
+- [ ] **Step 3: Implement** in `syncProgress`, after `const result = await unifiedSyncService.syncProvider(provider, options);`:
+
+```ts
+if (result.success) this.startProgressResolution();
+```
+
+plus
+
+```ts
+  /**
+   * The resolution run the last successful sync started (see
+   * `resolveSyncedProgress` in `hole-patch.ts`), retained for callers and
+   * tests that need the rows it mints. Sync itself never waits on it.
+   */
+  progressResolution: Promise<void> = Promise.resolve();
+
+  /**
+   * DYNAMIC import: `hole-patch.ts` imports this manager, and a static import
+   * back would close that into a cycle — the same discipline
+   * `cover-resolver.ts` uses for its key watch. A failure to import or run is
+   * logged and never reaches a sync result.
+   */
+  private startProgressResolution(): void {
+    this.progressResolution = import('$lib/metadata/hole-patch')
+      .then(({ resolveSyncedProgress }) => resolveSyncedProgress())
+      .catch((error) => console.debug('[sync] progress resolution failed to start:', error));
+  }
+```
+
+`init-providers.ts`: delete the import and the `void patchProgressHoles();` lines (the startup `syncProgress` now does it; leave a one-line comment saying so).
+
+`CatalogView.svelte`: delete the import and the `onMount` entirely (nothing else in it).
+
+`ReadingSpeedView.svelte`: replace the hole-patch import with `import { enrichAllOrphanedVolumes } from '$lib/settings';` and the `onMount` body's sweep with `void enrichAllOrphanedVolumes();` plus a comment: this view groups by the reading record's titles; enrichment copies titles off rows this device already has and is the only fix for a legacy record on a device with no provider. Rows for synced progress are minted after each sync (`resolveSyncedProgress`), not from here.
+
+- [ ] **Step 4:** `npm run check` → 0 errors; `npx vitest run` → PASS; grep `patchProgressHolesWhenListingReady\|MAX_HOLE_PATCHES\|MAX_HISTORY_` in `src` → nothing.
+
+- [ ] **Step 5: Commit** `feat(sync): resolve synced progress after every sync, not from view mounts`.
+
+### Task B4: cold-vs-warm harness and the Part B gate
+
+**Files:**
+
+- Test: `src/lib/metadata/hole-patch.integration.test.ts` (new; real Dexie like `history-rows.test.ts`, real `materializeHistoryRows`, mocked `openSeries` and manager with a controllable `whenSeriesIndexesSettled` that seeds the `series_index` table when released)
+
+- [ ] **Step 1:** Write the harness: seed 30 series' progress records (one volume each, `progress: 5`), a listing with all 30 folders, an EMPTY `series_index`. Make `whenSeriesIndexesSettled` return a promise that, before resolving, `put`s all 30 index records (the refresh landing). Call `resolveSyncedProgress()`. Assert `db.volumes.count()` is 30 and `openSeries` was never called (phase 2 had nothing left). Then a second `resolveSyncedProgress()` with `countIdbOps` asserting zero `readwrite` transactions and zero `openSeries` calls.
+- [ ] **Step 2:** Run → PASS (it is a characterization test of B1–B3; if it fails, the wiring is wrong — fix, don't relax).
+- [ ] **Step 3:** Full gate: `npm run check`, `npx vitest run`, `npm run lint`. Then e2e on a dedicated port: `E2E_PORT=4187 E2E_CHROMIUM=$(ls -d ~/.cache/ms-playwright/chromium-*/chrome-linux*/chrome | head -1) npx playwright test e2e/catalog-distribution.spec.ts` → 18 passed. Record the 12 pre-existing e2e failures elsewhere only if you run the whole suite.
+- [ ] **Step 4: Commit** `test(metadata): cold index cache materializes every synced series in one run`.
+- [ ] **Step 5:** Update `docs/superpowers/specs/2026-09-02-unified-cover-requests-design.md` status line to "implemented (parts A, B)" and commit.
+
+---
+
+## Part C — The tracker (branch `feat/progress-tracker`)
+
+### Task C1: merge and reconcile
+
+- [ ] **Step 1:** `cd .../feat-progress-tracker && git merge --no-ff feat/unified-cover-requests`. Expected conflicts: `ProgressTrackerView.svelte` does not conflict (only this branch touches it), but `hole-patch.ts`/tests may if the tracker branch touched them — it did not. Resolve any conflict keeping BOTH sides' intent.
+- [ ] **Step 2:** `npm run check` → the tracker view now fails: `patchProgressHolesWhenListingReady` no longer exists. Proceed to C2.
+
+### Task C2: the tracker view asks for enrichment only
+
+**Files:**
+
+- Modify: `src/lib/views/ProgressTrackerView.svelte:3,271-292`
+- Delete: `docs/superpowers/plans/2026-08-31-metadata-resolution-trigger.md`
+
+- [ ] **Step 1:** Replace the import with `import { enrichAllOrphanedVolumes } from '$lib/settings';` and the `onMount` tail with:
+
+```ts
+// Titles for legacy records that have a local row but no name yet; the
+// completed-by-series grouping reads them off the reading record. Rows
+// for progress synced from other devices are minted after each sync
+// (`resolveSyncedProgress`), never from a view.
+void enrichAllOrphanedVolumes();
+```
+
+- [ ] **Step 2:** `git rm docs/superpowers/plans/2026-08-31-metadata-resolution-trigger.md`; `npm run check` → 0 errors; `npx vitest run src/lib/views src/lib/goals` → PASS.
+- [ ] **Step 3: Commit** `fix(goals): the tracker relies on sync-time resolution for its rows`.
+
+### Task C3: `VolumeCard` draws through the shared cover claims
+
+**Files:**
+
+- Modify: `src/lib/components/VolumeCard.svelte` (drop the `thumbnail` prop; add claims; `use:gate`)
+- Modify: `src/lib/views/ProgressTrackerView.svelte` (remove the four `thumbnail={...}` props)
+- Test: create `src/lib/components/__tests__/VolumeCard.covers.test.ts` (pattern: `PlaceholderThumbnail.test.ts` — mock `$lib/catalog/cover-service` with `requestCover`/`isCoverFetchTarget`, stub `URL.createObjectURL`, `installIntersectionObserverStub`)
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+describe('VolumeCard covers', () => {
+  it('renders the row thumbnail as an object URL', async () => {
+    const { container } = render(VolumeCard, {
+      props: { ...baseProps, volume: volume('v1', { thumbnail: new File([], 'c.jpg') }) }
+    });
+    await tick();
+    expect(container.querySelector('img')?.getAttribute('src')).toBe('blob:cover-1');
+  });
+
+  it('shows the placeholder box and asks for the cover when the row has none', async () => {
+    const { container } = render(VolumeCard, {
+      props: {
+        ...baseProps,
+        volume: volume('v1', {
+          metadata_only: true,
+          cloudPath: 'S/V.cbz',
+          cloudThumbnailFileId: 't'
+        })
+      }
+    });
+    await tick();
+    expect(container.querySelector('img')).toBeNull();
+    expect(requestCover).toHaveBeenCalledWith(
+      expect.objectContaining({ volume_uuid: 'v1' }),
+      expect.objectContaining({ stillNear: expect.any(Function) })
+    );
+  });
+
+  it('asks nothing for a volume with no row at all', async () => {
+    render(VolumeCard, { props: { ...baseProps, volume: undefined } });
+    await tick();
+    expect(requestCover).not.toHaveBeenCalled();
+  });
+});
+```
+
+(`baseProps`: `volumeId: 'v1', seriesId: 's', volumeTitle: 'V', progressPercentString: '0%', remainingPages: 1, isHovered: false, onHover: () => {}`.)
+
+- [ ] **Step 2: Run** → FAIL (no `requestCover` call; prop shape).
+
+- [ ] **Step 3: Implement** in `VolumeCard.svelte`: remove `thumbnail` from `Props`; add
+
+```ts
+import { createCoverClaims } from '$lib/catalog/cover-claims.svelte';
+
+/**
+ * THE SHARED COVER EFFECT (see cover-claims.svelte.ts). Every volume this
+ * card lists has reading activity, so a request from here resolves onto the
+ * ROW — promoted from `cloud_covers` if the volume was browsed before it was
+ * read, fetched otherwise — and the card repaints from `volume.thumbnail`
+ * when that write lands. The claim shows the cached cover in the meantime.
+ */
+const coverClaims = createCoverClaims({
+  claims: () => (volume ? [volume] : []),
+  targets: () => (volume ? [volume] : [])
+});
+const { gate } = coverClaims;
+```
+
+Key the existing object-URL effect on `volume?.thumbnail` (content key `uuid:size:lastModified`, as now) and set `let displayUrl = $derived(thumbnailUrl ?? coverClaims.cover?.url);`. Put `use:gate` on the `.imagebox` div. Render `<img src={displayUrl}>` when set, else the existing `PlaceholderThumbnail` fallback — but pass it NO `volume` (it would create a second claim set for the same volume; this card owns the claim).
+
+In `ProgressTrackerView.svelte` delete the four `thumbnail={...}` lines.
+
+- [ ] **Step 4:** `npx vitest run src/lib/components/__tests__/VolumeCard.covers.test.ts src/lib/views` → PASS; `npm run check` → 0.
+
+- [ ] **Step 5: Commit** `feat(goals): tracker cards draw through the shared cover claims`.
+
+### Task C4: Part C gate
+
+- [ ] **Step 1:** `npm run check`, `npx vitest run`, `npm run lint`.
+- [ ] **Step 2:** `E2E_PORT=4188 E2E_CHROMIUM=... npx playwright test e2e/progress-tracker.spec.ts` → 7 passed (the `--spacing` regression assertion, the not-on-device card, the ghost-records case).
+- [ ] **Step 3:** Browser verification of promotion against the local bunko test instance if it is running (`project_bunko_test_env` memory: port 9090, accounts `<role>/password`): connect as `registered`, browse the catalog so a cover caches, seed a reading record for that volume's real uuid via the page context, trigger a sync from the NavBar, open `#/progress-tracker`, and assert in the page context that `db.volumes.get(uuid)` has `thumbnail` and that no network request for the `.webp` was made after the sync (read the network log). Record what was observed; if the instance is not running, say so rather than starting a production-facing one.
+- [ ] **Step 4:** Update `CHANGELOG.md` Unreleased on `feat/progress-tracker` if it lists tracker items (terse, ~8 words each): "Cover requests unified; cached covers install onto read volumes" and "Synced progress resolves after each sync, uncapped".
+- [ ] **Step 5: Commit** and report.
+
+---
+
+## Self-review notes
+
+- Spec A1–A9 → Tasks A1–A5 (+A6 docs). A8's `stillNear` shape → A2. A9 "cloud_covers row left in place" → nothing deletes it (A3 does not).
+- Spec B1 → B3; B2 → B1+B2; B3 caps/memos → B2; B4 → history-rows untouched transaction shape (B2 removes cap checks only); B5 views → B3.
+- Spec C → C1–C3.
+- Types: `CoverOutcome`, `RequestCoverOptions`, `coverBelongsOnRow(row, history)`, `whenSeriesIndexesSettled()`, `progressResolution`, `resolveSyncedProgress()` used consistently above.
+- Cycle hazards named where they exist (A4, A5, B3) with the lazy-import pattern already used in this codebase.

--- a/docs/superpowers/specs/2026-09-02-unified-cover-requests-design.md
+++ b/docs/superpowers/specs/2026-09-02-unified-cover-requests-design.md
@@ -1,7 +1,7 @@
 # Unified cover requests + sync-time metadata resolution — Design
 
 **Date:** 2026-09-02
-**Status:** approved (four decisions taken by the user in session, recorded below)
+**Status:** implemented on `feat/unified-cover-requests` (parts A, B) — part C lands on `feat/progress-tracker`. Four decisions taken by the user in session, recorded below.
 **Follows:** `2026-08-26-catalog-cover-ingest-design.md` (covers out of catalog derivation,
 per-card keyed resolution, `cloud_covers` cache) and the unimplemented plan
 `docs/superpowers/plans/2026-08-31-metadata-resolution-trigger.md` on `feat/progress-tracker`.

--- a/docs/superpowers/specs/2026-09-02-unified-cover-requests-design.md
+++ b/docs/superpowers/specs/2026-09-02-unified-cover-requests-design.md
@@ -1,0 +1,340 @@
+# Unified cover requests + sync-time metadata resolution — Design
+
+**Date:** 2026-09-02
+**Status:** approved (four decisions taken by the user in session, recorded below)
+**Follows:** `2026-08-26-catalog-cover-ingest-design.md` (covers out of catalog derivation,
+per-card keyed resolution, `cloud_covers` cache) and the unimplemented plan
+`docs/superpowers/plans/2026-08-31-metadata-resolution-trigger.md` on `feat/progress-tracker`.
+**Motivation:** PR #270 (progress tracker) was written before metadata-only rows, the
+`series.json` index cache and the `cloud_covers` cache existed. It reads covers as
+`row.thumbnail` and never asks for one, and it re-runs the capped hole-patch sweep from its
+own mount to get rows. Both are symptoms of two structural gaps this design closes.
+
+## Decisions (user, 2026-09-02)
+
+1. **Two branches, two PRs.** The shared changes (parts A and B) land on
+   `feat/unified-cover-requests` off `develop`; that branch is then merged into
+   `feat/progress-tracker`, where the tracker is refitted (part C).
+2. **Covers on demand only.** Rows minted by sync-time resolution carry no cover. Every
+   surface that draws a cover asks for it when near the viewport; a first connect costs zero
+   cover downloads.
+3. **Implement the 2026-08-31 resolution plan**: one trigger after each progress sync,
+   awaiting the index refresh, coverage caps removed, view-mount triggers deleted. Sync
+   reports success immediately; resolution continues behind it.
+4. **Bunko ships first**: the `goals.json` per-user fix is rebased onto the deployed 0.3.5
+   line as 0.3.6 and deployed (separate repo; tracked outside this spec).
+
+## The two gaps
+
+### Gap 1 — three cover installers, and a cache nothing installs from
+
+Cover installation has three independent fetch-and-install flows that share only the write
+queue (`cover-persist.ts`):
+
+| Flow                     | Caller                      | Picks candidates from      | Consults cache?          |
+| ------------------------ | --------------------------- | -------------------------- | ------------------------ |
+| `requestCover`           | every card (`cover-claims`) | the rendered volume        | yes — and STOPS on a hit |
+| `installCoversForSeries` | series open, backfill       | the series' rows + listing | yes — skips cached       |
+| `refreshStaleCover`      | backfill                    | stale stamps it computed   | no                       |
+
+Each decides on its own which rows need a cover and fetches on its own. And the cache is
+read-only to all of them: a cover that reached `cloud_covers` while the volume was browsed as
+a placeholder is never copied onto the row the volume later earns by being read. So a
+surface that renders `row.thumbnail` (the tracker) stays blank for exactly the volumes the
+user cares about.
+
+### Gap 2 — metadata resolution is driven by navigation
+
+`patchProgressHoles` runs from three view mounts and from startup, capped at five network
+pulls per run, with a session memo that can poison a series attempted before its index was
+cached. Its cheap phase (`materializeHistoryRows`) resolves rows against the cached
+`series.json` indexes — but the index refresh is fire-and-forget behind the listing, so on a
+network provider the startup sweep runs against a cold cache and materializes five series.
+Measured (2026-08-31): cold cache 5 of 30, warm cache 30 of 30. Convergence depends on how
+the user navigates.
+
+## Part A — one cover request, one resolution ladder
+
+### A1. The entry point
+
+`requestCover(vol, options?)` in `cover-service.ts` is the only way anything asks for a
+cover. It keeps its current contract for surfaces (idempotent, safe on every re-render,
+viewport-gated by the caller) and gains two things: a **return value** and an **option**.
+
+```ts
+type CoverOutcome = 'row' | 'cache' | 'none' | 'skipped' | 'unresolved';
+function requestCover(
+  vol: VolumeMetadata,
+  options?: { stillNear?: () => boolean; refresh?: boolean }
+): Promise<CoverOutcome>;
+```
+
+- `'row'` — the cover is on (or queued for) the volume's `volumes` row.
+- `'cache'` — the cover is in (or queued for) `cloud_covers`; surfaces resolve it by path.
+- `'none'` — positively no cover exists for this volume (no sidecar in the listing).
+- `'skipped'` — the dedupe ledger says nothing is left to do (see A4).
+- `'unresolved'` — every retry produced nothing (transient failure; not blacklisted).
+
+`stillNear` moves from a positional argument into `options` (one call site changes:
+`cover-claims.svelte.ts`). Surfaces keep calling it fire-and-forget; batch callers await it.
+
+### A2. The ladder
+
+`resolveAndDeliver` becomes this sequence. Steps 1 and 2 are new; 3–5 are today's cases 1–4
+unchanged.
+
+1. **Not a target** — `isCoverFetchTarget(vol)` is false (a fresh thumbnail, or a real row
+   the listing shows no sidecar for). Return `'skipped'` (unless `refresh`).
+2. **Cached** — `!vol.thumbnail` and the listing path's cover is in `cloud_covers` for the
+   active account (one keyed presence read, as today):
+   - if `coverBelongsOnRow(vol)` (A3): read the cached row (one keyed `get`, the only place
+     the blob is deliberately read outside the resolver), compare its stored stamp against
+     the listing's current sidecar stamp with `isSidecarStale`; if fresh or stampless, hand it
+     to `installCover(row, cached, cachedStamp, 'fill')` and return `'row'` — **promotion,
+     no network**; if stale, fall through to step 3 (a fetch, which the write queue then
+     routes onto the row).
+   - otherwise return `'cache'`.
+3. **Row exists** — fetch, `installCover` (mode `'overwrite'` iff `vol.thumbnail`), return
+   `'row'` or `'cache'` by `coverBelongsOnRow`.
+4. **Indexed placeholder** — fetch, `installCover`, return `'cache'` (no row is minted; the
+   write queue lands it on a row only if one exists by flush time).
+5. **Bare placeholder** — pull/materialize (batched, as today), fetch, `installCover`,
+   return `'cache'` or `'none'`.
+
+`refresh: true` (the backfill's stale-cover path) skips step 1's target test and step 2's
+cache short-circuit and the ledger: the caller has already decided the cover in hand is stale
+from stamps it computed. Mode is `'overwrite'` when the row carries a thumbnail; a
+cache-resident cover is simply re-fetched and re-put at the same key.
+
+### A3. Where a cover belongs — one predicate
+
+`cover-persist.ts` decides at flush time whether a cover lands on the row or in the cache:
+today's inline rule is "row exists AND (installed OR reading activity) AND `needsDownload`",
+which reduces to _metadata-only row with reading activity_. That rule is extracted as
+
+```ts
+export function coverBelongsOnRow(
+  row: VolumeMetadata | undefined,
+  history: ReadingHistoryEntry | undefined
+): boolean;
+```
+
+in `cover-persist.ts`, used both at flush time (as now) and at request time (step 2's
+promotion decision, and the outcome reported by steps 3–5). One definition, so the promise
+`requestCover` makes and the write the queue performs cannot disagree. `hasReadingActivity`
+(`reading-activity.ts`) stays the sole definition of "read".
+
+### A4. Dedupe records what was delivered
+
+Today's ledger is a `Set` of settled `<scope>\0<uuid>` keys: once a uuid settles it is never
+asked again this session. That is what would make promotion unreachable (settled as `'cache'`
+while browsed, refused when the tracker asks after the volume is read) and what makes the
+backfill's stale refresh a silent no-op for a uuid a card already settled.
+
+The ledger becomes `Map<key, { target: 'row' | 'cache' | 'none'; stamp: string }>` where
+`stamp` is the listing's cover-sidecar stamp the request was made against
+(`cloudThumbnailSize:cloudThumbnailModifiedTime`, empty when unknown). A request is
+redundant — returns `'skipped'` — only when an entry exists for the key, its stamp equals the
+current one, and either its target is `'row'` or `'none'`, or the volume does not
+`coverBelongsOnRow` now. So:
+
+- a re-render of the same card is free (same stamp, same target);
+- a volume settled `'cache'` while browsed is asked again the first time it is rendered as a
+  read volume, and promotes;
+- a changed sidecar (new stamp) is a fresh request, whoever asks;
+- `'unresolved'` never writes the ledger, so the next render retries (today's rule).
+
+In-flight dedupe is unchanged: a second request for a key in flight joins the first run and
+receives its outcome.
+
+### A5. `cloud_covers` rows carry their stamp
+
+`CloudCover` gains optional `cover_size?: number` / `cover_modified?: number` — the same two
+fields, same semantics and guards, as `VolumeMetadata.cover_size/cover_modified` and the
+`series.json` entry stamps. `cover-persist.ts` already holds the stamp at flush time and
+writes it on the cache row too. Promotion (A2 step 2) carries the cached stamp onto the row
+rather than the listing's current one, so a row never claims a freshness it did not fetch.
+Rows cached before this change are stampless, which the staleness rule treats as
+never-stale — the same migration-safety inversion as everywhere else. Non-indexed fields;
+no Dexie schema version bump.
+
+### A6. The series pass becomes a candidate builder
+
+`installCoversForSeries(seriesTitle)` keeps its name, its per-series in-flight dedupe and
+its "dirty re-scan when a joiner arrives" behaviour, and loses its fetching. It:
+
+1. reads the series' rows that `needsDownload` and lack a thumbnail (indexed read, as now);
+2. joins them against the listing's cover sidecars and archive paths (the existing folded
+   `coverKey` join);
+3. decorates each match on a COPY (`cloudProvider`, `cloudPath`, the four `cloudThumbnail*`
+   fields — never stored);
+4. calls `requestCover(decorated)` for each and awaits them all;
+5. returns how many resolved to `'row'` or `'cache'`.
+
+`withoutCachedCovers` is deleted: the ladder's step 2 is the same presence check, and now
+promotes where the pass used to skip. `MAX_CONCURRENT_COVER_INSTALLS` is deleted with the
+worker pool; `cloud-thumbnails.ts`'s 8-slot fetch pool is the only network bound, as it
+already was in practice. The post-fetch "did a download finish meanwhile" re-check moves
+with the fetch into the ladder, where it already exists in the write queue's transactional
+re-read.
+
+### A7. The backfill's stale refresh becomes a request
+
+`refreshStaleCover` in `series-backfill.ts` builds the same decorated copy (with the stale
+sidecar's `size`/`modifiedTime` as the `cloudThumbnail*` stamp and the archive path as
+`cloudPath`), calls `requestCover(copy, { refresh: true })`, awaits it, then
+`flushPendingCoverPersists()` as today. `fetchCloudThumbnail` and `installCover` stop being
+imported there; the module keeps `installCoversForSeries` for its post-write flesh-out.
+
+### A8. Surfaces
+
+`createCoverClaims` (`cover-claims.svelte.ts`) is unchanged apart from the `stillNear`
+argument shape. The five existing surfaces are untouched. The tracker's card adopts it in
+part C.
+
+### A9. What does not change
+
+- `cover-persist.ts`'s queue, batching, overflow policy, transactional re-check and routing
+  (only the predicate is named and the cache stamp is written).
+- `cloud-thumbnails.ts` (fetch pool, timeout, LIFO visible-first grant).
+- `cover-resolver.ts`, `cloud-covers-store.ts`, `cover-viewport.ts`.
+- Cases 3–5's materialization batching and `series.json` publish threading.
+- No row is minted by a cover request that did not mint one before.
+- A promoted cover's `cloud_covers` row is left in place; the 14-day TTL prunes it.
+
+## Part B — resolution runs after every progress sync
+
+### B1. One trigger
+
+`unifiedCloudManager.syncProgress()` — the single funnel every sync caller already goes
+through (startup, the sync button, the reader-exit auto-sync, Drive's post-login and re-auth
+syncs, the cloud view) — starts resolution after `unifiedSyncService.syncProvider` returns
+successfully, and returns its own result without waiting. The resolution promise is retained
+on the manager (`unifiedCloudManager.progressResolution`) so tests and any caller that needs
+the rows can await it.
+
+The call is a **dynamic import** of `hole-patch.ts`: that module already imports the
+manager, and the same one-way graph discipline that `cover-resolver.ts` uses for its key
+watch applies here. A failure to import or run is logged and never reaches the sync result.
+
+`unified-sync-service.ts` stays a byte mover and is not touched.
+
+### B2. Resolution awaits the index refresh
+
+`refreshSeriesIndexesInBackground()` keeps its fire-and-forget entry point and additionally
+retains the `refreshSeriesIndexes(...)` promise it started; `whenSeriesIndexesSettled()`
+returns it (resolved immediately when none is running). `resolveSyncedProgress()` in
+`hole-patch.ts` is:
+
+```
+if (!listingIsLoaded()) return;          // same guard as today; the next sync catches up
+await unifiedCloudManager.whenSeriesIndexesSettled();
+await patchProgressHolesAndEnrich();     // enrich → sweep → enrich, unchanged ordering
+```
+
+Nothing here fetches a listing: resolution reacts to a sync, it never starts I/O the sync
+did not already imply. (`fetchAllCloudVolumes` on Drive can itself trigger a sync after
+login; a resolution that fetched would close that loop.)
+
+### B3. Caps and memos
+
+| Symbol                              | Today | After                                  |
+| ----------------------------------- | ----- | -------------------------------------- |
+| `MAX_HOLE_PATCHES_PER_RUN`          | 5     | removed, with the `limit` option       |
+| `MAX_HISTORY_ROWS_PER_RUN`          | 1000  | removed, with the `limit` option       |
+| `MAX_HISTORY_SERIES_PER_RUN`        | 200   | removed, with the `seriesLimit` option |
+| `attemptedThisSession` (hole-patch) | kept  | removed                                |
+| `unmaterializableThisSession`       | kept  | **kept**                               |
+| `MAX_CONCURRENT_INDEX_DOWNLOADS`    | 4     | kept — bounds speed, not coverage      |
+| `MAX_CONCURRENT_FETCHES` (covers)   | 8     | kept — bounds speed, not coverage      |
+
+`attemptedThisSession` existed to stop a per-mount sweep re-pulling a series absent from the
+cloud. With the trigger per sync and the index refresh awaited, phase 2 only downloads when a
+`series.json` the listing shows is still uncached (a refresh failure) — a series absent from
+the cloud costs `openSeries` zero I/O — so the memo has nothing left to save and its
+poisoning hazard goes with it. `unmaterializableThisSession` is different in kind: it
+records uuids the cached index proved cannot become rows (owned by another series, title
+already taken, no listing for the series), is only ever written after the index was
+consulted, and bounds retries, not coverage. It stays.
+
+Phase 2 still goes through `openSeries`, which installs covers for the series it pulls.
+That is the rare path (an index the listing-wide refresh failed to cache), bounded by the
+same fetch pool; decision 2 is about the common path and is honoured there.
+
+### B4. Database discipline (unchanged, restated)
+
+One `primaryKeys()` on `volumes`, one `series_index` read shared by both phases, one `rw`
+transaction for the whole materialization, no per-volume `get`. Removing the caps must not
+split the transaction into batches. A run with nothing missing performs no DB writes and no
+network.
+
+### B5. View mounts
+
+`patchProgressHolesWhenListingReady` and its `cloudFiles` retry subscription are deleted,
+along with the `onMount` calls in `CatalogView`, `ReadingSpeedView` and (part C) the tracker.
+`init-providers.ts` drops its `void patchProgressHoles()` — the startup sync now does it.
+
+`enrichAllOrphanedVolumes` is not a cloud concern: it copies titles off rows this device
+already has onto reading records that lack them, reads IndexedDB only when the store holds an
+orphan, and is the only path by which a device with no provider ever fixes a legacy record.
+It keeps running on mount in the two views that render per-series groupings from the reading
+record — `ReadingSpeedView` and the tracker — called directly.
+
+## Part C — the tracker on `feat/progress-tracker`
+
+After merging `feat/unified-cover-requests` into `feat/progress-tracker`:
+
+- **`VolumeCard.svelte`** drops its `thumbnail: Blob` prop and adopts
+  `createCoverClaims({ claims: () => [volume], targets: () => [volume] })` with `use:gate` on
+  the image box, exactly as `PlaceholderThumbnail` does. Display is the row's own thumbnail
+  (object URL keyed on content, as now) first, the resolved cache cover second. Every volume
+  the tracker lists has reading activity, so a request from a tracker card resolves to
+  `'row'` — promoted from the cache or fetched — and the card repaints from the row when the
+  write lands; the claim path shows the cached cover in the meantime.
+- **`ProgressTrackerView.svelte`** passes `volume` only (already does) and replaces its
+  hole-patch `onMount` with a direct `enrichAllOrphanedVolumes()`.
+- The 2026-08-31 plan document is superseded by this spec and deleted.
+- Everything else on the branch (goals sync, `completedAt`, the counting rules, the e2e
+  spec) is unchanged. The e2e case "synced progress with no catalog row does not become a
+  wall of empty cards" runs with no provider and stays valid.
+
+## Error handling
+
+Unchanged posture, restated: every path in A and B is best-effort and never rejects into a
+view or a sync result. A cover request that fails transiently retries on the existing
+backoff and reports `'unresolved'`; a promotion whose cache read fails falls through to a
+fetch; a resolution run that throws is logged and the next sync tries again.
+
+## Testing
+
+Unit (Vitest, TDD per task):
+
+- `cover-service`: the ledger (skip / re-ask on target upgrade / re-ask on stamp change /
+  `refresh` bypass), promotion (cache hit + relationship → `installCover` with the cached
+  blob and stamp, no fetch; stale cached stamp → fetch), outcomes per case, `stillNear` in
+  options.
+- `cover-persist`: `coverBelongsOnRow` cases; cache rows written with stamps.
+- `cover-install`: retargeted — same observable behaviours (cached never re-downloaded, read
+  metadata-only row gets the cover on the row, relationship-less row's cover cached,
+  joiner re-scan) expressed through `requestCover`; the concurrency-pinning test deleted.
+- `series-backfill`: stale refresh issues a `refresh: true` request and flushes.
+- `hole-patch` / `history-rows`: cap and session-memo tests deleted; new tests for
+  `resolveSyncedProgress` (awaits the index refresh; no-op without a listing; cold-vs-warm
+  harness asserting N of N), `syncProgress` starting resolution and returning without it.
+- `perf-contracts`: unchanged and must stay green (bytes per cover insert, placeholder
+  regenerations per cover insert).
+- Tracker: `VolumeCard` renders the row thumbnail, then the resolved cover, and requests once
+  gated; the progress-tracker helpers untouched.
+
+Gates: `npm run check` 0 errors, full Vitest, `npm run lint` at the develop baseline,
+`e2e/catalog-distribution.spec.ts` and `e2e/progress-tracker.spec.ts` green on a dedicated
+port. Browser verification of the promote path against the local bunko test instance
+(read a volume as a placeholder, sync, open the tracker, observe the row's cover land
+without a network fetch) if the instance is available.
+
+## Non-goals
+
+- Virtualising the catalog grid; changing cover format or thumbnail generation.
+- Storing cloud fields on rows (`cloudPath` stays a listing decoration).
+- Any change to the sync file formats, `goals.json` included.
+- The reading-history heatmap branch.

--- a/e2e/catalog-distribution.spec.ts
+++ b/e2e/catalog-distribution.spec.ts
@@ -856,7 +856,7 @@ test.describe('Local Folder provider (OPFS)', () => {
     expectCleanConsole(watch);
   });
 
-  test('a progress hole is patched from the cloud series.json after a catalog open', async ({
+  test('a progress hole is patched from the cloud series.json after a progress sync', async ({
     page
   }) => {
     const watch = watchConsole(page);
@@ -894,8 +894,6 @@ test.describe('Local Folder provider (OPFS)', () => {
     await page.evaluate(async () => {
       const { db } = await import('/src/lib/catalog/db.ts');
       await db.series_index.clear();
-      const { resetHolePatchSessionForTests } = await import('/src/lib/metadata/hole-patch.ts');
-      resetHolePatchSessionForTests();
       const { volumesWithTrash, VolumeData } = await import('/src/lib/settings/volume-data.ts');
       volumesWithTrash.set({
         'hole-v1': new VolumeData({
@@ -910,9 +908,15 @@ test.describe('Local Folder provider (OPFS)', () => {
       });
     });
 
-    // The catalog open is what runs the patcher (CatalogView's onMount).
-    await goHash(page, '#/cloud');
-    await goHash(page, '#/');
+    // A progress sync is what runs the resolver — never a view mount. The
+    // same path the sync button, the reader-exit auto-sync and the startup
+    // sync all take; awaited here through the retained promise so the poll
+    // below is about the rows, not about timing.
+    await page.evaluate(async () => {
+      const { unifiedCloudManager } = await import('/src/lib/util/sync/unified-cloud-manager.ts');
+      await unifiedCloudManager.syncProgress({ silent: true });
+      await unifiedCloudManager.progressResolution;
+    });
 
     await expect
       .poll(

--- a/src/lib/catalog/cloud-covers.ts
+++ b/src/lib/catalog/cloud-covers.ts
@@ -76,6 +76,20 @@ export interface CloudCover {
    * comparison.
    */
   cached_at: number;
+  /**
+   * The listing stamp of the cover sidecar this blob was fetched from —
+   * bytes + epoch seconds, the same two fields with the same guards as
+   * `VolumeMetadata.cover_size`/`cover_modified` and the `series.json` entry
+   * stamps. Written by `cover-persist.ts` at flush; read by
+   * `cover-service.ts` when it PROMOTES a cached cover onto a row the user
+   * has since read, so the row inherits the freshness the blob actually has
+   * rather than the listing's current one. Absent on rows cached before this
+   * existed, which the staleness rule treats as never-stale (the
+   * migration-safety inversion everywhere else). Non-indexed: no schema
+   * version bump.
+   */
+  cover_size?: number;
+  cover_modified?: number;
 }
 
 /** Write covers, normalizing paths so every caller lands on the same key. */

--- a/src/lib/catalog/cover-claims.svelte.ts
+++ b/src/lib/catalog/cover-claims.svelte.ts
@@ -286,7 +286,7 @@ export function createCoverClaims(options: CoverClaimsOptions): CoverClaims {
   // nothing, and the list it finally asks for is the one current when it came into view.
   $effect(() => {
     if (!nearViewport) return;
-    for (const vol of fetchTargets) requestCover(vol, stillNear);
+    for (const vol of fetchTargets) void requestCover(vol, { stillNear });
   });
 
   /** Set by {@link gate}. See {@link warnIfUngated} for why this is worth tracking. */

--- a/src/lib/catalog/cover-claims.test.ts
+++ b/src/lib/catalog/cover-claims.test.ts
@@ -157,7 +157,7 @@ describe('every request carries a live still-near-viewport probe', () => {
     await settle();
 
     expect(requestCoverMock).toHaveBeenCalledTimes(1);
-    const probe = requestCoverMock.mock.calls[0][1] as (() => boolean) | undefined;
+    const probe = (requestCoverMock.mock.calls[0][1] as { stillNear?: () => boolean }).stillNear;
     expect(typeof probe).toBe('function');
 
     // jsdom rects are all zeros — indistinguishable from a detached node, so
@@ -194,7 +194,7 @@ describe('the probe survives its own gate node being torn down', () => {
     await settle();
 
     expect(requestCoverMock).toHaveBeenCalledTimes(1);
-    const probe = requestCoverMock.mock.calls[0][1] as () => boolean;
+    const probe = (requestCoverMock.mock.calls[0][1] as { stillNear: () => boolean }).stillNear;
     const node = observer.gates[0].target as HTMLElement;
 
     // Positive control #1: while mounted, the probe reads the LIVE rect —
@@ -235,7 +235,7 @@ describe('a swap between two gated elements', () => {
     observer.gates[0].emit(true);
     await settle();
     expect(requestCoverMock).toHaveBeenCalledTimes(1);
-    const probe = requestCoverMock.mock.calls[0][1] as () => boolean;
+    const probe = (requestCoverMock.mock.calls[0][1] as { stillNear: () => boolean }).stillNear;
     const nodeA = observer.gates[0].target as HTMLElement;
 
     // The `PlaceholderThumbnail` shape: a structurally different element

--- a/src/lib/catalog/cover-install.test.ts
+++ b/src/lib/catalog/cover-install.test.ts
@@ -75,7 +75,8 @@ vi.mock('$lib/catalog/cloud-thumbnails', () => ({
 import { db } from '$lib/catalog/db';
 import { _getCloudCoversForTests } from './cloud-covers';
 import { _resetCoverPersistForTests } from './cover-persist';
-import { MAX_CONCURRENT_COVER_INSTALLS, installCoversForSeries } from './cover-install';
+import { _resetCoverServiceForTests, _setRetryDelaysForTests } from './cover-service';
+import { installCoversForSeries } from './cover-install';
 
 const activeProvider = {
   type: 'webdav',
@@ -85,6 +86,10 @@ const activeProvider = {
 beforeEach(() => {
   vi.clearAllMocks();
   _resetCoverPersistForTests();
+  _resetCoverServiceForTests();
+  // A batch pass awaits the service's outcomes, retry schedule included; a
+  // failing download must not cost this suite the real 10 s.
+  _setRetryDelaysForTests([0, 0]);
   history.set({});
   // `clearAllMocks` clears call history, not implementations: re-pin the
   // per-test defaults so a `mockReturnValue` in one test cannot leak into the next.
@@ -111,6 +116,7 @@ function deferFetch() {
 
 afterEach(async () => {
   _resetCoverPersistForTests(); // cancel a pending timer before it can fire against a cleared table
+  _setRetryDelaysForTests(null);
   await db.volumes.clear();
   await db.cloud_covers.clear();
 });
@@ -247,7 +253,7 @@ describe('installCoversForSeries', () => {
 
   it('never rejects when a download fails', async () => {
     await addRow();
-    fetchCloudThumbnail.mockRejectedValueOnce(new Error('timeout'));
+    fetchCloudThumbnail.mockRejectedValue(new Error('timeout'));
     await expect(installCoversForSeries('Dr Stone')).resolves.toBe(0);
   });
 
@@ -366,6 +372,10 @@ describe('installCoversForSeries', () => {
     expect(await installCoversForSeries('Dr Stone')).toBe(1);
     await addRow(); // back to a coverless row
     await db.cloud_covers.clear(); // ...and its cached cover aged out (see below)
+    // The service's ledger is session-scoped, and the TTL prune runs at boot,
+    // before anything is requested: an aged-out cover is a fresh session's
+    // request. This stands in for that reload.
+    _resetCoverServiceForTests();
 
     expect(await installCoversForSeries('Dr Stone')).toBe(1);
     expect(fetchCloudThumbnail).toHaveBeenCalledTimes(2);
@@ -385,11 +395,25 @@ describe('installCoversForSeries', () => {
   });
 });
 
-describe('concurrency pinning', () => {
-  it('pins the install pass width at 8 — matched to MAX_CONCURRENT_FETCHES, change both together', () => {
-    // The fetch-pool constant has its own pin in cloud-thumbnails' suite
-    // (this file mocks that module, so cross-module equality cannot be
-    // asserted here); the pairing lives in both constants' doc comments.
-    expect(MAX_CONCURRENT_COVER_INSTALLS).toBe(8);
+describe('the pass is a candidate builder over the one cover entry point', () => {
+  // The decoration it builds from the listing is asserted through its effects
+  // above: the fetch receives the listing's cover id/path, and a READ row's
+  // update carries the listing's stamp. What is new here is what the service
+  // does with a candidate the old pass would have skipped.
+  it('promotes a cached cover onto a READ row without fetching', async () => {
+    await addRow();
+    history.set({ 'uuid-1': { progress: 3 } });
+    await db.cloud_covers.put({
+      account_scope: 'webdav:a@b.com',
+      path: 'Dr Stone/Volume 1.cbz',
+      thumbnail: new File(['c'], 'c.webp', { type: 'image/webp' }),
+      width: 10,
+      height: 15,
+      cached_at: Date.now()
+    });
+
+    expect(await installCoversForSeries('Dr Stone')).toBe(1);
+    expect(fetchCloudThumbnail).not.toHaveBeenCalled();
+    expect((await db.volumes.get('uuid-1'))?.thumbnail_width).toBe(10);
   });
 });

--- a/src/lib/catalog/cover-install.ts
+++ b/src/lib/catalog/cover-install.ts
@@ -1,28 +1,18 @@
 import { db } from '$lib/catalog/db';
 import type { VolumeMetadata } from '$lib/types';
-import { fetchCloudThumbnail } from '$lib/catalog/cloud-thumbnails';
-import { activeAccountScope, normalizeCachePath } from '$lib/catalog/cloud-cache-key';
-import { cachedCoverPaths } from '$lib/catalog/cloud-covers';
-import { installCover, flushPendingCoverPersists } from '$lib/catalog/cover-persist';
+import { flushPendingCoverPersists } from '$lib/catalog/cover-persist';
+// Deferred-use import into the module cycle cover-service → series-file-sync →
+// series-backfill → cover-install → cover-service (the backfill imports this
+// module for its post-write flesh-out). Safe for the same reason the existing
+// series-file-sync ↔ series-backfill cycle is: nothing on any side calls
+// across at module-init time, only from inside function bodies.
+import { requestCover, type CoverOutcome } from '$lib/catalog/cover-service';
 import { indexCoverSidecarsByBasePath, type CoverSidecarInfo } from '$lib/catalog/placeholders';
 import { needsDownload } from '$lib/catalog/volume-state';
+import { isArchiveSize } from '$lib/metadata/series-file';
 import { normalizeSeriesKey, normalizeVolumeTitleKey } from '$lib/metadata/series-key';
 import type { CloudFileMetadata } from '$lib/util/sync/provider-interface';
 import { unifiedCloudManager } from '$lib/util/sync/unified-cloud-manager';
-
-/**
- * Cover downloads started at once by one series-open pass. Matched to
- * `fetchCloudThumbnail`'s own `MAX_CONCURRENT_FETCHES` (the real network
- * cap) so a pass can actually fill that pool rather than starving it at
- * half width; the per-worker DB re-check between fetches is a keyed read
- * and costs nothing at this parallelism.
- */
-/**
- * Matched to `MAX_CONCURRENT_FETCHES` in `cloud-thumbnails.ts` (both 8) so the
- * install pass can keep the widened fetch pool fed. Pinned by test — change
- * both together or the narrower one silently becomes the real limit.
- */
-export const MAX_CONCURRENT_COVER_INSTALLS = 8;
 
 /**
  * The running pass per normalized series key, plus whether a joiner arrived
@@ -98,20 +88,20 @@ function foldArchiveIndex(files: Iterable<CloudFileMetadata>): Map<string, strin
  *
  * A materialized row has everything except a picture, and a catalog full of
  * blank cards is worse than a slow one — but the covers are the only heavy part
- * of the series-open path, so they are fetched lazily, bounded, and only for
- * rows that actually lack one. `fetchCloudThumbnail` provides the session cache,
- * the request coalescing, the concurrency cap (`MAX_CONCURRENT_FETCHES`) and the
- * 15 s timeout; this function only decides WHICH rows need one and hands the
- * result to `cover-persist.ts`.
+ * of the series-open path, so they are asked for lazily and only for rows that
+ * actually lack one. This module decides WHICH rows to ask for and from WHICH
+ * listing files; everything after that — the cache check, PROMOTING a cached
+ * cover onto a row the user has read, the fetch (`cloud-thumbnails.ts`'s
+ * 8-slot pool and 15 s timeout), the dedupe, the retry, and where the blob
+ * lands — is `cover-service.ts`'s `requestCover`, the ONE entry point every
+ * cover in the app goes through. There is no second fetch path here any more.
  *
- * It does NOT decide where the blob lands. `installCover` does, for every cover
- * path in the app: onto the `volumes` row only when this device has a
- * RELATIONSHIP with the volume (installed, or with reading activity), and
+ * Where the blob lands is `cover-persist.ts`'s call (`coverBelongsOnRow`):
+ * onto the `volumes` row only for a metadata-only row the user has READ, and
  * otherwise into the `cloud_covers` cache keyed by `[account_scope+path]`. The
  * rows this module targets are the metadata-only ones a mere series OPEN
- * materializes, which typically have neither — so in the common case nothing is
- * written to `volumes` at all, and the card paints from the cache instead
- * (`catalog/index.ts`'s join).
+ * materializes, which usually have no history — so in the common case nothing
+ * is written to `volumes` at all, and the card paints from the cache instead.
  *
  * A row that already has a thumbnail is never touched: it was either measured
  * from the volume's own pages or picked by hand, and the sidecar is a guess by
@@ -138,8 +128,8 @@ function foldArchiveIndex(files: Iterable<CloudFileMetadata>): Map<string, strin
  * never in a loop — a joiner during the re-scan is served the same promise and
  * the series settles rather than chasing a moving listing forever.
  *
- * Returns how many covers were fetched and routed (onto a row or into the
- * cache — `installCover` decides which). Never rejects.
+ * Returns how many requests delivered a cover (onto a row or into the cache —
+ * the service decides which). Never rejects.
  */
 export function installCoversForSeries(seriesTitle: string): Promise<number> {
   const key = normalizeSeriesKey(seriesTitle);
@@ -174,49 +164,6 @@ export function installCoversForSeries(seriesTitle: string): Promise<number> {
   return state.promise;
 }
 
-/** One row this pass could fetch a cover for, with the two listing facts it needs. */
-interface CoverCandidate {
-  row: VolumeMetadata;
-  info: CoverSidecarInfo | undefined;
-  archivePath: string | undefined;
-}
-
-/**
- * Drop the candidates whose cover this account already has in `cloud_covers`.
- *
- * Load-bearing, not an optimization. `!row.thumbnail` used to be a complete
- * "already done" test because this module wrote the blob onto the row; now
- * that a relationship-less row deliberately never carries one, that row stays
- * blank forever and every later pass — every series open, every backfill
- * sweep — would re-download a cover it already holds. This is the same
- * already-have-it check `cover-service.ts` gets for free, because the catalog
- * hands IT rows already decorated with the cached cover
- * (`catalog/index.ts`'s join); this module reads STORED rows, so it has to ask
- * directly. An indexed point read per path, keys only — never the blobs.
- *
- * Defensive by design: any failure to resolve the scope or read the table
- * means "skip nothing", so a broken cache can only cost a redundant fetch, and
- * never a blank card.
- */
-async function withoutCachedCovers(candidates: CoverCandidate[]): Promise<CoverCandidate[]> {
-  try {
-    const scope = activeAccountScope();
-    if (!scope) return candidates;
-    const paths = candidates
-      .map((candidate) => candidate.archivePath)
-      .filter((path): path is string => !!path);
-    const cached = await cachedCoverPaths(scope, paths);
-    if (cached.size === 0) return candidates;
-    return candidates.filter(
-      (candidate) =>
-        !candidate.archivePath || !cached.has(normalizeCachePath(candidate.archivePath))
-    );
-  } catch (error) {
-    console.debug('[cover-install] could not consult the cover cache:', error);
-    return candidates;
-  }
-}
-
 async function runCoverInstall(seriesTitle: string): Promise<number> {
   const provider = unifiedCloudManager.getActiveProvider();
   if (!provider) return 0;
@@ -232,78 +179,39 @@ async function runCoverInstall(seriesTitle: string): Promise<number> {
     .equalsIgnoreCase(seriesTitle)
     .toArray()) as VolumeMetadata[];
 
-  // `equalsIgnoreCase` is case- but not whitespace-insensitive; re-filter by the
-  // catalog's own grouping key, exactly as `materializeSeriesVolumes` does.
-  const candidates = rows
-    .filter(
-      (row) =>
-        normalizeSeriesKey(row.series_title) === seriesKey && needsDownload(row) && !row.thumbnail
-    )
-    .map((row) => {
-      const key = coverKey(row.series_title, row.volume_title);
-      return { row, info: covers.get(key), archivePath: archivePaths.get(key) ?? row.cloudPath };
-    })
-    .filter((candidate) => !!candidate.info);
-  if (candidates.length === 0) return 0;
+  // `equalsIgnoreCase` is case- but not whitespace-insensitive; re-filter by
+  // the catalog's own grouping key, exactly as `materializeSeriesVolumes` does.
+  // Each candidate is decorated on a COPY with the listing's cover sidecar
+  // and archive path — the same shape the catalog hands a card
+  // (`cloudFieldsForRemovedVolume`), so the service sees exactly what it
+  // would see from a render. Nothing here is ever written back to the row.
+  const requests: Promise<CoverOutcome>[] = [];
+  for (const row of rows) {
+    if (normalizeSeriesKey(row.series_title) !== seriesKey) continue;
+    if (!needsDownload(row) || row.thumbnail) continue;
+    const key = coverKey(row.series_title, row.volume_title);
+    const info = covers.get(key);
+    if (!info) continue;
+    const decorated: VolumeMetadata = {
+      ...row,
+      cloudProvider: provider.type,
+      cloudPath: archivePaths.get(key) ?? row.cloudPath,
+      cloudThumbnailFileId: info.fileId,
+      cloudThumbnailPath: info.path,
+      ...(isArchiveSize(info.size) ? { cloudThumbnailSize: info.size } : {}),
+      ...(info.modifiedTime ? { cloudThumbnailModifiedTime: info.modifiedTime } : {})
+    };
+    requests.push(requestCover(decorated));
+  }
+  if (requests.length === 0) return 0;
 
-  const targets = await withoutCachedCovers(candidates);
-  if (targets.length === 0) return 0;
-
-  let installed = 0;
-  let next = 0;
-  const workers = Array.from(
-    { length: Math.min(MAX_CONCURRENT_COVER_INSTALLS, targets.length) },
-    async () => {
-      while (next < targets.length) {
-        const { row, info, archivePath } = targets[next++];
-        if (!info) continue;
-        try {
-          const result = await fetchCloudThumbnail({
-            ...row,
-            cloudProvider: provider.type,
-            cloudThumbnailFileId: info.fileId,
-            cloudThumbnailPath: info.path
-          });
-          if (!result) continue;
-          // Re-check before queueing: a download can finish while this cover is
-          // in flight, which INSTALLS the volume and gives it a thumbnail
-          // measured from its own pages. The snapshot above is that old by the
-          // time the network answers, so the row is re-read and the same two
-          // conditions re-tested. This is only a "don't bother queueing"
-          // filter, not the safety guard it used to be — the flush re-reads and
-          // re-tests both conditions INSIDE its own write transaction, which is
-          // where the write actually happens now.
-          const fresh = (await db.volumes.get(row.volume_uuid)) as VolumeMetadata | undefined;
-          if (!fresh || !needsDownload(fresh) || fresh.thumbnail) continue;
-          // Routed, never written directly. A cover belongs on a `volumes` row
-          // only when the device has a RELATIONSHIP with the volume (installed,
-          // or read); the rows this module targets are metadata-only ones a
-          // mere series OPEN materialized, which usually have neither — and a
-          // blob on such a row is precisely what grew the table to 11,354 rows
-          // / 417MB of thumbnails and made every catalog scan expensive.
-          // `cover-persist.ts` owns that decision for every cover path in the
-          // app; this one used to bypass it with a raw `db.volumes.update`.
-          installCover({ volume_uuid: row.volume_uuid, cloudPath: archivePath }, result, {
-            size: info.size,
-            modifiedTime: info.modifiedTime
-          });
-          installed += 1;
-        } catch (error) {
-          console.debug(
-            `[cover-install] could not install a cover for '${row.volume_title}':`,
-            error
-          );
-        }
-      }
-    }
-  );
-  await Promise.all(workers);
-  // Drain what this pass queued before returning, the same way
-  // `series-backfill.ts`'s `refreshStaleCover` does: this runs inside an
+  const outcomes = await Promise.all(requests);
+  const installed = outcomes.filter((o) => o === 'row' || o === 'cache').length;
+  // Drain what this pass queued before returning: this runs inside an
   // already-async series-open/backfill pass whose caller awaits it, not a UI
   // burst, so "installed" should mean the covers have actually landed. One
-  // forced flush for the whole pass keeps the "one burst, one write per table"
-  // property the queue's write-storm design depends on.
+  // forced flush for the whole pass keeps the "one burst, one write per
+  // table" property the queue's write-storm design depends on.
   if (installed > 0) await flushPendingCoverPersists();
   return installed;
 }

--- a/src/lib/catalog/cover-persist.test.ts
+++ b/src/lib/catalog/cover-persist.test.ts
@@ -75,6 +75,7 @@ import {
   _resetCoverPersistForTests,
   COVER_PERSIST_MAX_BATCH,
   COVER_PERSIST_MAX_PENDING,
+  coverBelongsOnRow,
   flushPendingCoverPersists,
   installCover
 } from './cover-persist';
@@ -635,5 +636,56 @@ describe('cover installs route by relationship', () => {
     const cached = await _getCloudCoversForTests('mega:a@b.com', ['Dr Stone/Volume 01.cbz']);
     expect(cached.get('Dr Stone/Volume 01.cbz')?.width).toBe(250);
     expect(cached.get('Dr Stone/Volume 01.cbz')?.thumbnail).toBeInstanceOf(File);
+  });
+});
+
+describe('coverBelongsOnRow — the one routing predicate', () => {
+  const base = metadataOnlyRow();
+  const installed = { ...base, metadata_only: undefined } as VolumeMetadata;
+
+  it('is false with no row at all', () => {
+    expect(coverBelongsOnRow(undefined, { progress: 3 })).toBe(false);
+  });
+
+  it('is false for an installed row — its cover comes from its own pages', () => {
+    expect(coverBelongsOnRow(installed, { progress: 3 })).toBe(false);
+  });
+
+  it('is false for a metadata-only row with no reading activity', () => {
+    expect(coverBelongsOnRow(base, undefined)).toBe(false);
+    expect(coverBelongsOnRow(base, { progress: 0 })).toBe(false);
+  });
+
+  it('is true for a metadata-only row the user has read, "marked as finished" included', () => {
+    expect(coverBelongsOnRow(base, { progress: 3 })).toBe(true);
+    expect(coverBelongsOnRow(base, { completed: true })).toBe(true);
+  });
+});
+
+describe('cache rows carry the cover stamp', () => {
+  it('writes cover_size/cover_modified on the cloud_covers row, and omits them when unknown', async () => {
+    installCover(
+      { volume_uuid: 'stamped', cloudPath: 'Dr Stone/Stamped.cbz' } as never,
+      coverResult(),
+      { size: 321, modifiedTime: '2026-01-02T00:00:00.000Z' }
+    );
+    installCover(
+      { volume_uuid: 'unstamped', cloudPath: 'Dr Stone/Unstamped.cbz' } as never,
+      coverResult()
+    );
+    await flushPendingCoverPersists();
+
+    const cached = await _getCloudCoversForTests('mega:a@b.com', [
+      'Dr Stone/Stamped.cbz',
+      'Dr Stone/Unstamped.cbz'
+    ]);
+    expect(cached.get('Dr Stone/Stamped.cbz')).toMatchObject({
+      cover_size: 321,
+      cover_modified: Math.floor(Date.parse('2026-01-02T00:00:00.000Z') / 1000)
+    });
+    const unstamped = cached.get('Dr Stone/Unstamped.cbz')!;
+    expect(unstamped).toBeDefined();
+    expect('cover_size' in unstamped).toBe(false);
+    expect('cover_modified' in unstamped).toBe(false);
   });
 });

--- a/src/lib/catalog/cover-persist.ts
+++ b/src/lib/catalog/cover-persist.ts
@@ -381,6 +381,12 @@ async function flushOneBatch(): Promise<void> {
         // download that finished mid-flight — which installs the volume and
         // makes `needsDownload` false — from having its own page-measured
         // thumbnail clobbered by a stale cloud guess.
+        // An INSTALLED row (a download finished while this cover was in
+        // flight) has a thumbnail measured from its own pages: nothing to
+        // write, and nothing worth caching either — the cache exists for
+        // volumes whose pages are NOT here.
+        if (fresh && !needsDownload(fresh)) continue;
+
         if (fresh && coverBelongsOnRow(fresh, readingHistory[volumeUuid])) {
           if (mode === 'fill' && fresh.thumbnail) continue;
 

--- a/src/lib/catalog/cover-persist.ts
+++ b/src/lib/catalog/cover-persist.ts
@@ -1,7 +1,7 @@
 import { get } from 'svelte/store';
 import { db } from '$lib/catalog/db';
 import type { VolumeMetadata } from '$lib/types';
-import { isVolumeInstalled, needsDownload } from '$lib/catalog/volume-state';
+import { needsDownload } from '$lib/catalog/volume-state';
 import { isArchiveSize } from '$lib/metadata/series-file';
 import { isoToEpochSeconds } from '$lib/metadata/cloud-sidecar-stamps';
 import { thumbnailCache } from '$lib/catalog/thumbnail-cache';
@@ -48,9 +48,8 @@ import type { CloudThumbnailResult } from './cloud-thumbnails';
  *    thumbnail installed by older code, or measured from the volume's own
  *    pages, is left alone forever rather than being "healed" by a pull.
  *
- * ROUTING: a cover for a volume with a `volumes` row (installed, or
- * metadata-only because it carries reading history) lands on that row exactly
- * as described above. A cover for a volume with NO row — pure catalog
+ * ROUTING (`coverBelongsOnRow`): a cover for a metadata-only `volumes` row
+ * the user has read lands on that row exactly as described above. A cover for a volume with NO row — pure catalog
  * knowledge, nothing the user has installed or read — is catalog knowledge
  * only, and lands in `cloud_covers` instead (Task 2's blob-only cache table),
  * keyed by the ACTIVE account's scope so two accounts never blend covers.
@@ -227,6 +226,30 @@ function runDrain(): Promise<void> {
 }
 
 /**
+ * Does a cloud cover for this volume belong ON ITS `volumes` ROW?
+ *
+ * Yes exactly when the row exists, its pages are not on this device
+ * (`needsDownload` — an installed volume's thumbnail was measured from its
+ * own pages and is never replaced by a cloud guess) and the user has actually
+ * read it (`hasReadingActivity`). Everything else — no row, a row minted
+ * purely by browsing — is catalog knowledge and belongs in `cloud_covers`.
+ *
+ * ONE definition, consulted at REQUEST time (`cover-service.ts`, to decide
+ * whether a cached cover should be promoted onto the row and what outcome to
+ * report) and at FLUSH time (below, against the row re-read inside the write
+ * transaction). Two copies of this rule would let the service promise a row
+ * the queue then refuses.
+ */
+export function coverBelongsOnRow(
+  row: VolumeMetadata | undefined,
+  history: ReadingHistoryEntry | undefined
+): boolean {
+  if (!row) return false;
+  if (!needsDownload(row)) return false;
+  return hasReadingActivity(history);
+}
+
+/**
  * Queue a fetched cover for background persistence. `volume` is either a
  * bare uuid (an existing caller that knows a row exists, and never has a
  * cloud path to attribute an unrowed cover to) or a volume-shaped object
@@ -351,17 +374,14 @@ async function flushOneBatch(): Promise<void> {
         const [volumeUuid, { result, coverSize, coverModified, mode, cachePath }] = entries[i];
         const fresh = rows[i];
 
-        const hasRelationship =
-          !!fresh && (isVolumeInstalled(fresh) || hasReadingActivity(readingHistory[volumeUuid]));
-
         // A row exists AND the device has a relationship with it — that is
-        // the one case a cover belongs on the row itself. Re-reading and
-        // re-testing `needsDownload` INSIDE the transaction (rather than
-        // trusting the caller's snapshot) is what keeps a download that
-        // finished mid-flight from having its own page-measured thumbnail
-        // clobbered by a stale cloud guess.
-        if (hasRelationship && fresh) {
-          if (!needsDownload(fresh)) continue;
+        // the one case a cover belongs on the row itself
+        // (`coverBelongsOnRow`). Deciding it against the row RE-READ INSIDE
+        // the transaction (rather than the caller's snapshot) is what keeps a
+        // download that finished mid-flight — which installs the volume and
+        // makes `needsDownload` false — from having its own page-measured
+        // thumbnail clobbered by a stale cloud guess.
+        if (fresh && coverBelongsOnRow(fresh, readingHistory[volumeUuid])) {
           if (mode === 'fill' && fresh.thumbnail) continue;
 
           const patch: Partial<VolumeMetadata> = {
@@ -390,7 +410,13 @@ async function flushOneBatch(): Promise<void> {
             thumbnail: result.file,
             width: result.width,
             height: result.height,
-            cached_at: Date.now()
+            cached_at: Date.now(),
+            // The same decision-time stamp a row install records, so a later
+            // PROMOTION of this blob onto a row (`cover-service.ts`) carries
+            // the freshness it actually has. Omitted, never `undefined`, so
+            // the row's shape stays the same as a stampless one.
+            ...(coverSize !== undefined ? { cover_size: coverSize } : {}),
+            ...(coverModified !== undefined ? { cover_modified: coverModified } : {})
           });
         }
       }

--- a/src/lib/catalog/cover-service.publish.test.ts
+++ b/src/lib/catalog/cover-service.publish.test.ts
@@ -111,8 +111,8 @@ const { pullMokuroEntryMock } = vi.hoisted(() => ({
         | undefined
   )
 }));
-vi.mock('$lib/metadata/series-backfill', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('$lib/metadata/series-backfill')>();
+vi.mock('$lib/metadata/sidecar-pull', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/metadata/sidecar-pull')>();
   return {
     ...actual,
     pullMokuroEntry: (...a: Parameters<typeof pullMokuroEntryMock>) => pullMokuroEntryMock(...a)

--- a/src/lib/catalog/cover-service.retry.test.ts
+++ b/src/lib/catalog/cover-service.retry.test.ts
@@ -70,7 +70,9 @@ vi.mock('$lib/catalog/db', () => ({
         if (r) Object.assign(r, patch);
       }
     },
-    transaction: async (_mode: string, _table: unknown, body: () => Promise<unknown>) => body()
+    transaction: async (_mode: string, _table: unknown, body: () => Promise<unknown>) => body(),
+    // The cache short-circuit consults this table; nothing here is ever cached.
+    cloud_covers: { get: async () => undefined }
   }
 }));
 
@@ -192,5 +194,35 @@ describe('retry: a fetch that produces nothing is never permanently settled', ()
     await flushPendingCoverPersists();
     const persisted = (await db.volumes.get('v-1')) as VolumeMetadata;
     expect(persisted.thumbnail_width).toBe(210);
+  });
+});
+
+describe('outcomes: what the returned promise says', () => {
+  it("reports 'unresolved' after the schedule is spent, and a LATER request is not skipped", async () => {
+    await db.volumes.put(row('v-1'));
+    fetchCloudThumbnailMock.mockResolvedValue(null);
+
+    vi.useFakeTimers();
+    const first = requestCover(row('v-1'));
+    await vi.advanceTimersByTimeAsync(11000);
+    await expect(first).resolves.toBe('unresolved');
+
+    // `'unresolved'` never writes the ledger: the very next request runs.
+    fetchCloudThumbnailMock.mockResolvedValue(coverResult());
+    const second = requestCover(row('v-1'));
+    await vi.advanceTimersByTimeAsync(0);
+    await expect(second).resolves.toBe('row');
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("reports 'skipped' for a uuid that has settled, and for a volume that is not a target", async () => {
+    await db.volumes.put(row('v-1'));
+    await expect(requestCover(row('v-1'))).resolves.toBe('row');
+    await expect(requestCover(row('v-1'))).resolves.toBe('skipped');
+    // A real row the listing shows no sidecar for was never a target.
+    await expect(requestCover(row('v-2', { cloudThumbnailFileId: undefined }))).resolves.toBe(
+      'skipped'
+    );
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/catalog/cover-service.test.ts
+++ b/src/lib/catalog/cover-service.test.ts
@@ -647,20 +647,66 @@ describe('concurrency: render-demand mokuro pulls share the backfill semaphore',
 // under `vi.useFakeTimers()`. See `cover-service.retry.test.ts`, which mocks
 // `db` as a plain in-memory stub for exactly that reason.
 
-describe('dedupe: one in-flight/settled request per uuid, whichever surface asks', () => {
-  it('two requestCover calls before settling share ONE fetch, and a call after settling asks nothing further', async () => {
+describe('dedupe: the ledger records what was delivered, keyed by scope + uuid + listing stamp', () => {
+  it('two requests before settling share ONE fetch; a request after settling is skipped', async () => {
     await db.volumes.put(row('v-1'));
     const vol = row('v-1', { cloudThumbnailFileId: 'c-1' });
 
-    requestCover(vol);
-    requestCover(vol); // a second surface's effect, same render pass
-
+    const [a, b] = await Promise.all([requestCover(vol), requestCover(vol)]); // two surfaces, one render pass
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(1);
+    expect(a).toBe('row');
+    expect(b).toBe('row');
     await waitForCover('v-1');
-    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(1);
 
-    requestCover(vol); // settled: must not ask again
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(await requestCover(vol)).toBe('skipped'); // settled: must not ask again
     expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('a changed listing stamp is a fresh request, not a skip', async () => {
+    await db.volumes.put(row('v-1'));
+    const vol = row('v-1', {
+      cloudThumbnailFileId: 'c-1',
+      cloudThumbnailSize: 10,
+      cloudThumbnailModifiedTime: '2026-01-01T00:00:00.000Z'
+    });
+    expect(await requestCover(vol)).toBe('row');
+    const stored = await waitForCover('v-1');
+
+    // The same card, re-rendered after a listing whose sidecar changed: the
+    // row now carries a thumbnail AND a recorded stamp that mismatches.
+    const rerendered = {
+      ...stored,
+      ...vol,
+      thumbnail: stored.thumbnail,
+      cloudThumbnailSize: 11,
+      cloudThumbnailModifiedTime: '2026-02-01T00:00:00.000Z'
+    } as VolumeMetadata;
+    expect(await requestCover(rerendered)).toBe('row');
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('refresh: true bypasses the ledger and the target test, and overwrites the row', async () => {
+    await db.volumes.put(row('v-1'));
+    const vol = row('v-1', { cloudThumbnailFileId: 'c-1' });
+    expect(await requestCover(vol)).toBe('row');
+    const stored = await waitForCover('v-1');
+
+    // Same stamp, same uuid: an ordinary request is redundant now...
+    expect(await requestCover(vol)).toBe('skipped');
+    // ...but a caller that KNOWS the cover is stale gets a fetch and an overwrite.
+    const update = vi.spyOn(db.volumes, 'update');
+    const outcome = await requestCover(
+      { ...stored, ...vol, thumbnail: stored.thumbnail } as VolumeMetadata,
+      { refresh: true }
+    );
+    await flushPendingCoverPersists();
+    expect(outcome).toBe('row');
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(2);
+    expect(update).toHaveBeenCalledWith(
+      'v-1',
+      expect.objectContaining({ thumbnail: expect.any(File) })
+    );
+    update.mockRestore();
   });
 });
 

--- a/src/lib/catalog/cover-service.test.ts
+++ b/src/lib/catalog/cover-service.test.ts
@@ -1081,3 +1081,126 @@ describe('settled is scoped to the account it settled under', () => {
     expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(1);
   });
 });
+
+/**
+ * PROMOTION (ladder step 2): a cover this account already holds in
+ * `cloud_covers` — because the volume was browsed as a placeholder — reaches
+ * the `volumes` row the moment the volume is rendered as one the user has
+ * READ, with no network. Before this, the cache short-circuit settled such a
+ * request and the row stayed blank for exactly the volumes the user cares
+ * about (the progress tracker draws `row.thumbnail`).
+ */
+async function cacheCover(
+  path: string,
+  stamp: { cover_size?: number; cover_modified?: number } = {}
+): Promise<void> {
+  await putCloudCovers([
+    {
+      account_scope: 'mega:a@b.com',
+      path,
+      thumbnail: new File(['cached'], 'cached.webp', { type: 'image/webp' }),
+      width: 100,
+      height: 150,
+      cached_at: Date.now(),
+      ...stamp
+    }
+  ]);
+}
+
+describe('promotion: a cached cover is installed onto a row the user has read, with no fetch', () => {
+  const path = 'One Piece/Volume 01.cbz';
+
+  it('copies the cached blob and ITS stamp onto the row', async () => {
+    await db.volumes.put(row('v-1'));
+    await cacheCover(path, { cover_size: 5, cover_modified: 1700000000 });
+    const update = vi.spyOn(db.volumes, 'update');
+
+    const outcome = await requestCover(
+      row('v-1', {
+        cloudProvider: 'webdav',
+        cloudThumbnailFileId: 'c-1',
+        cloudPath: path,
+        cloudThumbnailSize: 5,
+        cloudThumbnailModifiedTime: '2023-11-14T22:13:20.000Z'
+      })
+    );
+    await flushPendingCoverPersists();
+
+    expect(outcome).toBe('row');
+    expect(fetchCloudThumbnailMock).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith(
+      'v-1',
+      expect.objectContaining({
+        thumbnail: expect.any(File),
+        thumbnail_width: 100,
+        thumbnail_height: 150,
+        cover_size: 5,
+        cover_modified: 1700000000
+      })
+    );
+    update.mockRestore();
+  });
+
+  it('a cached cover with no relationship stays in the cache and is not fetched', async () => {
+    await cacheCover(path);
+    const outcome = await requestCover(
+      indexedPlaceholder('idx-1', { cloudThumbnailFileId: 'c-1', cloudPath: path })
+    );
+    expect(outcome).toBe('cache');
+    expect(fetchCloudThumbnailMock).not.toHaveBeenCalled();
+    expect(await db.volumes.count()).toBe(0);
+  });
+
+  it('a STALE cached cover is fetched fresh instead of promoted', async () => {
+    await db.volumes.put(row('v-1'));
+    await cacheCover(path, { cover_size: 5, cover_modified: 1 });
+    const outcome = await requestCover(
+      row('v-1', {
+        cloudProvider: 'webdav',
+        cloudThumbnailFileId: 'c-1',
+        cloudPath: path,
+        cloudThumbnailSize: 9,
+        cloudThumbnailModifiedTime: '2026-01-01T00:00:00.000Z'
+      })
+    );
+    expect(outcome).toBe('row');
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(1);
+    await waitForCover('v-1');
+  });
+
+  it('a STAMPLESS cached cover (cached by older code) is promoted, never treated as stale', async () => {
+    await db.volumes.put(row('v-1'));
+    await cacheCover(path);
+    const outcome = await requestCover(
+      row('v-1', {
+        cloudProvider: 'webdav',
+        cloudThumbnailFileId: 'c-1',
+        cloudPath: path,
+        cloudThumbnailSize: 9,
+        cloudThumbnailModifiedTime: '2026-01-01T00:00:00.000Z'
+      })
+    );
+    expect(outcome).toBe('row');
+    expect(fetchCloudThumbnailMock).not.toHaveBeenCalled();
+  });
+
+  it('settled as cache while browsed, then promoted the first time it is rendered as read', async () => {
+    // Browsed: an indexed placeholder, no row → fetched once, cached.
+    const browsed = indexedPlaceholder('v-1', { cloudThumbnailFileId: 'c-1', cloudPath: path });
+    expect(await requestCover(browsed)).toBe('cache');
+    await drainQueues();
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(1);
+
+    // Read elsewhere: the row materialized, the history synced — same uuid,
+    // same listing stamp. The ledger must not call this redundant.
+    await db.volumes.put(row('v-1'));
+    const asRead = row('v-1', {
+      cloudProvider: 'webdav',
+      cloudThumbnailFileId: 'c-1',
+      cloudPath: path
+    });
+    expect(await requestCover(asRead)).toBe('row');
+    expect(fetchCloudThumbnailMock).toHaveBeenCalledTimes(1); // promoted, not re-fetched
+    await waitForCover('v-1');
+  });
+});

--- a/src/lib/catalog/cover-service.test.ts
+++ b/src/lib/catalog/cover-service.test.ts
@@ -79,8 +79,8 @@ const { pullMokuroEntryMock } = vi.hoisted(() => ({
         | undefined
   )
 }));
-vi.mock('$lib/metadata/series-backfill', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('$lib/metadata/series-backfill')>();
+vi.mock('$lib/metadata/sidecar-pull', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/metadata/sidecar-pull')>();
   return {
     ...actual,
     pullMokuroEntry: (...a: Parameters<typeof pullMokuroEntryMock>) => pullMokuroEntryMock(...a)

--- a/src/lib/catalog/cover-service.ts
+++ b/src/lib/catalog/cover-service.ts
@@ -25,7 +25,7 @@ import {
   buildNoMetadataEntry,
   pullMokuroEntry,
   releaseBackfillSlot
-} from '$lib/metadata/series-backfill';
+} from '$lib/metadata/sidecar-pull';
 import { scheduleSeriesFileWrite } from '$lib/metadata/series-file-sync';
 import type { CloudFileMetadata } from '$lib/util/sync/provider-interface';
 import { unifiedCloudManager } from '$lib/util/sync/unified-cloud-manager';
@@ -218,9 +218,12 @@ export interface RequestCoverOptions {
   refresh?: boolean;
 }
 
+/** The outcomes a resolution can actually DELIVER — what the ledger records. */
+type DeliveredOutcome = 'row' | 'cache' | 'none';
+
 /** What a settled request delivered, and against which listing stamp. */
 interface SettledCover {
-  target: 'row' | 'cache' | 'none';
+  target: DeliveredOutcome;
   stamp: string;
 }
 
@@ -707,7 +710,7 @@ async function readCachedCover(cloudPath: string): Promise<CloudCover | undefine
 async function resolveAndDeliver(
   vol: VolumeMetadata,
   options: RequestCoverOptions
-): Promise<CoverOutcome | 'retry'> {
+): Promise<DeliveredOutcome | 'retry'> {
   const { stillNear } = options;
 
   // Ladder step 0 — already on disk for this account. Checked BEFORE the

--- a/src/lib/catalog/cover-service.ts
+++ b/src/lib/catalog/cover-service.ts
@@ -4,6 +4,7 @@ import type { VolumeMetadata } from '$lib/types';
 import { volumes as readingHistoryStore } from '$lib/settings/volume-data';
 import type { ReadingHistoryEntry } from '$lib/settings/reading-activity';
 import { isIndexedPlaceholder } from '$lib/catalog/placeholders';
+import { needsDownload } from '$lib/catalog/volume-state';
 import { materializeSeriesVolumes } from '$lib/catalog/materialize';
 import {
   groupSeriesSidecarFiles,
@@ -149,8 +150,13 @@ import { coverBelongsOnRow, installCover } from './cover-persist';
  * burst, few enough that a provider which is down is not asked four times
  * for every cover on screen.
  */
-const RETRY_DELAYS_MS = [2000, 8000];
+let RETRY_DELAYS_MS = [2000, 8000];
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Test hook: shorten (or lengthen) the retry schedule for a suite that awaits batch outcomes. */
+export function _setRetryDelaysForTests(delays: number[] | null): void {
+  RETRY_DELAYS_MS = delays ?? [2000, 8000];
+}
 
 /**
  * How long a case-3/4 batch collects before it materializes.
@@ -760,6 +766,13 @@ async function resolveAndDeliver(
       stillNear
     );
     if (!result) return 'retry'; // transient: worth another attempt
+    // A download can finish during the fetch (up to 15s) and INSTALL the
+    // volume with a thumbnail measured from its own pages. The queue's own
+    // transactional re-read is the guard that keeps that from being
+    // clobbered; this keyed re-read only keeps the OUTCOME honest — nothing
+    // is delivered for a row that no longer wants a cloud cover.
+    const fresh = (await db.volumes.get(vol.volume_uuid)) as VolumeMetadata | undefined;
+    if (fresh && !needsDownload(fresh)) return 'none';
     deliverToRow(
       vol.volume_uuid,
       // The catalog decorates a metadata-only row's copy with the listing's

--- a/src/lib/catalog/cover-service.ts
+++ b/src/lib/catalog/cover-service.ts
@@ -1,5 +1,8 @@
+import { get } from 'svelte/store';
 import { db } from '$lib/catalog/db';
 import type { VolumeMetadata } from '$lib/types';
+import { volumes as readingHistoryStore } from '$lib/settings/volume-data';
+import type { ReadingHistoryEntry } from '$lib/settings/reading-activity';
 import { isIndexedPlaceholder } from '$lib/catalog/placeholders';
 import { materializeSeriesVolumes } from '$lib/catalog/materialize';
 import {
@@ -26,7 +29,7 @@ import { scheduleSeriesFileWrite } from '$lib/metadata/series-file-sync';
 import type { CloudFileMetadata } from '$lib/util/sync/provider-interface';
 import { unifiedCloudManager } from '$lib/util/sync/unified-cloud-manager';
 import { fetchCloudThumbnail, type CloudThumbnailResult } from './cloud-thumbnails';
-import { installCover } from './cover-persist';
+import { coverBelongsOnRow, installCover } from './cover-persist';
 
 /**
  * THE cover service: every surface that draws a cloud cover — the catalog
@@ -107,14 +110,25 @@ import { installCover } from './cover-persist';
  * through to case 3, whose publish attempt is intercepted/skipped server-side
  * the same way every other client write to that file is.
  *
- * DEDUPE: `requestCover` is idempotent and fire-and-forget. A uuid that has
- * already SETTLED (produced a result, however it was delivered) is never
- * asked again this session; a uuid currently IN FLIGHT shares that same
- * request rather than starting a second one. This is now the ONE ledger for
- * every surface — previously each component kept its own, which is exactly
- * how the same volume could be asked for three times by three different
- * views of it. Both halves are keyed by ACCOUNT SCOPE as well as uuid — see
- * {@link ledgerKey}.
+ * DEDUPE: `requestCover` is idempotent and safe to fire on every re-render.
+ * A uuid currently IN FLIGHT shares that request rather than starting a
+ * second one, and a uuid that has SETTLED is asked again only when something
+ * material changed: the ledger records WHAT was delivered (`'row'`,
+ * `'cache'` or `'none'`) and AGAINST WHICH listing stamp, and a request is
+ * redundant only when the same stamp already reached a target at least as
+ * good as the one this volume needs now — see {@link isRedundant}. That is
+ * what lets a cover settled in the cache while the volume was browsed be
+ * promoted onto the row the moment the volume is rendered as read, and what
+ * lets a changed sidecar be re-fetched by whichever surface notices. This is
+ * the ONE ledger for every surface — previously each component kept its own,
+ * which is exactly how the same volume could be asked for three times by
+ * three different views of it. Both halves are keyed by ACCOUNT SCOPE as
+ * well as uuid — see {@link ledgerKey}.
+ *
+ * Every request resolves to a {@link CoverOutcome}. Surfaces ignore it; the
+ * series-open pass and the backfill (`cover-install.ts`,
+ * `series-backfill.ts`) await it, which is how "installed" there means
+ * landed.
  */
 
 /**
@@ -162,10 +176,40 @@ const MATERIALIZE_BATCH_WINDOW_MS = 100;
  */
 export const MATERIALIZE_BATCH_MAX_ENTRIES = 25;
 
-/** Settled ledger keys (see {@link ledgerKey}): produced a result, whichever path delivered it. */
-const settled = new Set<string>();
+/** What a request delivered — or why it did not run. */
+export type CoverOutcome = 'row' | 'cache' | 'none' | 'skipped' | 'unresolved';
+
+export interface RequestCoverOptions {
+  /**
+   * Liveness probe from the requesting surface ("is my element still near
+   * the viewport?", see `isNearViewport`). It changes fetch ORDER only, never
+   * outcome: `cloud-thumbnails.ts` grants its download slots newest-first
+   * among probes that answer yes, and drains the rest as backlog. A deduped
+   * request keeps the FIRST caller's probe — two surfaces rarely
+   * fetch-target one uuid at once, and the cost of a stale probe is one
+   * mis-ranked grant, not a lost cover.
+   */
+  stillNear?: () => boolean;
+  /**
+   * The caller has already decided the cover on hand is STALE, from a stamp
+   * it computed against the listing (`series-backfill.ts`): skip the target
+   * test, the cache short-circuit and the ledger, fetch, and overwrite
+   * whatever is there — on the row if it carries a thumbnail, in
+   * `cloud_covers` at the same key otherwise.
+   */
+  refresh?: boolean;
+}
+
+/** What a settled request delivered, and against which listing stamp. */
+interface SettledCover {
+  target: 'row' | 'cache' | 'none';
+  stamp: string;
+}
+
+/** Ledger key → what was delivered. See {@link ledgerKey} and {@link isRedundant}. */
+const settled = new Map<string, SettledCover>();
 /** Ledger key → the request currently running for it. */
-const inFlight = new Map<string, Promise<void>>();
+const inFlight = new Map<string, Promise<CoverOutcome>>();
 
 /**
  * How both dedupe ledgers are keyed: ACCOUNT SCOPE, then uuid.
@@ -186,6 +230,37 @@ const inFlight = new Map<string, Promise<void>>();
  */
 function ledgerKey(uuid: string): string {
   return `${activeAccountScope() ?? ''}\u0000${uuid}`;
+}
+
+/** The listing's cover-sidecar stamp this request is made against; `':'` when unknown. */
+function listingStamp(vol: VolumeMetadata): string {
+  return `${vol.cloudThumbnailSize ?? ''}:${vol.cloudThumbnailModifiedTime ?? ''}`;
+}
+
+/**
+ * Request-time view of `coverBelongsOnRow`: the volume as the caller holds
+ * it (a placeholder has no row and never wants one here) plus the reading
+ * store. Synchronous — the store is localStorage-backed — so it can gate the
+ * ledger before any I/O.
+ */
+function wantsRow(vol: VolumeMetadata): boolean {
+  if (vol.isPlaceholder) return false;
+  const history = get(readingHistoryStore) as Record<string, ReadingHistoryEntry>;
+  return coverBelongsOnRow(vol, history[vol.volume_uuid]);
+}
+
+/**
+ * Is there nothing left for a request to do? Only when a request for this
+ * key already settled against the SAME listing stamp, and delivered to a
+ * target at least as good as this volume needs now: a `'row'` or `'none'`
+ * answer is final for that stamp; a `'cache'` answer is final only while the
+ * volume still has no relationship — once it is read, the same cover must be
+ * promoted onto its row, so the request runs again.
+ */
+function isRedundant(vol: VolumeMetadata, entry: SettledCover | undefined): boolean {
+  if (!entry || entry.stamp !== listingStamp(vol)) return false;
+  if (entry.target !== 'cache') return true;
+  return !wantsRow(vol);
 }
 
 /**
@@ -602,32 +677,40 @@ async function isCachedCoverPath(cloudPath: string | undefined): Promise<boolean
 }
 
 /**
- * Resolve and deliver `vol`'s cover, whichever decision-tree case applies.
- * Returns whether a cover was actually DELIVERED (or positively confirmed to
- * not exist, from data already in hand) — `true` — versus an attempt that
- * came back empty-handed for a reason that might well be transient (a
- * saturated provider, a timed-out download, a materialize race) — `false`.
- * `fetchCloudThumbnail` never throws; it swallows every network failure into
- * a `null` return (see `cloud-thumbnails.ts`), so `false` here is the ONLY
- * signal the caller has that this attempt produced nothing. The caller
- * (`requestCover`) treats the two identically to a thrown error for retry
- * purposes, but must NOT mark the uuid `settled` on `false` — a "nothing
- * yet" answer settled forever is exactly the "no covers until I navigate
- * away and back" regression this return value exists to prevent.
+ * Resolve and deliver `vol`'s cover, whichever ladder step applies. Returns
+ * the {@link CoverOutcome} it delivered — a cover on the row (`'row'`), in
+ * the cache (`'cache'`), or positively confirmed not to exist from data
+ * already in hand (`'none'`) — versus `'retry'` for an attempt that came
+ * back empty-handed for a reason that might well be transient (a saturated
+ * provider, a timed-out download, a materialize race). `fetchCloudThumbnail`
+ * never throws; it swallows every network failure into a `null` return (see
+ * `cloud-thumbnails.ts`), so `'retry'` here is the ONLY signal the caller has
+ * that this attempt produced nothing. The caller (`requestCover`) treats it
+ * identically to a thrown error for retry purposes, but must NOT write the
+ * ledger for it — a "nothing yet" answer settled forever is exactly the "no
+ * covers until I navigate away and back" regression this return value exists
+ * to prevent.
  */
-async function resolveAndDeliver(vol: VolumeMetadata, stillNear?: () => boolean): Promise<boolean> {
+async function resolveAndDeliver(
+  vol: VolumeMetadata,
+  options: RequestCoverOptions
+): Promise<CoverOutcome | 'retry'> {
+  const { stillNear } = options;
+
   // Already on disk for this account: the surface drawing this volume resolves
-  // it by path (`cover-resolver.ts`) and there is nothing to fetch. Settled, so
-  // the uuid is never asked again this session. Checked BEFORE the case split
-  // on purpose — it is also what keeps a cached cover from materializing a row
-  // for a bare placeholder (cases 3/4), which is exactly what the removed
-  // placeholder decoration used to prevent.
-  if (!vol.thumbnail && (await isCachedCoverPath(vol.cloudPath))) return true;
+  // it by path (`cover-resolver.ts`) and there is nothing to fetch. Checked
+  // BEFORE the case split on purpose — it is also what keeps a cached cover
+  // from materializing a row for a bare placeholder (cases 3/4), which is
+  // exactly what the removed placeholder decoration used to prevent. Skipped
+  // on `refresh`: the caller has decided the cached bytes are the stale ones.
+  if (!options.refresh && !vol.thumbnail && (await isCachedCoverPath(vol.cloudPath))) {
+    return 'cache';
+  }
 
   const existingRow = (await db.volumes.get(vol.volume_uuid)) as VolumeMetadata | undefined;
 
   if (existingRow) {
-    if (!vol.cloudThumbnailFileId) return true; // the row itself claims no cover exists
+    if (!vol.cloudThumbnailFileId) return 'none'; // the row itself claims no cover exists
     const result = await fetchCloudThumbnail(
       {
         ...existingRow,
@@ -637,7 +720,7 @@ async function resolveAndDeliver(vol: VolumeMetadata, stillNear?: () => boolean)
       },
       stillNear
     );
-    if (!result) return false; // transient: worth another attempt
+    if (!result) return 'retry'; // transient: worth another attempt
     deliverToRow(
       vol.volume_uuid,
       // The catalog decorates a metadata-only row's copy with the listing's
@@ -647,12 +730,15 @@ async function resolveAndDeliver(vol: VolumeMetadata, stillNear?: () => boolean)
       vol.cloudPath ?? existingRow.cloudPath,
       result,
       { size: vol.cloudThumbnailSize, modifiedTime: vol.cloudThumbnailModifiedTime },
-      !!vol.thumbnail
+      !!vol.thumbnail || !!options.refresh
     );
-    return true;
+    // The queue routes by the same predicate, against the row it re-reads
+    // inside its transaction; this is the answer it will give for the row
+    // as the caller holds it.
+    return wantsRow(vol) ? 'row' : 'cache';
   }
 
-  if (!vol.isPlaceholder) return true; // no row, not a placeholder: nothing this service can ever do
+  if (!vol.isPlaceholder) return 'none'; // no row, not a placeholder: nothing this service can ever do
 
   if (isIndexedPlaceholder(vol)) {
     // Deliberately NO materialize here — see the module doc's case 2. Fetch
@@ -661,19 +747,19 @@ async function resolveAndDeliver(vol: VolumeMetadata, stillNear?: () => boolean)
     // caches it in `cloud_covers` when an account scope is active, or drops
     // it, never minting a `volumes` row just because this placeholder was
     // rendered.
-    if (!vol.cloudThumbnailFileId) return true; // no row, and genuinely no cover to fetch
+    if (!vol.cloudThumbnailFileId) return 'none'; // no row, and genuinely no cover to fetch
     const result = await fetchCloudThumbnail(vol, stillNear);
-    if (!result) return false; // transient: worth another attempt
+    if (!result) return 'retry'; // transient: worth another attempt
     installCover({ volume_uuid: vol.volume_uuid, cloudPath: vol.cloudPath }, result, {
       size: vol.cloudThumbnailSize,
       modifiedTime: vol.cloudThumbnailModifiedTime
     });
-    return true;
+    return 'cache';
   }
 
   // Bare placeholder: cases 3/4.
   const resolved = await resolveBarePlaceholder(vol);
-  if (!resolved) return false; // the pull (if any) may have failed transiently — worth retrying
+  if (!resolved) return 'retry'; // the pull (if any) may have failed transiently — worth retrying
 
   const { entry, folderTitle, archivePath, cover } = resolved;
   // Queued, not written on its own: the batch this joins issues ONE
@@ -690,9 +776,9 @@ async function resolveAndDeliver(vol: VolumeMetadata, stillNear?: () => boolean)
   // retried — the uuid collision is a fact about the data, not a transient
   // failure, and re-pulling the same sidecar twice more to reach the same
   // verdict is pure waste.
-  if (outcome === 'foreign') return true;
-  if (outcome !== 'materialized') return false;
-  if (!cover) return true; // no cover sidecar anywhere in the listing: genuinely nothing to fetch
+  if (outcome === 'foreign') return 'none';
+  if (outcome !== 'materialized') return 'retry';
+  if (!cover) return 'none'; // no cover sidecar anywhere in the listing: genuinely nothing to fetch
 
   const result = await fetchCloudThumbnail(
     coverFetchTarget(
@@ -704,7 +790,7 @@ async function resolveAndDeliver(vol: VolumeMetadata, stillNear?: () => boolean)
     ),
     stillNear
   );
-  if (!result) return false;
+  if (!result) return 'retry';
   deliverToRow(
     entry.volume_uuid,
     // The row this just minted exists purely because the volume was browsed:
@@ -716,54 +802,53 @@ async function resolveAndDeliver(vol: VolumeMetadata, stillNear?: () => boolean)
     { size: cover.size, modifiedTime: cover.modifiedTime },
     false
   );
-  return true;
+  return 'cache';
 }
 
 /**
- * Ask for `vol`'s cover, once — idempotent and fire-and-forget. Safe to call
- * from every surface's own effect on every re-render; the dedupe below makes
- * a redundant call free.
+ * Ask for `vol`'s cover — THE entry point, for every caller. Idempotent:
+ * safe to call from every surface's own effect on every re-render, since the
+ * dedupe (see the module doc) makes a redundant call free. Resolves to what
+ * was delivered; surfaces ignore that, batch callers await it. Never rejects.
  */
-/**
- * `stillNear` — optional liveness probe from the requesting surface ("is my
- * element still near the viewport?", see `isNearViewport`). It changes fetch
- * ORDER only, never outcome: `cloud-thumbnails.ts` grants its download slots
- * newest-first among probes that answer yes, and drains the rest as backlog.
- * A deduped request keeps the FIRST caller's probe — two surfaces rarely
- * fetch-target one uuid at once, and the cost of a stale probe is one
- * mis-ranked grant, not a lost cover.
- */
-export function requestCover(vol: VolumeMetadata, stillNear?: () => boolean): void {
+export function requestCover(
+  vol: VolumeMetadata,
+  options: RequestCoverOptions = {}
+): Promise<CoverOutcome> {
   const uuid = vol.volume_uuid;
-  if (!uuid) return;
+  if (!uuid) return Promise.resolve('skipped');
   // Bound to the account the request is being made FOR, once: the same
   // request must not settle under one scope and be looked up under another
   // if the user switches accounts while it is in flight.
   const key = ledgerKey(uuid);
-  if (settled.has(key) || inFlight.has(key)) return;
-  if (!isCoverFetchTarget(vol)) return;
+  const running = inFlight.get(key);
+  if (running) return running;
+  if (!options.refresh) {
+    if (isRedundant(vol, settled.get(key))) return Promise.resolve('skipped');
+    if (!isCoverFetchTarget(vol)) return Promise.resolve('skipped');
+  }
 
-  const run = (async () => {
+  const run = (async (): Promise<CoverOutcome> => {
     for (let attempt = 0; ; attempt++) {
       try {
-        const delivered = await resolveAndDeliver(vol, stillNear);
-        if (delivered) {
-          settled.add(key);
-          return;
+        const outcome = await resolveAndDeliver(vol, options);
+        if (outcome !== 'retry') {
+          settled.set(key, { target: outcome, stamp: listingStamp(vol) });
+          return outcome;
         }
         // Produced nothing, but nothing THREW either — a saturated provider
         // or a materialize race, not a confirmed "no cover exists". Retried
         // on the SAME backoff schedule as a thrown error, but deliberately
-        // never marked `settled`: if the whole schedule is spent with no
-        // luck, the uuid is simply left alone (not blacklisted) so the very
-        // next render's `requestCover` call starts a fresh attempt cycle
+        // never written to the ledger: if the whole schedule is spent with
+        // no luck, the uuid is simply left alone (not blacklisted) so the
+        // very next render's `requestCover` call starts a fresh attempt cycle
         // rather than being permanently silenced for the rest of the session.
-        if (attempt >= RETRY_DELAYS_MS.length) return;
+        if (attempt >= RETRY_DELAYS_MS.length) return 'unresolved';
         await sleep(RETRY_DELAYS_MS[attempt]);
       } catch (error) {
         if (attempt >= RETRY_DELAYS_MS.length) {
           console.warn(`Cover request failed for ${vol.volume_title}:`, error);
-          return;
+          return 'unresolved';
         }
         await sleep(RETRY_DELAYS_MS[attempt]);
       }
@@ -774,6 +859,7 @@ export function requestCover(vol: VolumeMetadata, stillNear?: () => boolean): vo
   void run.finally(() => {
     if (inFlight.get(key) === run) inFlight.delete(key);
   });
+  return run;
 }
 
 export { flushPendingCoverPersists } from './cover-persist';

--- a/src/lib/catalog/cover-service.ts
+++ b/src/lib/catalog/cover-service.ts
@@ -18,7 +18,7 @@ import {
 } from '$lib/metadata/series-file';
 import { normalizeSeriesKey, normalizeVolumeTitleKey } from '$lib/metadata/series-key';
 import { activeAccountScope, normalizeCachePath } from '$lib/catalog/cloud-cache-key';
-import { cachedCoverPaths } from '$lib/catalog/cloud-covers';
+import type { CloudCover } from '$lib/catalog/cloud-covers';
 import {
   acquireBackfillSlot,
   buildNoMetadataEntry,
@@ -52,8 +52,20 @@ import { coverBelongsOnRow, installCover } from './cover-persist';
  * it does not license minting a `volumes` row for every volume merely
  * scrolled past in a large cloud catalog (a regression measured at 434 → over
  * 11,000 rows browsing a ~1,000-series library, see `installCover`'s ROUTING
- * doc). `requestCover` resolves exactly one of four cases per volume:
+ * doc). `requestCover` first asks the ACCOUNT'S CACHE, then resolves exactly one
+ * of four cases per volume:
  *
+ * 0. The cover is already in `cloud_covers` for this account (one keyed
+ *    read). If the volume is one the user has READ and whose pages are not
+ *    here (`coverBelongsOnRow`), the cached blob is PROMOTED onto the row —
+ *    handed to `installCover` with the stamp the cache row recorded, no
+ *    network — unless that stamp is stale against the listing's current
+ *    sidecar, in which case the ladder continues to a fetch. Otherwise the
+ *    surface drawing the volume resolves the cache by path itself
+ *    (`cover-resolver.ts`) and nothing more is done. This is what lets a
+ *    cover fetched while a volume was merely browsed reach the row that
+ *    volume earns by being read — the progress tracker draws
+ *    `row.thumbnail` and nothing else.
  * 1. A DB row already exists (installed, or metadata-only) → hand the cover
  *    to `installCover` for that row, WITH the listing's cloud path: a
  *    metadata-only row minted by browsing or by a series open has no
@@ -632,47 +644,42 @@ function deliverToRow(
 }
 
 /**
- * Is this path's cover ALREADY in the account's `cloud_covers` cache?
+ * The cached cover row for `cloudPath` under the active account — BLOB
+ * INCLUDED, deliberately: this is the one read in the app that wants the
+ * bytes, because it may be about to copy them onto a `volumes` row
+ * (promotion, ladder step 0). Everything else that asks "is it cached?"
+ * stays keys-only (`cachedCoverPaths`). One keyed `get` on the
+ * `[account_scope+path]` primary key, cost independent of table size.
  *
  * THE RE-DOWNLOAD GUARD. Until covers were cut out of catalog derivation, a
  * cached cover suppressed its own re-fetch by accident: `generatePlaceholders`
  * stamped the cached blob onto the placeholder, so `isCoverFetchTarget` saw a
  * `thumbnail` and said no. With that decoration gone, every cloud volume reads
- * as a fetch target on a cold page load — the `settled` ledger is
- * session-scoped — and a library of ~4,347 covers would re-download the lot
- * from the network on every reload, trading the freeze for a network storm.
+ * as a fetch target on a cold page load — the ledger is session-scoped — and
+ * a library of ~4,347 covers would re-download the lot from the network on
+ * every reload, trading the freeze for a network storm. Asked at REQUEST time
+ * rather than read off the keys-only store: the store fills asynchronously
+ * behind the cloud listing, while cards call `requestCover` the moment that
+ * same listing renders them — a gate read off it would be empty for the first
+ * screenful and let exactly the storm it exists to stop through.
  *
- * KEYS ONLY, and asked at REQUEST time rather than read off the keys-only
- * store. Same primitive `cover-install.ts` filters its own candidates with
- * (`withoutCachedCovers`), so the two paths cannot disagree about what counts
- * as already-cached. The store was the obvious alternative and is the wrong
- * tool here: it fills asynchronously behind the cloud listing, while cards
- * call `requestCover` the moment that same listing renders them — a gate read
- * off it would be empty for the first screenful and let exactly the storm it
- * exists to stop through. This costs one keyed presence read per requested
- * volume, no blobs, independent of table size.
+ * NOT A STALENESS CHECK on its own: for a relationship-less volume the
+ * answer is "cached, done" whatever the stamp says (a stale cache-resident
+ * cover is the backfill's `refresh` request to fix). Only a promotion
+ * compares stamps, because only a promotion writes the blob somewhere new.
  *
- * NOT A STALENESS CHECK, and it must never become one: it is consulted only
- * where the alternative is a FILL (`!vol.thumbnail`). The self-heal branch —
- * a persisted row whose own `cover_size`/`cover_modified` mismatch the
- * listing's current sidecar stamp — carries a `thumbnail` and never reaches
- * here, so an overwrite still fetches. (Nor can the two collide: a row with a
- * thumbnail has its covers routed onto the row itself, never into
- * `cloud_covers` — see `cover-persist.ts`'s ROUTING doc.)
+ * `undefined` = not cached; `'error'` = the cache could not be consulted,
+ * which the caller treats as a miss (fetching is the safe answer, exactly as
+ * the old keys-only guard decided it).
  */
-async function isCachedCoverPath(cloudPath: string | undefined): Promise<boolean> {
-  if (!cloudPath) return false;
+async function readCachedCover(cloudPath: string): Promise<CloudCover | undefined | 'error'> {
   try {
     const scope = activeAccountScope();
-    if (!scope) return false;
-    const normalized = normalizeCachePath(cloudPath);
-    const cached = await cachedCoverPaths(scope, [normalized]);
-    return cached.has(normalized);
+    if (!scope) return undefined;
+    return await db.cloud_covers.get([scope, normalizeCachePath(cloudPath)]);
   } catch (error) {
-    // A cache we cannot read is not a reason to refuse a cover; fetching is
-    // the safe answer, exactly as `withoutCachedCovers` decides it.
     console.debug('[cover-service] could not consult the cover cache:', error);
-    return false;
+    return 'error';
   }
 }
 
@@ -697,14 +704,46 @@ async function resolveAndDeliver(
 ): Promise<CoverOutcome | 'retry'> {
   const { stillNear } = options;
 
-  // Already on disk for this account: the surface drawing this volume resolves
-  // it by path (`cover-resolver.ts`) and there is nothing to fetch. Checked
-  // BEFORE the case split on purpose — it is also what keeps a cached cover
-  // from materializing a row for a bare placeholder (cases 3/4), which is
-  // exactly what the removed placeholder decoration used to prevent. Skipped
-  // on `refresh`: the caller has decided the cached bytes are the stale ones.
-  if (!options.refresh && !vol.thumbnail && (await isCachedCoverPath(vol.cloudPath))) {
-    return 'cache';
+  // Ladder step 0 — already on disk for this account. Checked BEFORE the
+  // case split on purpose: it is also what keeps a cached cover from
+  // materializing a row for a bare placeholder (cases 3/4), which is exactly
+  // what the removed placeholder decoration used to prevent. Skipped on
+  // `refresh`: the caller has decided the cached bytes are the stale ones.
+  if (!options.refresh && !vol.thumbnail && vol.cloudPath) {
+    const cached = await readCachedCover(vol.cloudPath);
+    if (cached && cached !== 'error') {
+      // No relationship: the surface drawing this volume resolves the cache
+      // by path (`cover-resolver.ts`) and there is nothing to fetch.
+      if (!wantsRow(vol)) return 'cache';
+      const cachedStamp = { size: cached.cover_size, modified: cached.cover_modified };
+      const currentStamp = {
+        size: vol.cloudThumbnailSize,
+        modified: isoToEpochSeconds(vol.cloudThumbnailModifiedTime)
+      };
+      if (!isSidecarStale(cachedStamp, currentStamp)) {
+        // PROMOTION: the blob this account already holds, carrying the
+        // freshness it actually has (the cache row's own stamp, never the
+        // listing's current one — a stampless row cached by older code
+        // promotes stampless, the same never-stale inversion as everywhere).
+        // `installCover` takes the stamp as (bytes, ISO); the cached epoch
+        // seconds go back through ISO so the row records the same seconds.
+        installCover(
+          { volume_uuid: vol.volume_uuid, cloudPath: vol.cloudPath },
+          { file: cached.thumbnail, width: cached.width, height: cached.height },
+          {
+            size: cached.cover_size,
+            modifiedTime:
+              cached.cover_modified !== undefined
+                ? new Date(cached.cover_modified * 1000).toISOString()
+                : undefined
+          },
+          'fill'
+        );
+        return 'row';
+      }
+      // Stale: fall through to a fetch, which the queue routes onto the row.
+    }
+    // `'error'` and a miss both fall through: fetching is the safe answer.
   }
 
   const existingRow = (await db.volumes.get(vol.volume_uuid)) as VolumeMetadata | undefined;

--- a/src/lib/components/__tests__/CatalogItem.test.ts
+++ b/src/lib/components/__tests__/CatalogItem.test.ts
@@ -1813,7 +1813,7 @@ describe('CatalogItem draws the covers that arrive after it mounted', () => {
     expect(requestCoverMock).toHaveBeenCalledWith(
       expect.objectContaining({ volume_uuid: 'c-2' }),
       // The still-near-viewport probe every request now carries.
-      expect.any(Function)
+      expect.objectContaining({ stillNear: expect.any(Function) })
     );
 
     updateCatalogSetting('horizontalStep', 12);
@@ -1823,7 +1823,7 @@ describe('CatalogItem draws the covers that arrive after it mounted', () => {
       // harmless — the card is not expected to suppress it itself.
       expect(requestCoverMock).toHaveBeenCalledWith(
         expect.objectContaining({ volume_uuid: 'c-2' }),
-        expect.any(Function)
+        expect.objectContaining({ stillNear: expect.any(Function) })
       );
       // Arity matters here: with the probe argument, a volume-only matcher
       // would "not match" every call vacuously.

--- a/src/lib/components/__tests__/PlaceholderThumbnail.test.ts
+++ b/src/lib/components/__tests__/PlaceholderThumbnail.test.ts
@@ -93,7 +93,7 @@ describe('PlaceholderThumbnail cover lifetime', () => {
 
     expect(requestCover).toHaveBeenCalledWith(
       expect.objectContaining({ volume_uuid: 'c-3' }),
-      expect.any(Function)
+      expect.objectContaining({ stillNear: expect.any(Function) })
     );
   });
 
@@ -211,7 +211,7 @@ describe('PlaceholderThumbnail asks for a cover only once it is near the viewpor
     expect(requestCover).toHaveBeenCalledTimes(1);
     expect(requestCover).toHaveBeenCalledWith(
       expect.objectContaining({ volume_uuid: 'near-1' }),
-      expect.any(Function)
+      expect.objectContaining({ stillNear: expect.any(Function) })
     );
   });
 

--- a/src/lib/metadata/history-rows.test.ts
+++ b/src/lib/metadata/history-rows.test.ts
@@ -63,12 +63,7 @@ vi.mock('$lib/util/sync/unified-cloud-manager', () => ({
 
 import { db } from '$lib/catalog/db';
 import { unifiedCloudManager } from '$lib/util/sync/unified-cloud-manager';
-import {
-  materializeHistoryRows,
-  resetHistoryRowsSessionForTests,
-  MAX_HISTORY_ROWS_PER_RUN,
-  MAX_HISTORY_SERIES_PER_RUN
-} from './history-rows';
+import { materializeHistoryRows, resetHistoryRowsSessionForTests } from './history-rows';
 
 function indexVolume(uuid: string, title: string, over: Partial<SeriesFileVolume> = {}) {
   return {
@@ -259,7 +254,11 @@ describe('materializeHistoryRows', () => {
   });
 
   describe('when a planned uuid cannot become a row', () => {
-    it('does not let a series with no cloud listing starve a materializable one behind it', async () => {
+    // There is no per-run cap any more, so nothing can be STARVED — what is
+    // left to prove is that a uuid the cached index has shown cannot become
+    // a row stops costing work on later runs (`unmaterializableThisSession`),
+    // while everything else in the same run still lands.
+    it('remembers a series with no cloud listing, and stops paying its listing lookup', async () => {
       // The concrete case: an index cached while a DIFFERENT provider was
       // connected. `runRefresh` deliberately never cleans those, so the record
       // is in `series_index` forever while `cloudVolumeTitlesFor` reports an
@@ -267,30 +266,28 @@ describe('materializeHistoryRows', () => {
       await seedSeries('Aaa Stale', [indexVolume('uuid-stale', 'Aaa Stale v01')]);
       listing.delete('Aaa Stale');
       await seedSeries('Bbb Live', [indexVolume('uuid-live', 'Bbb Live v01')]);
-
-      // Iteration order over the progress store is stable and puts the dead
-      // series first, which is the whole mechanism: with one series slot per
-      // run, it took that slot on every run and 'Bbb Live' never got one.
       progressStore.set({
         'uuid-stale': { completed: true },
         'uuid-live': { completed: true }
       });
+      const listingLookups = vi.spyOn(unifiedCloudManager, 'cloudVolumeTitlesFor');
 
-      await expect(materializeHistoryRows({ seriesLimit: 1 })).resolves.toBe(0);
-      expect(await db.volumes.get('uuid-live')).toBeUndefined();
-
-      await expect(materializeHistoryRows({ seriesLimit: 1 })).resolves.toBe(1);
+      await expect(materializeHistoryRows()).resolves.toBe(1);
       expect(await db.volumes.get('uuid-live')).toBeDefined();
-      // And the dead one is still dead — this is a scheduling fix, not a
-      // licence to write a row the listing gate refused.
+      // Not a licence to write a row the listing gate refused.
       expect(await db.volumes.get('uuid-stale')).toBeUndefined();
+      expect(listingLookups).toHaveBeenCalledWith('Aaa Stale');
+
+      listingLookups.mockClear();
+      await expect(materializeHistoryRows()).resolves.toBe(0);
+      expect(listingLookups).not.toHaveBeenCalledWith('Aaa Stale');
     });
 
-    it('does not let a uuid `materializeSeriesVolumes` skips starve a writable one behind it', async () => {
+    it('remembers a uuid `materializeSeriesVolumes` skips, and still writes the one beside it', async () => {
       // Rule 2: a local row already owns 'Dr Stone v01' under a different uuid
       // (a re-OCR elsewhere, or a path-derived placeholder). The index entry is
-      // skipped every run — it survives the listing gate, so this is the OTHER
-      // half of the problem: the row cap is spent, not the series cap.
+      // skipped every run — it survives the listing gate, so it is the OTHER
+      // way a planned uuid ends up row-less.
       await seedSeries('Dr Stone', [
         indexVolume('uuid-shadowed', 'Dr Stone v01'),
         indexVolume('uuid-writable', 'Dr Stone v02')
@@ -306,17 +303,21 @@ describe('materializeHistoryRows', () => {
         page_char_counts: [],
         metadata_only: true
       } as VolumeMetadata);
-
       progressStore.set({
         'uuid-shadowed': { completed: true },
         'uuid-writable': { completed: true }
       });
 
-      await expect(materializeHistoryRows({ limit: 1 })).resolves.toBe(0);
-      expect(await db.volumes.get('uuid-writable')).toBeUndefined();
-
-      await expect(materializeHistoryRows({ limit: 1 })).resolves.toBe(1);
+      await expect(materializeHistoryRows()).resolves.toBe(1);
       expect(await db.volumes.get('uuid-writable')).toBeDefined();
+      expect(await db.volumes.get('uuid-shadowed')).toBeUndefined();
+
+      // The shadowed uuid is not re-planned: a second run has nothing to do
+      // and opens no write transaction at all.
+      const counts = await countIdbOps(async () => {
+        await expect(materializeHistoryRows()).resolves.toBe(0);
+      });
+      expect(counts['tx.volumes.readwrite'] ?? 0).toBe(0);
     });
   });
 
@@ -385,33 +386,35 @@ describe('materializeHistoryRows', () => {
       expect(counts['volumes.bytes'] ?? 0).toBe(0);
     });
 
-    it('honours the per-run cap and drains across runs', async () => {
-      await expect(materializeHistoryRows({ limit: 40 })).resolves.toBe(40);
-      expect(await db.volumes.count()).toBe(40 + 20);
+    it('has no per-run cap: more history than the old caps allowed drains in ONE run and ONE transaction', async () => {
+      // The removed caps were 1,000 rows and 200 series per run. Add enough
+      // history to exceed both on top of the fixture above.
+      const EXTRA_SERIES = 200;
+      const READ_PER_EXTRA = 5;
+      let progress: Record<string, unknown> = {};
+      progressStore.subscribe((v) => (progress = { ...v }))();
+      for (let s = 0; s < EXTRA_SERIES; s++) {
+        const seriesTitle = `Extra ${String(s).padStart(3, '0')}`;
+        const volumes: SeriesFileVolume[] = [];
+        for (let v = 0; v < READ_PER_EXTRA; v++) {
+          const uuid = `x${s}-v${v}`;
+          volumes.push(indexVolume(uuid, `${seriesTitle} v${v}`));
+          progress[uuid] = { completed: true };
+        }
+        await seedSeries(seriesTitle, volumes);
+      }
+      progressStore.set(progress);
+      const expected = SERIES * READ_PER_SERIES + EXTRA_SERIES * READ_PER_EXTRA;
+      expect(expected).toBeGreaterThan(1000);
+      expect(SERIES + EXTRA_SERIES).toBeGreaterThan(200);
 
-      await expect(materializeHistoryRows({ limit: 40 })).resolves.toBe(40);
-      expect(await db.volumes.count()).toBe(80 + 20);
-
-      // Left to itself the default cap swallows the rest in one go: a sweep
-      // that needed twenty page loads to finish would leave the stats views
-      // wrong for most of them.
-      expect(MAX_HISTORY_ROWS_PER_RUN).toBeGreaterThanOrEqual(SERIES * READ_PER_SERIES);
-      await expect(materializeHistoryRows()).resolves.toBe(SERIES * READ_PER_SERIES - 80);
+      let created = 0;
+      const counts = await countIdbOps(async () => {
+        created = await materializeHistoryRows();
+      });
+      expect(created).toBe(expected);
+      expect(counts['tx.volumes.readwrite']).toBe(1);
       await expect(materializeHistoryRows()).resolves.toBe(0);
-    });
-
-    it('bounds the SERIES a run touches, not just the rows it writes', async () => {
-      // Each new series costs a `cloudVolumeTitlesFor` lookup, which on every
-      // provider but Google Drive walks the whole cloud listing — twice. The
-      // row cap cannot bound that; this one does.
-      const listingLookups = vi.spyOn(unifiedCloudManager, 'cloudVolumeTitlesFor');
-
-      await expect(materializeHistoryRows({ seriesLimit: 3 })).resolves.toBe(3 * READ_PER_SERIES);
-      expect(listingLookups).toHaveBeenCalledTimes(3);
-
-      // Untouched series are not lost — the next run takes the next three.
-      await expect(materializeHistoryRows({ seriesLimit: 3 })).resolves.toBe(3 * READ_PER_SERIES);
-      expect(MAX_HISTORY_SERIES_PER_RUN).toBeGreaterThanOrEqual(SERIES);
     });
   });
 });

--- a/src/lib/metadata/history-rows.ts
+++ b/src/lib/metadata/history-rows.ts
@@ -8,38 +8,6 @@ import { listSeriesIndexes, type SeriesIndexRecord } from './series-index';
 import { normalizeSeriesKey } from './series-key';
 import type { SeriesFileVolume } from './series-file';
 
-/**
- * Volumes given a row per run.
- *
- * The set this sweep works from is bounded by the user's own reading history,
- * not by the size of their library: a 12,520-file cloud account with 2,075
- * progress entries yields at most 2,075 candidates, and the ~726 of those with
- * genuine activity is the number that matters. So the cap is generous enough
- * that a real library drains in ONE run — a sweep that needed twenty page
- * loads to finish would leave the stats views wrong for most of them — while
- * still refusing to be unbounded: a pathological store drains over successive
- * runs instead of building one enormous transaction.
- */
-export const MAX_HISTORY_ROWS_PER_RUN = 1000;
-
-/**
- * Series touched per run.
- *
- * A SECOND cap, because the two costs are not the same shape. Rows are cheap
- * and local; each series costs a `cloudVolumeTitlesFor` lookup, and that is
- * the one genuinely superlinear thing this sweep does — only the Google Drive
- * cache answers it from a Map (`currentCache.get(seriesTitle)`); the MEGA,
- * OneDrive and local-folder caches all walk the WHOLE listing per call, twice
- * (`resolveCloudFolderTitle` then `cloudVolumeTitles`). On a 12,520-file
- * account that is ~25k string comparisons per series. 200 series bounds the
- * first sweep at ~5M comparisons — tens of milliseconds, once, off the render
- * path — where the row cap alone would have allowed five times that. A real
- * library is nowhere near it (726 read volumes spread over well under 200
- * series), so this only ever bites the pathological case, and even then it
- * drains over successive runs.
- */
-export const MAX_HISTORY_SERIES_PER_RUN = 200;
-
 /** The fields this module reads off a reading-state entry, structurally. */
 type ProgressRecord = ReadingHistoryEntry & {
   deletedOn?: string;
@@ -49,17 +17,17 @@ type ProgressRecord = ReadingHistoryEntry & {
 /**
  * Uuids a run PLANNED and still failed to give a row.
  *
- * WHY THIS EXISTS. Both caps are spent at PLAN time, but a planned uuid is not
- * a written row: `materializeSeriesVolumes` skips an entry whose uuid belongs
- * to another series (rule 0) or whose title a local row already owns (rule 2),
- * and a whole batch is dropped before the transaction when
- * `cloudVolumeTitlesFor` reports an empty listing for its series — the state of
- * every index cached from a provider that is no longer the connected one, which
- * `runRefresh` deliberately never cleans. Iteration order over the progress
- * store is stable, so without this set those uuids are re-planned in the same
- * order on every run, spend the same slots, and everything behind them is
- * starved FOREVER: 200 such series is all it takes to make the series cap
- * unreachable for a series that WOULD materialize.
+ * WHY THIS EXISTS. A planned uuid is not a written row:
+ * `materializeSeriesVolumes` skips an entry whose uuid belongs to another
+ * series (rule 0) or whose title a local row already owns (rule 2), and a whole
+ * batch is dropped before the transaction when `cloudVolumeTitlesFor` reports
+ * an empty listing for its series — the state of every index cached from a
+ * provider that is no longer the connected one, which `runRefresh`
+ * deliberately never cleans. Without this set those uuids are re-planned on
+ * every run — one listing lookup per series and one indexed read per batch,
+ * on every sync, forever, for rows that can never be written. Not a coverage
+ * cap: it only ever holds uuids the cached index has PROVED cannot become
+ * rows, and it is written only after that index was consulted.
  *
  * SESSION-SCOPED, cleared only by a page load, matching the same contract
  * `hole-patch.ts` uses for its own attempt memory. The trade-off is deliberate:
@@ -134,14 +102,14 @@ export function resetHistoryRowsSessionForTests(): void {
  * broadcast and therefore ONE catalog re-derive rather than N. Zero network:
  * everything it reads is already on the device. A run with nothing to do opens
  * no write transaction at all, and a readwrite transaction that writes nothing
- * broadcasts nothing (both verified).
+ * broadcasts nothing (both verified). There is no per-run cap on rows or
+ * series: the set is bounded by the reading history, and one run drains it
+ * (the transaction must not be split into batches to reintroduce one).
  *
  * Best-effort throughout: never rejects, never surfaces UI. Returns the number
  * of rows created or filled.
  */
 export async function materializeHistoryRows(options?: {
-  limit?: number;
-  seriesLimit?: number;
   /**
    * How to read the cached `series.json` indexes. Defaults to
    * `listSeriesIndexes`; `patchProgressHoles` passes a lazy, memoized reader so
@@ -150,8 +118,6 @@ export async function materializeHistoryRows(options?: {
    */
   readIndexes?: () => Promise<SeriesIndexRecord[]>;
 }): Promise<number> {
-  const limit = options?.limit ?? MAX_HISTORY_ROWS_PER_RUN;
-  const seriesLimit = options?.seriesLimit ?? MAX_HISTORY_SERIES_PER_RUN;
   const readIndexes = options?.readIndexes ?? listSeriesIndexes;
 
   try {
@@ -200,23 +166,20 @@ export async function materializeHistoryRows(options?: {
     if (candidates.size === 0) return 0;
 
     // 4. Group the wanted uuids by the series that will materialize them.
+    //    UNCAPPED: the set is bounded by the user's own reading history, not
+    //    by the library, and one run drains it entirely — a sweep that
+    //    needed several syncs to finish would leave the stats views and the
+    //    tracker wrong until then. What is planned is not yet a row, so
+    //    whatever is still row-less when this run ends is remembered as
+    //    unmaterializable and never planned again. See
+    //    `unmaterializableThisSession`.
     const plan = new Map<string, { record: SeriesIndexRecord; uuids: Set<string> }>();
-    // Every uuid that SPENT a slot. Both caps are charged here, at plan time,
-    // but a plan entry is not a row — so whatever is still row-less when this
-    // run ends is remembered as unmaterializable and never charged again. See
-    // `unmaterializableThisSession`.
     const plannedUuids = new Set<string>();
     for (const [uuid, storedTitle] of wanted) {
-      if (plannedUuids.size >= limit) break;
       const record = pickSeriesFor(candidates.get(uuid), storedTitle);
       if (!record) continue;
       let slot = plan.get(record.series_key);
       if (!slot) {
-        // A series already in the plan costs nothing more; a NEW one costs a
-        // listing lookup, which is what `seriesLimit` bounds. Skipping the
-        // uuid rather than breaking out lets the series already planned keep
-        // filling, and the skipped ones are picked up by the next run.
-        if (plan.size >= seriesLimit) continue;
         slot = { record, uuids: new Set() };
         plan.set(record.series_key, slot);
       }

--- a/src/lib/metadata/hole-patch.integration.test.ts
+++ b/src/lib/metadata/hole-patch.integration.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { countIdbOps } from '$lib/catalog/__tests__/idb-op-counter';
+import type { SeriesFile, SeriesFileVolume } from './series-file';
+import type { SeriesIndexRecord } from './series-index';
+
+/**
+ * THE COLD-CACHE HARNESS — the measurement that motivated moving resolution
+ * out of the views (2026-08-31): against a cold `series_index` the old
+ * startup sweep materialized 5 of 30 synced series; against a warm one, 30
+ * of 30. `resolveSyncedProgress` awaits the index refresh the listing
+ * started, so the cache is warm by the time phase 1 runs, and phase 1 is
+ * uncapped — one run must resolve every series, with no network pull left
+ * for phase 2.
+ *
+ * Real Dexie over fake-indexeddb and the REAL `materializeHistoryRows`, so
+ * the assertion is about rows that actually landed. The index refresh is the
+ * one controllable seam: releasing it is what lands the 30 `series.json`
+ * records, exactly as the listing-wide refresh does.
+ */
+vi.mock('$lib/catalog/db', async () => {
+  const { CatalogDexieV3 } =
+    await vi.importActual<typeof import('$lib/catalog/db-v3')>('$lib/catalog/db-v3');
+  return { db: new CatalogDexieV3('mokuro_v3_hole_patch_integration_test') };
+});
+
+const { progressStore } = vi.hoisted(() => {
+  let value: Record<string, unknown> = {};
+  const subscribers = new Set<(v: Record<string, unknown>) => void>();
+  return {
+    progressStore: {
+      set(next: Record<string, unknown>) {
+        value = next;
+        subscribers.forEach((fn) => fn(value));
+      },
+      subscribe(fn: (v: Record<string, unknown>) => void) {
+        subscribers.add(fn);
+        fn(value);
+        return () => subscribers.delete(fn);
+      }
+    }
+  };
+});
+vi.mock('$lib/settings/volume-data', () => ({ volumes: progressStore }));
+const enrichAllOrphanedVolumes = vi.fn(async () => {});
+vi.mock('$lib/settings', () => ({
+  get volumes() {
+    return progressStore;
+  },
+  enrichAllOrphanedVolumes: () => enrichAllOrphanedVolumes()
+}));
+
+const openSeries = vi.fn(async (_title: string) => {});
+vi.mock('$lib/metadata/series-open', () => ({ openSeries: (t: string) => openSeries(t) }));
+
+/** The listing: every seeded series folder, with its one archive. */
+let listing = new Map<string, Set<string>>();
+/** The index refresh in flight; `null` = nothing running. */
+let indexRefresh: Promise<void> | null = null;
+vi.mock('$lib/util/sync/unified-cloud-manager', () => ({
+  unifiedCloudManager: {
+    getActiveProvider: () => ({ type: 'webdav' }),
+    cloudVolumeTitlesFor: (title: string) => listing.get(title) ?? new Set<string>(),
+    whenSeriesIndexesSettled: () => indexRefresh ?? Promise.resolve()
+  }
+}));
+vi.mock('$lib/util/sync/cache-manager', () => ({
+  cacheManager: { getCache: () => ({ isLoaded: () => true }) }
+}));
+
+import { db } from '$lib/catalog/db';
+import { resolveSyncedProgress } from './hole-patch';
+import { resetHistoryRowsSessionForTests } from './history-rows';
+
+const SERIES = 30;
+
+function seriesTitle(i: number): string {
+  return `Series ${String(i).padStart(2, '0')}`;
+}
+
+function indexRecord(i: number): SeriesIndexRecord {
+  const title = seriesTitle(i);
+  const volume: SeriesFileVolume = {
+    volume_uuid: `uuid-${i}`,
+    volume_title: `${title} v01`,
+    page_count: 180,
+    character_count: 12_000,
+    mokuro_version: '0.2.1'
+  };
+  const file: SeriesFile = {
+    version: 2,
+    series_title: title,
+    external_ids: {},
+    titles: {},
+    synonyms: [],
+    updated_at: '2026-08-01T00:00:00.000Z',
+    volumes: [volume]
+  };
+  return {
+    series_key: title.toLowerCase(),
+    series_title: title,
+    file,
+    source: {
+      provider: 'webdav',
+      path: `${title}/series.json`,
+      size: 1,
+      modifiedTime: '2026-08-01T00:00:00.000Z'
+    },
+    fetched_at: '2026-08-01T00:00:00.000Z'
+  };
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  resetHistoryRowsSessionForTests();
+  await db.volumes.clear();
+  await db.series_index.clear();
+
+  // 30 series in the listing, progress synced for one volume of each, and a
+  // COLD index cache: nothing in `series_index` yet.
+  listing = new Map();
+  const progress: Record<string, unknown> = {};
+  for (let i = 0; i < SERIES; i++) {
+    listing.set(seriesTitle(i), new Set([`${seriesTitle(i)} v01`]));
+    progress[`uuid-${i}`] = { progress: 5, series_title: seriesTitle(i) };
+  }
+  progressStore.set(progress);
+  indexRefresh = null;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('resolveSyncedProgress against a cold index cache', () => {
+  it('materializes every synced series in ONE run once the refresh lands, with no network pull', async () => {
+    let landIndexes!: () => void;
+    indexRefresh = new Promise<void>((resolve) => {
+      landIndexes = resolve;
+    }).then(async () => {
+      // The listing-wide refresh landing all 30 sidecars at once.
+      await db.series_index.bulkPut(Array.from({ length: SERIES }, (_, i) => indexRecord(i)));
+    });
+
+    const run = resolveSyncedProgress();
+    // Nothing happens against the cold cache: the sweep is waiting.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(await db.volumes.count()).toBe(0);
+
+    landIndexes();
+    await run;
+
+    expect(await db.volumes.count()).toBe(SERIES);
+    for (let i = 0; i < SERIES; i++) {
+      const row = await db.volumes.get(`uuid-${i}`);
+      expect(row?.series_title).toBe(seriesTitle(i));
+      expect(row?.metadata_only).toBe(true);
+    }
+    // Phase 2 had nothing left to pull: every series was served locally.
+    expect(openSeries).not.toHaveBeenCalled();
+    // Enriched on both sides of the sweep.
+    expect(enrichAllOrphanedVolumes).toHaveBeenCalledTimes(2);
+  });
+
+  it('a second run with nothing missing performs no writes and no network', async () => {
+    await db.series_index.bulkPut(Array.from({ length: SERIES }, (_, i) => indexRecord(i)));
+    await resolveSyncedProgress();
+    expect(await db.volumes.count()).toBe(SERIES);
+
+    openSeries.mockClear();
+    const counts = await countIdbOps(async () => {
+      await resolveSyncedProgress();
+    });
+    expect(counts['tx.volumes.readwrite'] ?? 0).toBe(0);
+    expect(counts['volumes.getAll'] ?? 0).toBe(0);
+    expect(openSeries).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/metadata/hole-patch.test.ts
+++ b/src/lib/metadata/hole-patch.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { readable, writable } from 'svelte/store';
+import { readable } from 'svelte/store';
 
 let progress: Record<string, { series_title?: string; deletedOn?: string }> = {};
 /**
@@ -54,23 +54,12 @@ vi.mock('$lib/metadata/history-rows', () => ({
 // to know about the listing gate; the gate-specific tests flip these.
 let activeProvider: { type: string } | null = { type: 'google-drive' };
 const getActiveProvider = vi.fn(() => activeProvider);
-// The "has the listing arrived" signal `patchProgressHolesWhenListingReady`
-// subscribes to. A real `writable`, not a reassigned `let` behind a thunk
-// like the other mocks here: the whole point of the tests that use it is to
-// push a SECOND emission at a subscriber already listening, which a plain
-// value swap can't do.
-const cloudFilesStore = writable<Map<string, unknown[]>>(new Map());
+// The series-index refresh `resolveSyncedProgress` awaits before sweeping.
+let indexRefresh: Promise<void> = Promise.resolve();
 vi.mock('$lib/util/sync/unified-cloud-manager', () => ({
   unifiedCloudManager: {
     getActiveProvider: () => getActiveProvider(),
-    // A getter, not a direct property: `vi.mock` factories are hoisted above
-    // this file's own top-level `const cloudFilesStore = ...`, so evaluating
-    // the reference eagerly here would hit the TDZ. Deferring behind a getter
-    // matches the `getActiveProvider` thunk above — both wait until something
-    // actually asks.
-    get cloudFiles() {
-      return cloudFilesStore;
-    }
+    whenSeriesIndexesSettled: () => indexRefresh
   }
 }));
 
@@ -82,8 +71,7 @@ vi.mock('$lib/util/sync/cache-manager', () => ({
 import {
   patchProgressHoles,
   patchProgressHolesAndEnrich,
-  patchProgressHolesWhenListingReady,
-  resetHolePatchSessionForTests
+  resolveSyncedProgress
 } from './hole-patch';
 
 beforeEach(() => {
@@ -93,10 +81,9 @@ beforeEach(() => {
   indexes = [];
   activeProvider = { type: 'google-drive' };
   cacheLoaded = true;
-  cloudFilesStore.set(new Map());
+  indexRefresh = Promise.resolve();
   materializeHistoryRows.mockImplementation(async () => 0);
   enrichAllOrphanedVolumes.mockImplementation(async () => {});
-  resetHolePatchSessionForTests();
 });
 
 describe('patchProgressHoles', () => {
@@ -128,16 +115,20 @@ describe('patchProgressHoles', () => {
     expect(openSeries).not.toHaveBeenCalled();
   });
 
-  it('de-duplicates by series and caps the run', async () => {
+  it('de-duplicates by series and pulls every dangling series in one run — no cap', async () => {
     progress = {
       a: { series_title: 'One' },
       b: { series_title: 'one' },
       c: { series_title: 'Two' },
-      d: { series_title: 'Three' }
+      d: { series_title: 'Three' },
+      e: { series_title: 'Four' },
+      f: { series_title: 'Five' },
+      g: { series_title: 'Six' },
+      h: { series_title: 'Seven' }
     };
-    const pulled = await patchProgressHoles({ limit: 2 });
-    expect(pulled).toHaveLength(2);
-    expect(openSeries).toHaveBeenCalledTimes(2);
+    const pulled = await patchProgressHoles();
+    expect(pulled).toHaveLength(7);
+    expect(openSeries).toHaveBeenCalledTimes(7);
   });
 
   it('never rejects when an open fails', async () => {
@@ -146,33 +137,15 @@ describe('patchProgressHoles', () => {
     await expect(patchProgressHoles()).resolves.toEqual([]);
   });
 
-  it('does not re-attempt a series already tried this session, even if it is still a hole', async () => {
+  it('re-attempts a still-dangling series on the next run — there is no session memo', async () => {
     // Nothing in localRows/indexes ever appears for this title — as if the
-    // series is genuinely absent from the cloud (or the device is offline).
+    // series is genuinely absent from the cloud. `openSeries` costs zero I/O
+    // for such a series, and a memo here used to poison a series attempted
+    // before its index had landed.
     progress = { 'uuid-1': { series_title: 'Ghost Series' } };
 
     await expect(patchProgressHoles()).resolves.toEqual(['Ghost Series']);
-    expect(openSeries).toHaveBeenCalledTimes(1);
-
-    // A later catalog open re-runs the patcher against the same still-dangling
-    // progress record; it must not call openSeries again this session.
-    await expect(patchProgressHoles()).resolves.toEqual([]);
-    expect(openSeries).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not count an attempt left off by the run cap against the session memory', async () => {
-    progress = {
-      a: { series_title: 'One' },
-      b: { series_title: 'Two' }
-    };
-    const first = await patchProgressHoles({ limit: 1 });
-    expect(first).toEqual(['One']);
-    expect(openSeries).toHaveBeenCalledTimes(1);
-
-    // 'Two' was deferred by the cap, not attempted — it must still be picked
-    // up on the next run.
-    const second = await patchProgressHoles({ limit: 1 });
-    expect(second).toEqual(['Two']);
+    await expect(patchProgressHoles()).resolves.toEqual(['Ghost Series']);
     expect(openSeries).toHaveBeenCalledTimes(2);
   });
 
@@ -216,7 +189,7 @@ describe('patchProgressHoles', () => {
     expect(openSeries).toHaveBeenCalledTimes(1);
   });
 
-  it('stops attempting mid-run if the provider drops, without memoizing the untried titles', async () => {
+  it('stops attempting mid-run if the provider drops, and picks everything up next run', async () => {
     progress = {
       a: { series_title: 'One' },
       b: { series_title: 'Two' }
@@ -230,11 +203,11 @@ describe('patchProgressHoles', () => {
     expect(pulled).toEqual(['One']);
     expect(openSeries).toHaveBeenCalledTimes(1);
 
-    // 'Two' was never attempted (provider dropped before its turn), so it is
-    // not memoized — reconnecting must let it through on the next run.
+    // Reconnecting: 'Two' was never attempted and 'One' left no row or
+    // index behind, so both are dangling and both are pulled again.
     activeProvider = { type: 'google-drive' };
     const second = await patchProgressHoles();
-    expect(second).toEqual(['Two']);
+    expect(second).toEqual(['One', 'Two']);
   });
 
   describe('phase 1 hand-off', () => {
@@ -314,19 +287,6 @@ describe('patchProgressHoles', () => {
     expect(listSeriesIndexes).toHaveBeenCalledTimes(1);
   });
 
-  it('reads nothing at all on a re-run whose titles are all already memoized', async () => {
-    // Why the shared reader is LAZY rather than fetched once up front: a run
-    // that bails before either phase wants the indexes must still issue no
-    // `series_index` read, and this page's caller re-runs on every mount.
-    progress = { 'uuid-1': { series_title: 'Ghost Series' } };
-    await expect(patchProgressHoles()).resolves.toEqual(['Ghost Series']);
-    expect(listSeriesIndexes).toHaveBeenCalledTimes(1);
-
-    listSeriesIndexes.mockClear();
-    await expect(patchProgressHoles()).resolves.toEqual([]);
-    expect(listSeriesIndexes).not.toHaveBeenCalled();
-  });
-
   describe('patchProgressHolesAndEnrich', () => {
     it('runs the enrichment AGAIN after the sweep, where it can see the rows the sweep wrote', async () => {
       // The bug this exists to prevent: `ReadingSpeedView` enriched first and
@@ -388,130 +348,51 @@ describe('patchProgressHoles', () => {
   });
 });
 
-// Every mock in this file resolves through plain microtasks (no real timers,
-// no I/O) — including the fire-and-forget `void patchProgressHolesAndEnrich()`
-// calls `patchProgressHolesWhenListingReady` makes, which the caller never
-// gets a handle on. A `setTimeout` macrotask boundary is therefore a reliable
-// "wait for whatever is currently in flight to finish" gate: the microtask
-// queue drains completely — including every continuation THOSE microtasks
-// enqueue — before any timer callback runs. `vi.waitFor`'s "did the mock get
-// called yet" polling is the wrong tool for the "nothing happened" side of
-// these assertions: it resolves the instant a condition is first satisfied,
-// which can be BEFORE an in-flight bailing call has reached the very check
-// this suite exists to test, letting a later state change in the test race
-// ahead of it and silently turn a bail into a real sweep.
-async function flush(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 0));
-}
-
-describe('patchProgressHolesWhenListingReady', () => {
-  it('retries the sweep once the listing arrives, after a mount that raced ahead of it did no sweep work', async () => {
-    // The bug this exists to prevent: a mount that fires before the cloud
-    // listing has loaded gets an immediate `patchProgressHoles` call that
-    // bails at its very first line (`listingIsLoaded()`), doing NOTHING —
-    // not even the local, network-free phase — for the rest of that visit.
-    cacheLoaded = false; // mirrors an unloaded listing at mount
-    progress = { 'uuid-1': { series_title: 'Dr Stone' } };
-
-    const unsubscribe = patchProgressHolesWhenListingReady();
-
-    // Let the immediate call run to completion before touching any state it
-    // reads, so its bail is really a bail and not a race.
-    await flush();
+describe('resolveSyncedProgress — the one trigger, run after every progress sync', () => {
+  it('does nothing before the listing is loaded', async () => {
+    cacheLoaded = false;
+    progress = { v1: { series_title: 'Ghost' } };
+    await resolveSyncedProgress();
     expect(materializeHistoryRows).not.toHaveBeenCalled();
+    expect(enrichAllOrphanedVolumes).not.toHaveBeenCalled();
     expect(openSeries).not.toHaveBeenCalled();
+  });
 
-    // The listing arrives (e.g. `fetchAllCloudVolumes()` resolves): the cache
-    // reports loaded AND its store emits a non-empty map, same as a real
-    // provider's `fetch()` does together.
-    cacheLoaded = true;
-    cloudFilesStore.set(new Map([['Dr Stone', [{}]]]));
-    await flush();
+  it('waits for the series-index refresh before sweeping', async () => {
+    let release!: () => void;
+    indexRefresh = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    progress = { v1: { series_title: 'Ghost' } };
 
-    // This is the assertion that fails without the fix: without a retry
-    // triggered off the listing arriving, this never happens for the rest of
-    // the visit.
-    expect(openSeries).toHaveBeenCalledWith('Dr Stone');
+    const run = resolveSyncedProgress();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(materializeHistoryRows).not.toHaveBeenCalled();
+
+    release();
+    await run;
     expect(materializeHistoryRows).toHaveBeenCalledTimes(1);
-
-    unsubscribe();
+    expect(openSeries).toHaveBeenCalledWith('Ghost');
   });
 
-  it('does not retry when the listing was already loaded and non-empty at mount', async () => {
-    // `.subscribe()` replays the CURRENT value synchronously to a new
-    // subscriber. If that replay were treated as "the listing just arrived",
-    // every ordinary mount (listing already loaded) would sweep twice.
-    cacheLoaded = true;
-    cloudFilesStore.set(new Map([['Dr Stone', [{}]]]));
-    progress = { 'uuid-1': { series_title: 'Dr Stone' } };
-
-    const unsubscribe = patchProgressHolesWhenListingReady();
-    await flush();
-
-    expect(openSeries).toHaveBeenCalledTimes(1);
-    expect(openSeries).toHaveBeenCalledWith('Dr Stone');
-    expect(materializeHistoryRows).toHaveBeenCalledTimes(1);
-
-    unsubscribe();
+  it('enriches before AND after the sweep', async () => {
+    const order: string[] = [];
+    enrichAllOrphanedVolumes.mockImplementation(async () => {
+      order.push('enrich');
+    });
+    materializeHistoryRows.mockImplementation(async () => {
+      order.push('sweep');
+      return 0;
+    });
+    await resolveSyncedProgress();
+    expect(order).toEqual(['enrich', 'sweep', 'enrich']);
   });
 
-  it('retries at most once even if the listing keeps re-emitting after it arrives', async () => {
-    cacheLoaded = false;
-    progress = { 'uuid-1': { series_title: 'Dr Stone' } };
-
-    const unsubscribe = patchProgressHolesWhenListingReady();
-    await flush();
-    expect(openSeries).not.toHaveBeenCalled();
-
-    cacheLoaded = true;
-    cloudFilesStore.set(new Map([['Dr Stone', [{}]]]));
-    await flush();
-    expect(openSeries).toHaveBeenCalledTimes(1);
-
-    // The listing store re-emits again (e.g. a background dedup pass, or a
-    // second unrelated fetch) — this must NOT trigger a second sweep.
-    cloudFilesStore.set(
-      new Map([
-        ['Dr Stone', [{}]],
-        ['One Piece', [{}]]
-      ])
-    );
-    cloudFilesStore.set(new Map([['Dr Stone', [{}]]]));
-    await flush();
-    expect(openSeries).toHaveBeenCalledTimes(1);
-    expect(materializeHistoryRows).toHaveBeenCalledTimes(1);
-
-    unsubscribe();
-  });
-
-  it('an empty re-emission after mount does not count as the listing arriving', async () => {
-    cacheLoaded = false;
-    progress = { 'uuid-1': { series_title: 'Dr Stone' } };
-
-    const unsubscribe = patchProgressHolesWhenListingReady();
-    await flush();
-
-    // Still empty — must not be mistaken for "arrived".
-    cloudFilesStore.set(new Map());
-    await flush();
-    expect(openSeries).not.toHaveBeenCalled();
-
-    unsubscribe();
-  });
-
-  it('unsubscribes on the returned cleanup — a listing arriving after unmount must not trigger a sweep', async () => {
-    cacheLoaded = false;
-    progress = { 'uuid-1': { series_title: 'Dr Stone' } };
-
-    const unsubscribe = patchProgressHolesWhenListingReady();
-    await flush();
-    expect(openSeries).not.toHaveBeenCalled();
-
-    unsubscribe();
-
-    cacheLoaded = true;
-    cloudFilesStore.set(new Map([['Dr Stone', [{}]]]));
-    await flush();
-    expect(openSeries).not.toHaveBeenCalled();
+  it('never rejects', async () => {
+    materializeHistoryRows.mockRejectedValueOnce(new Error('boom'));
+    await expect(resolveSyncedProgress()).resolves.toBeUndefined();
+    indexRefresh = Promise.reject(new Error('refresh exploded'));
+    await expect(resolveSyncedProgress()).resolves.toBeUndefined();
   });
 });

--- a/src/lib/metadata/hole-patch.ts
+++ b/src/lib/metadata/hole-patch.ts
@@ -9,43 +9,6 @@ import { materializeHistoryRows } from './history-rows';
 import { normalizeSeriesKey } from './series-key';
 
 /**
- * Series pulled per run. Each pull is a `series.json` download, so a device
- * whose progress file references a hundred long-gone series must not turn a
- * catalog open into a hundred requests — the rest are patched on the next run.
- *
- * This caps the NETWORK phase only, and that phase is now the rare one: a
- * series whose `series.json` is already cached is served by
- * `materializeHistoryRows` with no request at all, and the listing-wide index
- * refresh (`series-index-sync.ts`) caches one for every folder in the account.
- * What is left here is the window before that refresh has caught up — where
- * five downloads per run is exactly the right budget.
- */
-export const MAX_HOLE_PATCHES_PER_RUN = 5;
-
-/**
- * Series keys this page load has already tried to pull. A series that still
- * has no local row and no cached index after `openSeries` settles is either
- * genuinely absent from the cloud or unreachable right now — either way,
- * retrying it on every catalog open (the caller re-runs this on EVERY mount)
- * would turn a permanent gap into a permanent request. Cleared only by a
- * fresh page load, matching the "session-scoped" contract; a series that was
- * only deferred by the run cap is never added here, so it is still picked up
- * next run.
- *
- * It can no longer hide a hole for a whole session, which it used to be able
- * to: a series memoized here before its `series.json` had been cached is still
- * picked up by `materializeHistoryRows`, which consults nothing in this set —
- * it reads the index cache, so it heals the moment the background refresh
- * lands the file.
- */
-const attemptedThisSession = new Set<string>();
-
-/** Test-only: clears the session memory so cases don't leak into each other. */
-export function resetHolePatchSessionForTests(): void {
-  attemptedThisSession.clear();
-}
-
-/**
  * Is there a COMPLETE cloud listing to check `openSeries` against right now?
  *
  * A non-null `getActiveProvider()` is not enough: `initializeCurrentProvider()`
@@ -84,11 +47,19 @@ function listingIsLoaded(): boolean {
  * connected account arrives on its own, and for a series long gone from the
  * cloud never does.
  *
- * PHASE 2 — the network fallback, capped. A series that phase 1 could not
- * serve because this device has NO cached index for it gets its `series.json`
+ * PHASE 2 — the network fallback. A series that phase 1 could not serve
+ * because this device has NO cached index for it gets its `series.json`
  * pulled and its volumes materialized (`openSeries`), which is exactly the
  * state the series would have been in had the user opened it. Phase 1 runs
  * first so the rows it creates take those series out of phase 2's reckoning.
+ * Uncapped, and with no session memory of what it tried: the trigger is one
+ * run per progress sync with the index refresh already awaited
+ * (`resolveSyncedProgress`), so this phase only ever downloads an index the
+ * listing shows but that refresh failed to cache — and a series absent from
+ * the cloud costs `openSeries` zero I/O. The old per-mount memo existed to
+ * stop a per-mount sweep re-pulling an absent series; it could also poison a
+ * series attempted before its index had landed, and it had nothing left to
+ * save.
  *
  * Cheap in the normal case: one pass over the progress records, one INDEX-KEY
  * read of the local rows (never a full scan — `volumes` rows carry thumbnail
@@ -101,8 +72,7 @@ function listingIsLoaded(): boolean {
  * exist in the cloud, in which case nothing is downloaded but nothing throws
  * either — so this is "attempted", not "confirmed fetched". Never rejects.
  */
-export async function patchProgressHoles(options?: { limit?: number }): Promise<string[]> {
-  const limit = options?.limit ?? MAX_HOLE_PATCHES_PER_RUN;
+export async function patchProgressHoles(): Promise<string[]> {
   const pulled: string[] = [];
 
   // ONE `series_index` read for the whole run, shared by both phases — they
@@ -111,8 +81,8 @@ export async function patchProgressHoles(options?: { limit?: number }): Promise<
   // 1 writes only to `volumes`, so the index list it read cannot have gone
   // stale by the time phase 2 wants it. LAZY, not fetched up front: a run that
   // bails before either phase asks — no provider, no listing, or every
-  // dangling title already attempted this session — must still issue no read
-  // at all, and this caller re-runs on every mount.
+  // dangling title already rowed or indexed — must still issue no read at
+  // all, and this runs on every sync.
   let indexesOnce: Promise<SeriesIndexRecord[]> | null = null;
   const readIndexes = () => (indexesOnce ??= listSeriesIndexes());
 
@@ -132,11 +102,11 @@ export async function patchProgressHoles(options?: { limit?: number }): Promise<
     // runs once the listing has loaded. See `listingIsLoaded`.
     if (!listingIsLoaded()) return pulled;
 
-    // Phase 1. Local, network-free, and NOT capped at five: it is the phase
-    // that actually closes the gap the user reported (726 volumes with
-    // history, 36 of them tracked), and it can only act on data already on
-    // the device. Awaited before phase 2 plans anything so the rows it writes
-    // are visible to the "does this series already have a row" check below.
+    // Phase 1. Local and network-free: it is the phase that actually closes
+    // the gap the user reported (726 volumes with history, 36 of them
+    // tracked), and it can only act on data already on the device. Awaited
+    // before phase 2 plans anything so the rows it writes are visible to the
+    // "does this series already have a row" check below.
     await materializeHistoryRows({ readIndexes });
 
     const progress = get(progressStore);
@@ -151,7 +121,7 @@ export async function patchProgressHoles(options?: { limit?: number }): Promise<
       const title = record.series_title;
       if (typeof title !== 'string') continue;
       const key = normalizeSeriesKey(title);
-      if (!key || wanted.has(key) || attemptedThisSession.has(key)) continue;
+      if (!key || wanted.has(key)) continue;
       wanted.set(key, title);
     }
     if (wanted.size === 0) return pulled;
@@ -172,13 +142,11 @@ export async function patchProgressHoles(options?: { limit?: number }): Promise<
     }
     if (wanted.size === 0) return pulled;
 
-    for (const [key, title] of [...wanted.entries()].slice(0, limit)) {
+    for (const title of wanted.values()) {
       // Re-checked per attempt, not just once at entry: the provider or its
       // listing can drop between awaits (e.g. a logout, or a provider switch
-      // clearing the cache). A title skipped here was never actually
-      // attempted, so it is left un-memoized for the next run.
+      // clearing the cache), and `openSeries` would then silently no-op.
       if (!listingIsLoaded()) break;
-      attemptedThisSession.add(key);
       try {
         await openSeries(title);
         pulled.push(title);
@@ -213,9 +181,9 @@ export async function patchProgressHoles(options?: { limit?: number }): Promise<
  *
  * Best-effort, like everything else here: never rejects.
  */
-export async function patchProgressHolesAndEnrich(options?: { limit?: number }): Promise<string[]> {
+export async function patchProgressHolesAndEnrich(): Promise<string[]> {
   await enrichQuietly();
-  const pulled = await patchProgressHoles(options);
+  const pulled = await patchProgressHoles();
   // Awaited AFTER the sweep, not alongside it: this is the pass that sees the
   // rows the sweep just wrote.
   await enrichQuietly();
@@ -223,57 +191,32 @@ export async function patchProgressHolesAndEnrich(options?: { limit?: number }):
 }
 
 /**
- * Run `patchProgressHolesAndEnrich` now, and — if the listing was not loaded
- * yet at that moment — exactly once more when it arrives.
+ * THE trigger. Runs once per progress sync, from
+ * `unifiedCloudManager.syncProgress()` — never from a view mount.
  *
- * THE RACE THIS CLOSES. `patchProgressHoles` bails with ZERO work done,
- * including the local, network-free phase (`materializeHistoryRows`) that
- * needs no cloud round trip and is the one that actually closes a gap like
- * "726 volumes with history, 36 tracked" — whenever `listingIsLoaded()` is
- * false. Both callers (`CatalogView`, `ReadingSpeedView`) run the sweep from
- * `onMount`, which on a cold app start can fire before `initializeProviders()`
- * `fetchAllCloudVolumes()` has resolved. A mount that loses that race used to
- * get nothing for the rest of that visit — the exact symptom reported: a
- * stats page opened straight after launch, before the listing was in, showed
- * untracked history forever.
+ * Waits for the `series.json` refresh the listing started, because that is
+ * what phase 1 resolves against: measured 2026-08-31, the same sweep
+ * materialized 5 of 30 series against a cold index cache and 30 of 30 against
+ * a warm one, and on a network provider the startup sweep always ran cold
+ * (the refresh is fire-and-forget behind the listing). Coverage was then made
+ * up by re-running the sweep from view mounts, so convergence depended on how
+ * the user navigated. With the refresh awaited, phase 1 is in-memory plus one
+ * bulk read, and phase 2 only ever downloads an index the listing shows but
+ * the refresh failed to cache.
  *
- * `unifiedCloudManager.cloudFiles` is used as the "the listing just arrived"
- * signal rather than a bespoke one, matching how `SeriesView` already treats
- * that store's transition-to-non-empty as "cache is now loaded". It is not a
- * perfect proxy — an account with a genuinely empty cloud never re-triggers —
- * but `patchProgressHoles`'s own internal `listingIsLoaded()` check is the
- * actual authority in that case too, and a truly empty listing has nothing
- * for either phase to resolve regardless.
- *
- * AT MOST ONE RETRY. `cloudFiles` re-emits on every fetch, dedup pass and
- * cache mutation for the rest of the app's life — reacting to all of them
- * would re-sweep on every unrelated cache change. The `retried` flag caps it
- * at one. The delivery `.subscribe()` makes SYNCHRONOUSLY the moment this
- * subscribes (Svelte stores replay their current value to a new subscriber)
- * is treated as a snapshot, not a trigger: if the listing was already loaded
- * at mount, the unconditional call above already covered it, and firing the
- * retry on that same initial value would double the sweep on every ordinary
- * visit instead of only the cold-start one this exists for.
- *
- * NO LEAK. Returns the store's unsubscribe function; callers MUST invoke it
- * on unmount (e.g. from `onMount`'s cleanup return) or the subscription — and
- * the closure it holds — outlives the component.
+ * Starts no I/O the sync did not already imply: no listing is fetched here
+ * (a Drive listing fetch can itself trigger a post-login sync, and a
+ * resolution that fetched would close that loop). Without a loaded listing it
+ * is a no-op; the next sync catches up. Never rejects.
  */
-export function patchProgressHolesWhenListingReady(): () => void {
-  void patchProgressHolesAndEnrich();
-
-  let sawInitialSnapshot = false;
-  let retried = false;
-  return unifiedCloudManager.cloudFiles.subscribe((files) => {
-    if (!sawInitialSnapshot) {
-      // The replay-on-subscribe delivery: not a change, so not a trigger.
-      sawInitialSnapshot = true;
-      return;
-    }
-    if (retried || files.size === 0) return;
-    retried = true;
-    void patchProgressHolesAndEnrich();
-  });
+export async function resolveSyncedProgress(): Promise<void> {
+  try {
+    if (!listingIsLoaded()) return;
+    await unifiedCloudManager.whenSeriesIndexesSettled();
+    await patchProgressHolesAndEnrich();
+  } catch (error) {
+    console.debug('[hole-patch] resolution failed:', error);
+  }
 }
 
 /**

--- a/src/lib/metadata/series-backfill.test.ts
+++ b/src/lib/metadata/series-backfill.test.ts
@@ -173,7 +173,10 @@ vi.mock('$lib/catalog/db', () => ({
     // stand-in is sufficient here because every test drives the race by hand
     // (mutating `volumeRows` directly between a deferred fetch and its
     // release), not by relying on real lock ordering.
-    transaction: async (_mode: string, _table: unknown, body: () => Promise<unknown>) => body()
+    transaction: async (_mode: string, _table: unknown, body: () => Promise<unknown>) => body(),
+    // The cover service's cache short-circuit reads this; a `refresh` request
+    // skips it, and nothing in this file caches anything.
+    cloud_covers: { get: async () => undefined }
   }
 }));
 
@@ -226,6 +229,7 @@ vi.mock('./write-slot', async (importOriginal) => {
   };
 });
 
+import { _resetCoverServiceForTests, _setRetryDelaysForTests } from '$lib/catalog/cover-service';
 import {
   _resetSeriesBackfillForTests,
   backfillNewlyLinkedSeries,
@@ -290,6 +294,11 @@ beforeEach(() => {
   vi.clearAllMocks();
   _resetSeriesBackfillForTests();
   _resetWriteSlotForTests();
+  // A stale-cover refresh is a request to the REAL cover service (only its
+  // network fetch is mocked above): reset its dedupe between cases, and do
+  // not let a null fetch cost this suite the service's 10 s retry schedule.
+  _resetCoverServiceForTests();
+  _setRetryDelaysForTests([0, 0]);
   status = {
     hasAnyAuthenticated: true,
     currentProviderType: 'webdav',
@@ -316,6 +325,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  _setRetryDelaysForTests(null);
   vi.restoreAllMocks();
 });
 

--- a/src/lib/metadata/series-backfill.ts
+++ b/src/lib/metadata/series-backfill.ts
@@ -9,11 +9,8 @@ import { flushPendingCoverPersists } from '$lib/catalog/cover-persist';
 // series-file-sync note below, same reasoning).
 import { requestCover } from '$lib/catalog/cover-service';
 import { materializeSeriesVolumes } from '$lib/catalog/materialize';
-import { buildPageCharCounts, decodeMokuroSidecar } from '$lib/catalog/cloud-ocr-upgrade';
 import { isVolumeInstalled, needsDownload } from '$lib/catalog/volume-state';
-import { parseMokuroFile } from '$lib/import/processing';
 import type { VolumeMetadata } from '$lib/types';
-import { generateDeterministicUUID } from '$lib/util/series-extraction';
 import type { CloudFileMetadata, SyncProvider } from '$lib/util/sync/provider-interface';
 import { isCbzFile } from '$lib/util/sync/syncable-file';
 import { providerManager } from '$lib/util/sync/provider-manager';
@@ -39,6 +36,13 @@ import { getSeriesIndex } from './series-index';
 // inside function bodies.
 import { scheduleSeriesFileWrite } from './series-file-sync';
 import { normalizeSeriesKey, normalizeVolumeTitleKey } from './series-key';
+import {
+  _resetBackfillSlotsForTests,
+  acquireBackfillSlot,
+  buildNoMetadataEntry,
+  pullMokuroEntry,
+  releaseBackfillSlot
+} from './sidecar-pull';
 import { acquireWriteSlot, releaseWriteSlot } from './write-slot';
 
 /**
@@ -72,10 +76,11 @@ import { acquireWriteSlot, releaseWriteSlot } from './write-slot';
  * concurrent PUTs" stampede `series-file-sync.ts`'s own `WRITE_CONCURRENCY`
  * was written to prevent (see `write-slot.ts`):
  *
- * - {@link acquireBackfillSlot} bounds how many series' worth of EXPENSIVE
- *   work (the indexed `volumesForFoldedSeriesTitle` read, the sidecar pulls,
- *   the write) run at once — module-local to this file, since it is
- *   specifically the backfill's own fan-out that needs bounding. A
+ * - `acquireBackfillSlot` (`sidecar-pull.ts`) bounds how many series' worth
+ *   of EXPENSIVE work (the indexed `volumesForFoldedSeriesTitle` read, the
+ *   sidecar pulls, the write) run at once — shared with the cover service's
+ *   render-demand pulls, since fast browsing must not stampede a provider any
+ *   more than a reconcile sweep may. A
  *   CONVERGED series never touches this budget at all: the cheap
  *   listing-only candidate check runs first and returns immediately when
  *   there is nothing to do, so a sweep over N already-converged folders
@@ -88,39 +93,6 @@ import { acquireWriteSlot, releaseWriteSlot } from './write-slot';
 
 /** Sidecar pulls in flight at once, per series. Small on purpose — see `cloud-ocr-upgrade.ts`. */
 const PULL_CONCURRENCY = 2;
-
-/**
- * How many series' worth of expensive backfill work (volumes scan, pulls,
- * write) may run at once, across every series. Mirrors `WRITE_CONCURRENCY` —
- * see the module doc above for why this is a SEPARATE pool from it.
- */
-const BACKFILL_PASS_CONCURRENCY = 2;
-let activeBackfillPasses = 0;
-const waitingBackfillPasses: Array<() => void> = [];
-
-/**
- * Exported so `cover-service.ts`'s render-demand single-archive pulls share
- * this SAME pool: "fast browsing can't stampede a provider" applies to a
- * .mokuro pull triggered by scrolling past a bare placeholder exactly as much
- * as one triggered by a reconcile sweep — one budget, not two.
- */
-export function acquireBackfillSlot(): Promise<void> {
-  if (activeBackfillPasses < BACKFILL_PASS_CONCURRENCY) {
-    activeBackfillPasses += 1;
-    return Promise.resolve();
-  }
-  return new Promise<void>((resolve) => {
-    waitingBackfillPasses.push(() => {
-      activeBackfillPasses += 1;
-      resolve();
-    });
-  });
-}
-
-export function releaseBackfillSlot(): void {
-  activeBackfillPasses -= 1;
-  waitingBackfillPasses.shift()?.();
-}
 
 /** series_key → the pass currently running for it. */
 const inFlight = new Map<string, Promise<void>>();
@@ -149,89 +121,6 @@ function basename(path: string): string {
 
 function archiveStemOf(path: string): string {
   return basename(path).replace(/\.cbz$/i, '');
-}
-
-/**
- * Zero-count entry for an archive with no `.mokuro` sidecar at all.
- *
- * NOT an image-only claim, despite the empty `mokuro_version`. A sidecar-less
- * archive is most often a LEGACY backup whose mokuro is EMBEDDED in the
- * `.cbz` (the whole reason `sidecar-backfill.ts` exists) — nothing can know
- * which until the archive is downloaded. This entry exists only to carry the
- * archive's identity, size and cover stamps, and to stop the backfill pass
- * re-planning the archive on every listing; its zero-content shape is exactly
- * what `hasMeasuredContent` (series-file.ts) reads as "this entry proves
- * nothing", which keeps merges treating it as the weakest possible claim.
- * Consumers that copy a version onto a row or placeholder go through
- * `entryMokuroVersion`: with no cover stamps either (ALL sidecars missing)
- * this shape surfaces as `'unknown'` — never as the image-only `''` — while
- * cover stamps prove a modern backup wrote sidecars without a mokuro, which
- * IS a genuine image-only signal.
- *
- * Exported for `cover-service.ts`'s render-demand path (decision-tree case
- * 4), which builds an entry for exactly one archive the same way this module
- * does for a whole series — reused, not re-derived.
- */
-export function buildNoMetadataEntry(
-  folderTitle: string,
-  archiveStem: string,
-  archiveFile: CloudFileMetadata
-): SeriesFileVolume {
-  const entry: SeriesFileVolume = {
-    volume_uuid: generateDeterministicUUID(`${folderTitle}/${archiveStem}`),
-    volume_title: archiveStem,
-    page_count: 0,
-    character_count: 0,
-    mokuro_version: ''
-  };
-  if (isArchiveSize(archiveFile.size)) entry.archive_size = archiveFile.size;
-  return entry;
-}
-
-/**
- * Download and parse one `.mokuro`/`.mokuro.gz`, building the entry the ENTRY-
- * BUILDING rules describe: `volume_title` from the ARCHIVE's filename stem
- * (never the mokuro's own `title`/`volume` fields — real files get those
- * wrong), `volume_uuid` from the mokuro's own `volume_uuid`, counts measured
- * with the same char math `cloud-ocr-upgrade.ts` uses for its own upgrade
- * path. `undefined` for anything that fails to parse or lacks a usable uuid —
- * the caller treats that as "skip this one volume", never a hard failure.
- *
- * `sidecarFile` is the snapshot the caller already captured from ONE listing
- * read (`groupSeriesSidecarFiles`); it is used here for BOTH the download and
- * the stamp below, so there is no second listing lookup to race a concurrent
- * re-list — the stamp always describes exactly the bytes that were pulled.
- *
- * Exported for `cover-service.ts`'s render-demand path (decision-tree case
- * 3: a bare placeholder with a real sidecar) — the SAME pull, whether it is
- * triggered by a backfill pass or by a card being scrolled into view.
- */
-export async function pullMokuroEntry(
-  provider: SyncProvider,
-  archiveStem: string,
-  sidecarFile: CloudFileMetadata
-): Promise<SeriesFileVolume | undefined> {
-  const blob = await provider.downloadFile(sidecarFile);
-  const decoded = await decodeMokuroSidecar(sidecarFile.path, blob);
-  if (!decoded) return undefined;
-
-  const parsed = await parseMokuroFile(decoded);
-  if (typeof parsed.volumeUuid !== 'string' || !parsed.volumeUuid.trim()) return undefined;
-
-  const pages = Array.isArray(parsed.pages) ? parsed.pages : [];
-  const { totalChars } = buildPageCharCounts(pages);
-
-  // Base fields only — the caller (`buildEntryForTask`) applies `archive_size`
-  // and the stamp fields through `orderVolumeEntryFields` so every entry this
-  // module produces re-serializes in the pinned wire order regardless of
-  // which fields end up set.
-  return {
-    volume_uuid: parsed.volumeUuid,
-    volume_title: archiveStem,
-    page_count: pages.length,
-    character_count: totalChars,
-    mokuro_version: typeof parsed.version === 'string' ? parsed.version : ''
-  };
 }
 
 /**
@@ -853,6 +742,5 @@ export function backfillNewlyLinkedSeries(seriesTitle: string): Promise<void> {
 /** Test hook: forget in-flight backfill passes and the pass-concurrency bookkeeping. */
 export function _resetSeriesBackfillForTests(): void {
   inFlight.clear();
-  activeBackfillPasses = 0;
-  waitingBackfillPasses.length = 0;
+  _resetBackfillSlotsForTests();
 }

--- a/src/lib/metadata/series-backfill.ts
+++ b/src/lib/metadata/series-backfill.ts
@@ -2,8 +2,12 @@ import { get } from 'svelte/store';
 import { db } from '$lib/catalog/db';
 import { volumesForFoldedSeriesTitle } from '$lib/catalog/volumes-by-series';
 import { installCoversForSeries } from '$lib/catalog/cover-install';
-import { fetchCloudThumbnail } from '$lib/catalog/cloud-thumbnails';
-import { flushPendingCoverPersists, installCover } from '$lib/catalog/cover-persist';
+import { flushPendingCoverPersists } from '$lib/catalog/cover-persist';
+// Deferred-use import into the module cycle cover-service → series-file-sync →
+// series-backfill → cover-service: safe because nothing on any side calls
+// across at module-init time, only from inside function bodies (see the
+// series-file-sync note below, same reasoning).
+import { requestCover } from '$lib/catalog/cover-service';
 import { materializeSeriesVolumes } from '$lib/catalog/materialize';
 import { buildPageCharCounts, decodeMokuroSidecar } from '$lib/catalog/cloud-ocr-upgrade';
 import { isVolumeInstalled, needsDownload } from '$lib/catalog/volume-state';
@@ -375,37 +379,38 @@ function excludeInstalledCandidates(
 }
 
 /**
- * Overwrite a materialized/metadata-only row's cover from a stale cover
+ * Refresh a materialized/metadata-only row's cover from a stale cover
  * sidecar. Never touches an installed row — its thumbnail was measured from
  * its own pages, not a cloud guess.
  *
- * `fetchCloudThumbnail` is a network fetch that can take up to 15s
- * (`FETCH_TIMEOUT_MS`), during which a download can finish and INSTALL the
- * volume with a thumbnail measured from its own pages. The snapshot read
- * above is that old by the time the network answers, so the actual write
- * routes through `cover-persist.ts`'s shared queue (`installCover`, `mode:
- * 'overwrite'` — this row already HAS a thumbnail, which is the entire
- * premise of "stale"), whose flush re-reads and re-tests the row inside its
- * own write transaction — the same guard every other cover path relies on.
- * Flushed immediately (not left to the debounce) since this runs inside
- * an already-async backfill pass, not a UI burst — see `flushPendingCoverPersists`.
+ * This is a `refresh: true` REQUEST to the one cover entry point
+ * (`cover-service.ts`'s `requestCover`), not a fetch of its own: the caller
+ * here has already decided, from stamps it computed against the listing,
+ * that whatever is on hand is stale — so the service skips its target test,
+ * its cache short-circuit and its dedupe ledger, fetches, and hands the
+ * result to `cover-persist.ts`'s shared queue with mode `'overwrite'` for a
+ * row that carries a thumbnail. Everything the fetch used to own here — the
+ * up-to-15s download during which a download can INSTALL the volume, the
+ * transactional re-read that keeps a page-measured thumbnail from being
+ * clobbered, the routing of a relationship-less row's cover into
+ * `cloud_covers` — is the service's and the queue's, exactly as for a card.
+ * Flushed here (not left to the queue's own cadence) since this runs inside
+ * an already-async backfill pass whose caller awaits it.
  *
- * Also RESTAMPS the row from `cover` — the same listing record the fetch was
- * made against — with `cover_size`/`cover_modified`, mirroring
- * `cover-service.ts`'s catalog-card path. This is what lets a FUTURE pass
- * (here, or a row-level check elsewhere) decide staleness from the row alone
- * without guessing, whichever path most recently touched it.
+ * The stale sidecar's OWN listing stamp rides as the `cloudThumbnail*`
+ * decoration, so the row (or cache row) is restamped with `cover_size`/
+ * `cover_modified` describing exactly the bytes fetched — what lets a FUTURE
+ * pass decide staleness from the row alone, whichever path last touched it.
  *
  * `archivePath` is the ARCHIVE's own cloud path from the listing this refresh
  * was planned against — the volume's CACHE IDENTITY, and a required argument
  * rather than an optional nicety. A row this device has no RELATIONSHIP with
- * (nothing installed, nothing read) cannot carry a blob at all under
- * `cover-persist.ts`'s routing rule, and such a row is the ordinary outcome of
- * merely OPENING a cloud series (`materializeSeriesVolumes` mints it, and
- * `cover-install.ts` routes its cover into `cloud_covers` rather than onto it).
- * Handing `installCover` a bare uuid gives that cover no `cloud_covers`
- * identity either, so the fetch is made and then silently DROPPED — the exact
- * "stale cover never refreshes" dead end this argument exists to close.
+ * (nothing installed, nothing read) cannot carry a blob at all under the
+ * queue's routing rule, and such a row is the ordinary outcome of merely
+ * OPENING a cloud series. Without a `cloudPath` that cover has no
+ * `cloud_covers` identity either, so the fetch would be made and then silently
+ * DROPPED — the exact "stale cover never refreshes" dead end this argument
+ * exists to close. Decorated on a COPY, never stored.
  */
 async function refreshStaleCover(
   providerType: SyncProvider['type'],
@@ -416,22 +421,21 @@ async function refreshStaleCover(
   const row = (await db.volumes.get(volumeUuid)) as VolumeMetadata | undefined;
   if (!row || !needsDownload(row)) return;
 
-  const result = await fetchCloudThumbnail({
-    ...row,
-    cloudProvider: providerType,
-    cloudThumbnailFileId: cover.fileId,
-    cloudThumbnailPath: cover.path
-  });
-  if (!result) return;
-
-  installCover(
-    // The listing's archive path wins over anything decorated onto the stored
-    // row: it is the same key `catalog/index.ts` reads a cached cover back
-    // under (`cloudFieldsForRemovedVolume` → `normalizeCachePath(cloudPath)`).
-    { volume_uuid: volumeUuid, cloudPath: archivePath ?? row.cloudPath },
-    result,
-    { size: cover.size, modifiedTime: cover.modifiedTime },
-    'overwrite'
+  await requestCover(
+    {
+      ...row,
+      cloudProvider: providerType,
+      // The listing's archive path wins over anything decorated onto the
+      // stored row: it is the same key `catalog/index.ts` reads a cached
+      // cover back under (`cloudFieldsForRemovedVolume` →
+      // `normalizeCachePath(cloudPath)`).
+      cloudPath: archivePath ?? row.cloudPath,
+      cloudThumbnailFileId: cover.fileId,
+      cloudThumbnailPath: cover.path,
+      ...(isArchiveSize(cover.size) ? { cloudThumbnailSize: cover.size } : {}),
+      ...(cover.modifiedTime ? { cloudThumbnailModifiedTime: cover.modifiedTime } : {})
+    },
+    { refresh: true }
   );
   await flushPendingCoverPersists();
 }

--- a/src/lib/metadata/sidecar-pull.ts
+++ b/src/lib/metadata/sidecar-pull.ts
@@ -1,0 +1,138 @@
+import { buildPageCharCounts, decodeMokuroSidecar } from '$lib/catalog/cloud-ocr-upgrade';
+import { parseMokuroFile } from '$lib/import/processing';
+import { generateDeterministicUUID } from '$lib/util/series-extraction';
+import type { CloudFileMetadata, SyncProvider } from '$lib/util/sync/provider-interface';
+import { isArchiveSize, type SeriesFileVolume } from './series-file';
+
+/**
+ * The sidecar PULL primitives, and the one budget every pull shares.
+ *
+ * Its own leaf so both of its consumers can depend on it without depending on
+ * each other: `series-backfill.ts` (a whole-series pass) and
+ * `cover-service.ts` (a single archive, pulled because a bare placeholder was
+ * scrolled into view). These used to live in the backfill, which the cover
+ * service imported directly — and once the backfill's stale-cover refresh
+ * became a request to the cover service, that direct edge was a two-file
+ * cycle, and a partially-mocked backfill inside it resolved to the wrong
+ * instance under test. Nothing here imports either of them.
+ */
+
+/**
+ * How many series' worth of expensive backfill work (volumes scan, pulls,
+ * write) may run at once, across every series — and the same pool a
+ * render-demand single-archive pull draws from: "fast browsing can't stampede
+ * a provider" applies to a .mokuro pull triggered by scrolling past a bare
+ * placeholder exactly as much as one triggered by a reconcile sweep. One
+ * budget, not two. Mirrors `WRITE_CONCURRENCY`; see `series-backfill.ts`'s
+ * module doc for why it is a SEPARATE pool from that one.
+ */
+const BACKFILL_PASS_CONCURRENCY = 2;
+let activeBackfillPasses = 0;
+const waitingBackfillPasses: Array<() => void> = [];
+
+export function acquireBackfillSlot(): Promise<void> {
+  if (activeBackfillPasses < BACKFILL_PASS_CONCURRENCY) {
+    activeBackfillPasses += 1;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    waitingBackfillPasses.push(() => {
+      activeBackfillPasses += 1;
+      resolve();
+    });
+  });
+}
+
+export function releaseBackfillSlot(): void {
+  activeBackfillPasses -= 1;
+  waitingBackfillPasses.shift()?.();
+}
+
+/** Test hook: release every slot and forget every waiter. */
+export function _resetBackfillSlotsForTests(): void {
+  activeBackfillPasses = 0;
+  waitingBackfillPasses.length = 0;
+}
+
+/**
+ * Zero-count entry for an archive with no `.mokuro` sidecar at all.
+ *
+ * NOT an image-only claim, despite the empty `mokuro_version`. A sidecar-less
+ * archive is most often a LEGACY backup whose mokuro is EMBEDDED in the
+ * `.cbz` (the whole reason `sidecar-backfill.ts` exists) — nothing can know
+ * which until the archive is downloaded. This entry exists only to carry the
+ * archive's identity, size and cover stamps, and to stop the backfill pass
+ * re-planning the archive on every listing; its zero-content shape is exactly
+ * what `hasMeasuredContent` (series-file.ts) reads as "this entry proves
+ * nothing", which keeps merges treating it as the weakest possible claim.
+ * Consumers that copy a version onto a row or placeholder go through
+ * `entryMokuroVersion`: with no cover stamps either (ALL sidecars missing)
+ * this shape surfaces as `'unknown'` — never as the image-only `''` — while
+ * cover stamps prove a modern backup wrote sidecars without a mokuro, which
+ * IS a genuine image-only signal.
+ *
+ * Used by the backfill for a whole series and by `cover-service.ts`'s
+ * render-demand path (decision-tree case 4) for exactly one archive — the
+ * SAME entry, not re-derived.
+ */
+export function buildNoMetadataEntry(
+  folderTitle: string,
+  archiveStem: string,
+  archiveFile: CloudFileMetadata
+): SeriesFileVolume {
+  const entry: SeriesFileVolume = {
+    volume_uuid: generateDeterministicUUID(`${folderTitle}/${archiveStem}`),
+    volume_title: archiveStem,
+    page_count: 0,
+    character_count: 0,
+    mokuro_version: ''
+  };
+  if (isArchiveSize(archiveFile.size)) entry.archive_size = archiveFile.size;
+  return entry;
+}
+
+/**
+ * Download and parse one `.mokuro`/`.mokuro.gz`, building the entry the ENTRY-
+ * BUILDING rules describe: `volume_title` from the ARCHIVE's filename stem
+ * (never the mokuro's own `title`/`volume` fields — real files get those
+ * wrong), `volume_uuid` from the mokuro's own `volume_uuid`, counts measured
+ * with the same char math `cloud-ocr-upgrade.ts` uses for its own upgrade
+ * path. `undefined` for anything that fails to parse or lacks a usable uuid —
+ * the caller treats that as "skip this one volume", never a hard failure.
+ *
+ * `sidecarFile` is the snapshot the caller already captured from ONE listing
+ * read (`groupSeriesSidecarFiles`); it is used here for BOTH the download and
+ * the stamp below, so there is no second listing lookup to race a concurrent
+ * re-list — the stamp always describes exactly the bytes that were pulled.
+ *
+ * Used by the backfill pass and by `cover-service.ts`'s render-demand path
+ * (decision-tree case 3: a bare placeholder with a real sidecar) — the SAME
+ * pull, whether it is triggered by a sweep or by a card scrolled into view.
+ */
+export async function pullMokuroEntry(
+  provider: SyncProvider,
+  archiveStem: string,
+  sidecarFile: CloudFileMetadata
+): Promise<SeriesFileVolume | undefined> {
+  const blob = await provider.downloadFile(sidecarFile);
+  const decoded = await decodeMokuroSidecar(sidecarFile.path, blob);
+  if (!decoded) return undefined;
+
+  const parsed = await parseMokuroFile(decoded);
+  if (typeof parsed.volumeUuid !== 'string' || !parsed.volumeUuid.trim()) return undefined;
+
+  const pages = Array.isArray(parsed.pages) ? parsed.pages : [];
+  const { totalChars } = buildPageCharCounts(pages);
+
+  // Base fields only — the caller (`buildEntryForTask`) applies `archive_size`
+  // and the stamp fields through `orderVolumeEntryFields` so every entry this
+  // module produces re-serializes in the pinned wire order regardless of
+  // which fields end up set.
+  return {
+    volume_uuid: parsed.volumeUuid,
+    volume_title: archiveStem,
+    page_count: pages.length,
+    character_count: totalChars,
+    mokuro_version: typeof parsed.version === 'string' ? parsed.version : ''
+  };
+}

--- a/src/lib/util/sync/init-providers.ts
+++ b/src/lib/util/sync/init-providers.ts
@@ -1,6 +1,5 @@
 import { providerManager } from './provider-manager';
 import { unifiedCloudManager } from './unified-cloud-manager';
-import { patchProgressHoles } from '$lib/metadata/hole-patch';
 import { driveApiClient } from '$lib/util/sync/providers/google-drive/api-client';
 import { tokenManager } from '$lib/util/sync/providers/google-drive/token-manager';
 import { GOOGLE_DRIVE_CONFIG } from '$lib/util/sync/providers/google-drive/constants';
@@ -148,11 +147,10 @@ export async function initializeProviders(): Promise<void> {
 
         // Sync progress after cache is populated
         console.log('🔄 Syncing progress on app startup...');
+        // `syncProgress` itself starts the resolution of any series the
+        // synced progress references but this device has no rows for.
         await unifiedCloudManager.syncProgress({ silent: true });
         console.log('✅ Initial sync completed');
-
-        // Synced progress may reference series this device knows nothing about.
-        void patchProgressHoles();
       } catch (error) {
         console.warn('⚠️ Failed to populate cloud cache or sync on startup:', error);
       }

--- a/src/lib/util/sync/unified-cloud-manager.test.ts
+++ b/src/lib/util/sync/unified-cloud-manager.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { normalizeVolumeTitleKey } from '$lib/metadata/series-key';
+import { unifiedSyncService } from './unified-sync-service';
 import type { CloudFileMetadata } from './provider-interface';
 
 const fetchAll = vi.fn();
@@ -151,6 +152,14 @@ const refreshSeriesIndexes = vi.fn(async (_map: unknown, _providerType?: string)
 vi.mock('$lib/metadata/series-index-sync', () => ({
   refreshSeriesIndexes: (map: unknown, providerType: string) =>
     refreshSeriesIndexes(map, providerType)
+}));
+
+const resolveSyncedProgress = vi.fn(async () => {});
+vi.mock('$lib/metadata/hole-patch', () => ({
+  resolveSyncedProgress: () => resolveSyncedProgress()
+}));
+vi.mock('$lib/util/sync/sidecar-backfill', () => ({
+  sweepInstalledVolumesForSidecarBackfill: vi.fn(async () => {})
 }));
 
 const refreshCatalogIndex = vi.fn(async (_map: unknown, _providerType?: string) => {});
@@ -3660,5 +3669,85 @@ describe('the raw-doubles flag on cached records (raw_entry_collapse)', () => {
 
     expect(putSeriesIndex).toHaveBeenCalledTimes(1);
     expect(putSeriesIndex.mock.calls[0][0]).not.toHaveProperty('raw_entry_collapse');
+  });
+});
+
+describe('the series-index refresh is retained for the post-sync resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getActiveProvider.mockReturnValue({ type: 'webdav', getStatus: () => ({ isReadOnly: false }) });
+    getAllFiles.mockReturnValue([
+      { provider: 'webdav', fileId: '1', path: 'S/V.cbz', size: 1, modifiedTime: '' }
+    ]);
+  });
+
+  it('resolves immediately when no refresh is running', async () => {
+    const { unifiedCloudManager } = await import('$lib/util/sync/unified-cloud-manager');
+    await expect(unifiedCloudManager.whenSeriesIndexesSettled()).resolves.toBeUndefined();
+  });
+
+  it('waits for the refresh the last listing started', async () => {
+    const { unifiedCloudManager } = await import('$lib/util/sync/unified-cloud-manager');
+    let release!: () => void;
+    refreshSeriesIndexes.mockReturnValueOnce(new Promise<void>((resolve) => (release = resolve)));
+    unifiedCloudManager.refreshSeriesIndexesInBackground();
+
+    let settled = false;
+    const waiting = unifiedCloudManager.whenSeriesIndexesSettled().then(() => (settled = true));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    release();
+    await waiting;
+    expect(settled).toBe(true);
+    // And once it has settled there is nothing left to wait on.
+    await expect(unifiedCloudManager.whenSeriesIndexesSettled()).resolves.toBeUndefined();
+  });
+
+  it('never rejects, even when the refresh does', async () => {
+    const { unifiedCloudManager } = await import('$lib/util/sync/unified-cloud-manager');
+    refreshSeriesIndexes.mockRejectedValueOnce(new Error('boom'));
+    unifiedCloudManager.refreshSeriesIndexesInBackground();
+    await expect(unifiedCloudManager.whenSeriesIndexesSettled()).resolves.toBeUndefined();
+  });
+});
+
+describe('syncProgress starts progress resolution behind its result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getActiveProvider.mockReturnValue({ type: 'webdav', getStatus: () => ({ isReadOnly: false }) });
+  });
+
+  it('runs resolveSyncedProgress after a successful sync, without waiting for it', async () => {
+    const { unifiedCloudManager } = await import('$lib/util/sync/unified-cloud-manager');
+    let release!: () => void;
+    resolveSyncedProgress.mockReturnValueOnce(new Promise<void>((resolve) => (release = resolve)));
+    vi.mocked(unifiedSyncService.syncProvider).mockResolvedValue({ success: true } as never);
+
+    const result = await unifiedCloudManager.syncProgress({ silent: true });
+    expect(result.succeeded).toBe(1);
+    expect(resolveSyncedProgress).toHaveBeenCalledTimes(1);
+
+    let done = false;
+    const retained = unifiedCloudManager.progressResolution.then(() => (done = true));
+    await Promise.resolve();
+    expect(done).toBe(false); // the sync result came back first
+    release();
+    await retained;
+    expect(done).toBe(true);
+  });
+
+  it('does not start resolution after a failed sync, and never lets it reject', async () => {
+    const { unifiedCloudManager } = await import('$lib/util/sync/unified-cloud-manager');
+    vi.mocked(unifiedSyncService.syncProvider).mockResolvedValue({ success: false } as never);
+    await unifiedCloudManager.syncProgress();
+    expect(resolveSyncedProgress).not.toHaveBeenCalled();
+
+    vi.mocked(unifiedSyncService.syncProvider).mockResolvedValue({ success: true } as never);
+    resolveSyncedProgress.mockRejectedValueOnce(new Error('boom'));
+    const result = await unifiedCloudManager.syncProgress();
+    expect(result.succeeded).toBe(1);
+    await expect(unifiedCloudManager.progressResolution).resolves.toBeUndefined();
   });
 });

--- a/src/lib/util/sync/unified-cloud-manager.ts
+++ b/src/lib/util/sync/unified-cloud-manager.ts
@@ -64,6 +64,12 @@ import {
   putCatalogIndex
 } from '$lib/metadata/catalog-index';
 import { refreshSeriesIndexes } from '$lib/metadata/series-index-sync';
+// Deferred-use import into the module cycle hole-patch → unified-cloud-manager
+// → hole-patch (the resolver reads this manager's listing state). Safe for the
+// same reason the existing unified-cloud-manager ↔ series-file-sync cycle is:
+// nothing on either side calls across at module-init time, only from inside
+// function bodies.
+import { resolveSyncedProgress } from '$lib/metadata/hole-patch';
 import { refreshCatalogIndex } from '$lib/metadata/catalog-index-sync';
 import { markListingFresh, reconcileMissingMetadataFiles } from '$lib/metadata/series-file-sync';
 import { sweepInstalledVolumesForSidecarBackfill } from './sidecar-backfill';
@@ -179,6 +185,27 @@ function pickSeriesMetadata(
 
 class UnifiedCloudManager {
   /**
+   * The `series.json` refresh the most recent listing started, or `null`.
+   * Retained so a caller that needs the cached indexes to be CURRENT — the
+   * post-sync progress resolution — can await the run already in flight
+   * instead of starting a second one. Always settles without rejecting (the
+   * refresh logs its own failures).
+   */
+  private seriesIndexRefresh: Promise<void> | null = null;
+
+  /**
+   * The resolution run the last successful sync started (see
+   * `resolveSyncedProgress` in `hole-patch.ts`), retained for callers and
+   * tests that need the rows it mints. Sync itself never waits on it.
+   */
+  progressResolution: Promise<void> = Promise.resolve();
+
+  /** Settles when the series-index refresh the last listing started has finished; immediately when none is running. */
+  whenSeriesIndexesSettled(): Promise<void> {
+    return this.seriesIndexRefresh ?? Promise.resolve();
+  }
+
+  /**
    * Store containing cloud volumes from the current provider
    * Returns Map<seriesTitle, CloudVolumeWithProvider[]> for efficient series-based operations
    * Delegates to cacheManager and adds provider field to each file
@@ -263,10 +290,15 @@ class UnifiedCloudManager {
       }
 
       // Bound to THIS provider: the run may start long after the switch that
-      // makes these ids and paths meaningless.
-      void Promise.resolve(refreshSeriesIndexes(listing, provider.type)).catch((error) =>
+      // makes these ids and paths meaningless. RETAINED (not just fired) so
+      // `whenSeriesIndexesSettled` can hand it to the post-sync resolution.
+      const refresh = Promise.resolve(refreshSeriesIndexes(listing, provider.type)).catch((error) =>
         console.warn('Series index refresh failed:', error)
       );
+      this.seriesIndexRefresh = refresh;
+      void refresh.finally(() => {
+        if (this.seriesIndexRefresh === refresh) this.seriesIndexRefresh = null;
+      });
       // The root catalog rides the same listing: one download for the whole
       // library, skipped entirely when its size/mtime has not moved.
       void Promise.resolve(refreshCatalogIndex(listing, provider.type)).catch((error) =>
@@ -2026,12 +2058,23 @@ class UnifiedCloudManager {
     }
 
     const result = await unifiedSyncService.syncProvider(provider, options);
+    // Synced progress may reference series this device has no rows for. THE
+    // one trigger for resolving that — never a view mount — and started
+    // behind the result: sync reports what it did, resolution continues.
+    if (result.success) this.startProgressResolution();
     return {
       totalProviders: 1,
       succeeded: result.success ? 1 : 0,
       failed: result.success ? 0 : 1,
       results: [result]
     };
+  }
+
+  /** Never throws into a sync result: `resolveSyncedProgress` swallows its own failures, and so does this. */
+  private startProgressResolution(): void {
+    this.progressResolution = Promise.resolve()
+      .then(() => resolveSyncedProgress())
+      .catch((error) => console.debug('[sync] progress resolution failed to start:', error));
   }
 
   /**

--- a/src/lib/views/CatalogView.svelte
+++ b/src/lib/views/CatalogView.svelte
@@ -1,22 +1,8 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
   import Catalog from '$lib/components/Catalog.svelte';
-  import { patchProgressHolesWhenListingReady } from '$lib/metadata/hole-patch';
-
-  onMount(() => {
-    // Enrich orphaned volumes, pull any series the synced progress references
-    // but this device has never seen, then enrich AGAIN so the rows the sweep
-    // just minted are reflected in this visit rather than the next one. The
-    // second pass is what stops a resolved volume still reading as orphaned
-    // for the rest of the session. Session-scoped memory inside the sweep means
-    // repeated mounts don't re-pull a series genuinely absent from the cloud.
-    //
-    // `patchProgressHolesWhenListingReady` (see hole-patch.ts) also re-runs the
-    // whole sweep once more if THIS mount fired before the cloud listing had
-    // loaded — otherwise a mount that lost that race gets zero sweep work for
-    // the whole visit, cloud listing or not.
-    return patchProgressHolesWhenListingReady();
-  });
+  // Rows for series the synced progress references but this device has never
+  // seen are minted after every progress sync (`resolveSyncedProgress`), not
+  // from this mount — a view is not what decides when metadata converges.
 </script>
 
 <svelte:head>

--- a/src/lib/views/ReadingSpeedView.svelte
+++ b/src/lib/views/ReadingSpeedView.svelte
@@ -16,7 +16,7 @@
     isOrphanedVolumeData
   } from '$lib/settings/volume-data';
   import { volumes as catalogStore } from '$lib/catalog';
-  import { patchProgressHolesWhenListingReady } from '$lib/metadata/hole-patch';
+  import { enrichAllOrphanedVolumes } from '$lib/settings';
   import { personalizedReadingSpeed } from '$lib/settings/reading-speed';
   import {
     Badge,
@@ -702,29 +702,19 @@
   });
 
   onMount(() => {
-    // Enrich, sweep, then enrich AGAIN — in that order, each awaited.
+    // Titles for legacy records that have a local row but no name yet: this
+    // page groups by the reading record's titles, and the `[Missing Series
+    // Info]` bucket it offers for deletion is exactly what an un-enriched
+    // record falls into. `enrichAllOrphanedVolumes` copies them off rows this
+    // device already has, reads IndexedDB only when there is an orphan, and
+    // is the only path a device with no provider ever has for this.
     //
-    // `enrichAllOrphanedVolumes` can only copy metadata off rows this device
-    // already has; a volume read on another machine has none, which is what
-    // puts it in the `[Missing Series Info]` bucket this page then offers for
-    // deletion. The sweep mints those missing rows from data already on the
-    // device (see `materializeHistoryRows`) — but a row only reaches
-    // `$orphanedVolumeIds` once an enrichment pass has copied it onto the
-    // reading record. Enriching BEFORE the sweep and firing the sweep off
-    // un-awaited (which is what this used to do) therefore left the bucket, and
-    // the trash button on it, holding every volume the sweep had just resolved
-    // for the whole visit. `patchProgressHolesAndEnrich` is that ordering, and
-    // `patchProgressHolesWhenListingReady` (see hole-patch.ts) is what re-runs
-    // it once more if THIS mount fired before the cloud listing was in —
-    // otherwise a cold start straight into this page can sweep zero volumes
-    // for the whole visit, which was the user-reported bug.
-    //
-    // The promise itself is not awaited here: it never rejects and must never
-    // hold up the page. What matters is the order INSIDE it.
-    const unsubscribeListing = patchProgressHolesWhenListingReady();
+    // Rows for progress synced from OTHER devices are minted after each
+    // progress sync (`resolveSyncedProgress`, which enriches again once its
+    // rows land), never from a view mount — so there is no sweep here.
+    void enrichAllOrphanedVolumes();
 
     return () => {
-      unsubscribeListing();
       if (chart) {
         chart.destroy();
       }

--- a/src/lib/views/__tests__/ReadingSpeedView.orphans.test.ts
+++ b/src/lib/views/__tests__/ReadingSpeedView.orphans.test.ts
@@ -12,20 +12,21 @@ import { get, readable } from 'svelte/store';
  * therefore have to hold, and neither is visible to a unit test of any single
  * module:
  *
- * 1. The repair has to reach the orphan set. `patchProgressHolesAndEnrich`
- *    mints rows and then copies them onto the reading records; if the page's
- *    orphan set does not reflect that by the time the user can click, a volume
- *    the app JUST resolved is still sitting in the bucket being offered up.
+ * 1. The repair has to reach the orphan set. `resolveSyncedProgress` (run
+ *    after every progress sync, never from this page) mints rows and then
+ *    copies them onto the reading records; if the page's orphan set does not
+ *    reflect that by the time the user can click, a volume the app JUST
+ *    resolved is still sitting in the bucket being offered up.
  * 2. The button has to act on the row it is in. It is revealed by one row of
  *    the "Speed by Series" table and used to hand the whole store's orphan list
  *    to `clearOrphanedVolumeData`.
  *
  * So the component is rendered for real, over the REAL `volume-data` store and
- * the REAL `patchProgressHolesAndEnrich`. Only the edges are doubled: the
- * catalog liveQuery, Chart.js, and the four modules the hole patcher talks to
- * (the row sweep, the index cache, `openSeries`, the cloud listing). A double
- * for `patchProgressHolesAndEnrich` itself would make case 1 vacuous — the
- * ordering IS the thing under test.
+ * the REAL `resolveSyncedProgress`. Only the edges are doubled: the catalog
+ * liveQuery, Chart.js, and the four modules the hole patcher talks to (the row
+ * sweep, the index cache, `openSeries`, the cloud listing). A double for the
+ * resolver itself would make case 1 vacuous — the ordering IS the thing under
+ * test.
  */
 
 const { catalogVolumes } = vi.hoisted(() => {
@@ -79,11 +80,9 @@ vi.mock('$lib/metadata/series-open', () => ({ openSeries: vi.fn(async () => {}) 
 vi.mock('$lib/util/sync/unified-cloud-manager', () => ({
   unifiedCloudManager: {
     getActiveProvider: () => ({ type: 'google-drive' }),
-    // Already loaded, matching `cacheManager.isLoaded()` below being `true`
-    // from the start: `patchProgressHolesWhenListingReady` subscribes to
-    // this, and its own "already loaded at mount" fast path is what this
-    // suite exercises — a real retry is `hole-patch.test.ts`'s job.
-    cloudFiles: readable(new Map([['Dr Stone', [{}]]]))
+    cloudFiles: readable(new Map([['Dr Stone', [{}]]])),
+    // The index refresh the resolver awaits: already settled here.
+    whenSeriesIndexesSettled: () => Promise.resolve()
   }
 }));
 vi.mock('$lib/util/sync/cache-manager', () => ({
@@ -98,6 +97,7 @@ vi.mock('chart.js/auto', () => ({
 }));
 
 import ReadingSpeedView from '$lib/views/ReadingSpeedView.svelte';
+import { resolveSyncedProgress } from '$lib/metadata/hole-patch';
 import { VolumeData, volumes, volumesWithTrash } from '$lib/settings/volume-data';
 
 /** A record that clears `processVolumeSpeedData`'s filters, so it is SPEED-TRACKED. */
@@ -159,6 +159,14 @@ describe('ReadingSpeedView orphan bucket', () => {
     });
 
     render(ReadingSpeedView);
+    // The page itself never sweeps; it renders the bucket for what it has...
+    await vi.waitFor(() => {
+      expect(seriesRow('[Missing Series Info]')).toBeDefined();
+    });
+    expect(materializeHistoryRows).not.toHaveBeenCalled();
+
+    // ...and a progress sync lands mid-visit and resolves the volume.
+    await resolveSyncedProgress();
 
     // The load-bearing assertion is the page's own orphan bucket, not the
     // store: the fake series must be gone and its trash button with it — a
@@ -177,10 +185,9 @@ describe('ReadingSpeedView orphan bucket', () => {
     volumesWithTrash.set({ 'uuid-unresolved': speedTracked() });
 
     render(ReadingSpeedView);
+    await resolveSyncedProgress();
+    expect(materializeHistoryRows).toHaveBeenCalled();
 
-    await vi.waitFor(() => {
-      expect(materializeHistoryRows).toHaveBeenCalled();
-    });
     const row = await vi.waitFor(() => {
       const found = seriesRow('[Missing Series Info]');
       expect(found).toBeDefined();


### PR DESCRIPTION
## Summary

One entry point for every cloud cover, and metadata resolution that runs after each progress sync instead of from view mounts. Groundwork for the progress tracker (#270), which draws `row.thumbnail` and needs rows to exist without the user navigating.

**Covers** (`cover-service.ts`)
- `requestCover` is the only fetch-and-install path. The series-open pass (`installCoversForSeries`) and the backfill's stale refresh are now candidate builders over it — no second fetch path anywhere.
- New ladder step: a cover already in the `cloud_covers` cache is **promoted** onto the row when the volume is metadata-only and read (`coverBelongsOnRow`, the one routing predicate shared with the write queue). No network. A stale cached stamp falls through to a fetch.
- Requests resolve to an outcome (`row` / `cache` / `none` / `skipped` / `unresolved`). The dedupe ledger records what was delivered and against which listing stamp, so a volume browsed then read is promoted, and a changed sidecar is re-fetched.
- `cloud_covers` rows carry `cover_size`/`cover_modified` (non-indexed, no schema bump) so a promotion keeps the freshness the blob actually has.
- The sidecar pull primitives moved to `metadata/sidecar-pull.ts`, a leaf, so the cover service no longer imports the backfill.

**Resolution** (`hole-patch.ts`, `unified-cloud-manager.ts`)
- `syncProgress` starts `resolveSyncedProgress` behind its result after every successful sync. It awaits the series-index refresh the listing started (cold cache used to resolve 5 of 30 series; now 30 of 30, characterized by `hole-patch.integration.test.ts`), then runs enrich → sweep → enrich with the per-run caps and the session memo removed.
- CatalogView, ReadingSpeedView and the startup path lose their sweep triggers; the stats view keeps a direct `enrichAllOrphanedVolumes` for legacy records.

Spec: `docs/superpowers/specs/2026-09-02-unified-cover-requests-design.md`.

## Verification
- `npm run check` 0 errors; 2,922 unit tests; lint at the develop baseline (272 warnings, 0 errors); perf contracts untouched and green.
- `e2e/catalog-distribution.spec.ts`: 10 pass, 8 fail — the same 8 fail on untouched develop (verified on a separate port). The one case this branch changes (hole patched after a progress sync) passes.
- Live promotion path verified in a headless browser against a local bunko test instance on top of #275 (browse → cover cached, 1 GET; read + sync → row minted; tracker render → cover on the row, **0** cover GETs after the sync began).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
